### PR TITLE
Stop dropping USD/EUR transactions from dashboard totals

### DIFF
--- a/client/src/hooks/useCredits.ts
+++ b/client/src/hooks/useCredits.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
-import { db } from "../lib/instant";
+import { db, type Credit } from "../lib/instant";
 import { isWithinInterval, startOfMonth, endOfMonth } from "date-fns";
+import { useGelConverter } from "../lib/exchangeRates";
 import type { MonthYear } from "./useMonthlyAnalytics";
 
 export function useCredits() {
@@ -14,25 +15,40 @@ export function useCredits() {
   return { credits, isLoading, error };
 }
 
+export type ConvertedCredit = Credit & { gelAmount: number | null };
+
+export function useConvertedCredits() {
+  const { credits, isLoading, error } = useCredits();
+  const toGel = useGelConverter();
+  const converted = useMemo<ConvertedCredit[]>(
+    () => credits.map((c) => ({ ...c, gelAmount: toGel(c.amount, c.currency, c.transactionDate) })),
+    [credits, toGel]
+  );
+  return { credits: converted, isLoading, error };
+}
+
 export function useMonthCredits(my: MonthYear) {
-  const { data } = db.useQuery({ credits: {} });
+  const { credits } = useConvertedCredits();
 
   return useMemo(() => {
-    const credits = data?.credits || [];
     const start = startOfMonth(new Date(my.year, my.month, 1));
     const end = endOfMonth(new Date(my.year, my.month, 1));
     const monthCredits = credits.filter((c) =>
       isWithinInterval(new Date(c.transactionDate), { start, end })
     );
-    // `total` and `count` describe the same GEL slice so the hero card's
-    // "N incoming transactions" matches the "+₾X earned" right above it.
-    // `credits` returns the full list regardless of currency so the feed
-    // doesn't silently drop USD/EUR income rows.
-    const gelCredits = monthCredits.filter((c) => c.currency === "GEL");
-    const total = gelCredits.reduce((s, c) => s + c.amount, 0);
-    const count = gelCredits.length;
+    // `total` sums every currency converted to GEL; `count` reflects rows
+    // that have actually contributed (i.e. either GEL or non-GEL with a
+    // resolved rate). Rows still waiting on a rate are kept in `credits`
+    // but excluded from the totals until the rate lands.
+    let total = 0;
+    let count = 0;
+    for (const c of monthCredits) {
+      if (c.gelAmount === null) continue;
+      total += c.gelAmount;
+      count += 1;
+    }
     return { total, count, credits: monthCredits };
-  }, [data?.credits, my.month, my.year]);
+  }, [credits, my.month, my.year]);
 }
 
 export function useMonthCashflow(my: MonthYear, spendingTotal: number) {

--- a/client/src/hooks/useMonthlyAnalytics.ts
+++ b/client/src/hooks/useMonthlyAnalytics.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { db } from "../lib/instant";
 import { DEFAULT_CATEGORIES, autoCategorize } from "../lib/utils";
 import { formatLocalDay } from "../ink/format";
+import { useConvertedPayments } from "./useTransactions";
 import {
   startOfMonth,
   endOfMonth,
@@ -60,11 +61,10 @@ export function useAvailableMonths() {
 }
 
 export function useMonthStats(my: MonthYear) {
-  const { data: paymentsData } = db.useQuery({ payments: {} });
+  const { payments } = useConvertedPayments();
   const { data: failedData } = db.useQuery({ failedPayments: {} });
 
   return useMemo(() => {
-    const payments = paymentsData?.payments || [];
     const failed = failedData?.failedPayments || [];
     const interval = getMonthInterval(my);
     const prevInterval = getMonthInterval(getPreviousMonth(my));
@@ -72,26 +72,28 @@ export function useMonthStats(my: MonthYear) {
     const inRange = (date: number, iv: { start: Date; end: Date }) =>
       isWithinInterval(new Date(date), iv);
 
-    // Filter to GEL before summing: foreign-currency amounts (USD/EUR) can't
-    // be added to a GEL total without a conversion, and summing them raw
-    // would inflate the number. Count + average track the same GEL set as
-    // the total so every displayed number on the hero card is on the same
-    // currency basis — otherwise "daily average" would be a GEL sum divided
-    // by an all-currency count.
-    const currentPayments = payments.filter((p) => inRange(p.transactionDate, interval));
-    const currentFailed = failed.filter((p) => inRange(p.transactionDate, interval));
-    const prevPayments = payments.filter((p) => inRange(p.transactionDate, prevInterval));
-
-    const currentGelPayments = currentPayments.filter((p) => p.currency === "GEL");
-    const prevGelPayments = prevPayments.filter((p) => p.currency === "GEL");
-
-    const total = currentGelPayments.reduce((s, p) => s + p.amount, 0);
-    const count = currentGelPayments.length;
-    const failedCount = currentFailed.length;
+    // Sum every currency converted to GEL via the NBG rate for each
+    // transaction's date. Rows still loading (`gelAmount === null`)
+    // skip the total this render, then snap in once the rate arrives.
+    let total = 0;
+    let count = 0;
+    let prevTotal = 0;
+    let prevCount = 0;
+    for (const p of payments) {
+      const inCur = inRange(p.transactionDate, interval);
+      const inPrev = !inCur && inRange(p.transactionDate, prevInterval);
+      if (!inCur && !inPrev) continue;
+      if (p.gelAmount === null) continue;
+      if (inCur) {
+        total += p.gelAmount;
+        count += 1;
+      } else {
+        prevTotal += p.gelAmount;
+        prevCount += 1;
+      }
+    }
+    const failedCount = failed.filter((p) => inRange(p.transactionDate, interval)).length;
     const avg = count > 0 ? total / count : 0;
-
-    const prevTotal = prevGelPayments.reduce((s, p) => s + p.amount, 0);
-    const prevCount = prevGelPayments.length;
     const totalChange = prevTotal > 0 ? ((total - prevTotal) / prevTotal) * 100 : 0;
     const countChange = prevCount > 0 ? ((count - prevCount) / prevCount) * 100 : 0;
 
@@ -105,14 +107,13 @@ export function useMonthStats(my: MonthYear) {
       totalChange,
       countChange,
     };
-  }, [paymentsData?.payments, failedData?.failedPayments, my.month, my.year]);
+  }, [payments, failedData?.failedPayments, my.month, my.year]);
 }
 
 export function useMonthSpendingByDay(my: MonthYear) {
-  const { data: paymentsData } = db.useQuery({ payments: {} });
+  const { payments } = useConvertedPayments();
 
   return useMemo(() => {
-    const payments = paymentsData?.payments || [];
     const interval = getMonthInterval(my);
 
     const monthPayments = payments.filter((p) =>
@@ -121,8 +122,9 @@ export function useMonthSpendingByDay(my: MonthYear) {
 
     const dailyTotals: Record<string, number> = {};
     for (const p of monthPayments) {
+      if (p.gelAmount === null) continue;
       const date = formatLocalDay(p.transactionDate);
-      dailyTotals[date] = (dailyTotals[date] || 0) + p.amount;
+      dailyTotals[date] = (dailyTotals[date] || 0) + p.gelAmount;
     }
 
     const daysInMonth = getDaysInMonth(new Date(my.year, my.month, 1));
@@ -133,14 +135,13 @@ export function useMonthSpendingByDay(my: MonthYear) {
     }
 
     return result;
-  }, [paymentsData?.payments, my.month, my.year]);
+  }, [payments, my.month, my.year]);
 }
 
 export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
-  const { data: paymentsData } = db.useQuery({ payments: {} });
+  const { payments } = useConvertedPayments();
 
   return useMemo(() => {
-    const payments = paymentsData?.payments || [];
     const interval = getMonthInterval(my);
 
     const monthPayments = payments.filter((p) =>
@@ -149,9 +150,10 @@ export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
 
     const merchantTotals: Record<string, { total: number; count: number }> = {};
     for (const p of monthPayments) {
+      if (p.gelAmount === null) continue;
       const merchant = p.merchant || "Unknown";
       if (!merchantTotals[merchant]) merchantTotals[merchant] = { total: 0, count: 0 };
-      merchantTotals[merchant].total += p.amount;
+      merchantTotals[merchant].total += p.gelAmount;
       merchantTotals[merchant].count += 1;
     }
 
@@ -159,15 +161,14 @@ export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
       .map(([name, data]) => ({ name, ...data }))
       .sort((a, b) => b.total - a.total)
       .slice(0, limit);
-  }, [paymentsData?.payments, my.month, my.year, limit]);
+  }, [payments, my.month, my.year, limit]);
 }
 
 export function useMonthCategoryAnalytics(my: MonthYear) {
-  const { data: paymentsData } = db.useQuery({ payments: {} });
+  const { payments } = useConvertedPayments();
   const { data: catData } = db.useQuery({ categories: {} });
 
   return useMemo(() => {
-    const payments = paymentsData?.payments || [];
     const categories = catData?.categories || [];
     const interval = getMonthInterval(my);
 
@@ -186,12 +187,13 @@ export function useMonthCategoryAnalytics(my: MonthYear) {
     }
 
     for (const payment of monthPayments) {
+      if (payment.gelAmount === null) continue;
       const categoryName = autoCategorize(payment.merchant ?? null);
       if (categoryTotals[categoryName]) {
-        categoryTotals[categoryName].total += payment.amount;
+        categoryTotals[categoryName].total += payment.gelAmount;
         categoryTotals[categoryName].count += 1;
       } else {
-        categoryTotals["Other"].total += payment.amount;
+        categoryTotals["Other"].total += payment.gelAmount;
         categoryTotals["Other"].count += 1;
       }
     }
@@ -211,5 +213,5 @@ export function useMonthCategoryAnalytics(my: MonthYear) {
         percentage: totalSpent > 0 ? (cat.total / totalSpent) * 100 : 0,
       })),
     };
-  }, [paymentsData?.payments, catData?.categories, my.month, my.year]);
+  }, [payments, catData?.categories, my.month, my.year]);
 }

--- a/client/src/hooks/useMonthlyTrend.ts
+++ b/client/src/hooks/useMonthlyTrend.ts
@@ -1,20 +1,19 @@
 import { useMemo } from "react";
-import { db } from "../lib/instant";
+import { useConvertedPayments } from "./useTransactions";
 import { monthKey, monthLabel } from "../ink/format";
 
 export function useMonthlyTrend(months: number = 9) {
-  const { data } = db.useQuery({ payments: {} });
+  const { payments } = useConvertedPayments();
 
   return useMemo(() => {
-    const payments = data?.payments || [];
     const totals: Record<string, number> = {};
     for (const p of payments) {
-      if (p.currency !== "GEL") continue;
+      if (p.gelAmount === null) continue;
       const k = monthKey(p.transactionDate);
-      totals[k] = (totals[k] || 0) + p.amount;
+      totals[k] = (totals[k] || 0) + p.gelAmount;
     }
     const keys = Object.keys(totals).sort();
     const taken = keys.slice(-months);
     return taken.map((k) => ({ key: k, label: monthLabel(k), total: totals[k] }));
-  }, [data?.payments, months]);
+  }, [payments, months]);
 }

--- a/client/src/hooks/useSignals.ts
+++ b/client/src/hooks/useSignals.ts
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 import { startOfMonth, endOfMonth, isWithinInterval, subDays } from "date-fns";
-import { usePayments, useFailedPayments } from "./useTransactions";
+import { useConvertedPayments, useFailedPayments } from "./useTransactions";
 
 export function useSignals() {
-  const { payments } = usePayments();
+  const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
 
   return useMemo(() => {
@@ -13,7 +13,12 @@ export function useSignals() {
     const inMonth = (ts: number) => isWithinInterval(new Date(ts), { start: monthStart, end: monthEnd });
 
     const monthFailed = failedPayments.filter((f) => inMonth(f.transactionDate));
-    const monthPayments = payments.filter((p) => inMonth(p.transactionDate) && p.currency === "GEL");
+    // For card/total math we need a GEL-equivalent amount, so rows still
+    // waiting on a rate (gelAmount === null) sit out. Largest-tx and
+    // new-merchant detection still see the full set: those don't sum
+    // amounts, they look at the row's existence + merchant string.
+    const monthPaymentsAll = payments.filter((p) => inMonth(p.transactionDate));
+    const monthPaymentsForSums = monthPaymentsAll.filter((p) => p.gelAmount !== null);
 
     const repeatedMap: Record<string, number> = {};
     for (const f of monthFailed) {
@@ -24,7 +29,9 @@ export function useSignals() {
       .filter(([, n]) => n >= 2)
       .map(([merchant, count]) => ({ merchant, count }));
 
-    const largeTx = [...monthPayments].sort((a, b) => b.amount - a.amount).slice(0, 4);
+    const largeTx = [...monthPaymentsForSums]
+      .sort((a, b) => (b.gelAmount as number) - (a.gelAmount as number))
+      .slice(0, 4);
 
     const ninetyStart = subDays(now, 90);
     const priorMerchants = new Set(
@@ -35,17 +42,17 @@ export function useSignals() {
     );
     const newMerchants = Array.from(
       new Set(
-        monthPayments
+        monthPaymentsAll
           .map((p) => p.merchant || "")
           .filter((m) => m && !priorMerchants.has(m))
       )
     );
 
     const cardTotals: Record<string, { total: number; count: number }> = {};
-    for (const p of monthPayments) {
+    for (const p of monthPaymentsForSums) {
       const c = p.cardLastDigits || "—";
       if (!cardTotals[c]) cardTotals[c] = { total: 0, count: 0 };
-      cardTotals[c].total += p.amount;
+      cardTotals[c].total += p.gelAmount as number;
       cardTotals[c].count += 1;
     }
     const cards = Object.entries(cardTotals)

--- a/client/src/hooks/useTransactions.ts
+++ b/client/src/hooks/useTransactions.ts
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
-import { db } from "../lib/instant";
+import { db, type Payment } from "../lib/instant";
 import { groupBy, getDateGroup } from "../lib/utils";
 import { formatLocalDay } from "../ink/format";
+import { useGelConverter } from "../lib/exchangeRates";
 import { startOfMonth, endOfMonth, subMonths, isWithinInterval } from "date-fns";
 
 export function usePayments() {
@@ -13,6 +14,23 @@ export function usePayments() {
   }, [data?.payments]);
 
   return { payments, isLoading, error };
+}
+
+// Same as usePayments but with each row decorated with `gelAmount` —
+// the GEL-equivalent of `amount` after applying the NBG rate for the
+// transaction's date. Returns null while the rate is still loading;
+// aggregators treat null as "skip" so totals snap to the converted
+// value once rates arrive instead of briefly inflating.
+export type ConvertedPayment = Payment & { gelAmount: number | null };
+
+export function useConvertedPayments() {
+  const { payments, isLoading, error } = usePayments();
+  const toGel = useGelConverter();
+  const converted = useMemo<ConvertedPayment[]>(
+    () => payments.map((p) => ({ ...p, gelAmount: toGel(p.amount, p.currency, p.transactionDate) })),
+    [payments, toGel]
+  );
+  return { payments: converted, isLoading, error };
 }
 
 export function useFailedPayments() {

--- a/client/src/lib/exchangeRates.ts
+++ b/client/src/lib/exchangeRates.ts
@@ -1,0 +1,129 @@
+// Lazy converter that turns a foreign-currency amount into its GEL
+// equivalent using NBG's per-day rate. Hits /api/exchange-rate when a
+// rate isn't already in the in-memory cache; subscribed components
+// re-render once the fetch resolves and the converter starts returning
+// numbers instead of nulls.
+//
+// Why null on the first call (instead of the raw amount or 0): the
+// caller is almost always summing into a GEL total, so returning null
+// lets the aggregate hook skip the row during the load window. Once the
+// rate arrives the row gets included and the total snaps to the correct
+// value. Returning the raw amount would briefly inflate the total with
+// USD-denominated numbers added to GEL ones; returning 0 would have the
+// same UX as null without the explicit "not loaded yet" signal.
+
+import { useCallback, useEffect, useState } from "react";
+import { formatLocalDay } from "../ink/format";
+
+type RatesByCurrency = Map<string, number>;
+
+const cache = new Map<string, RatesByCurrency>();
+const inflight = new Map<string, Promise<void>>();
+const subscribers = new Set<() => void>();
+
+const STORAGE_KEY = "xarji-nbg-rates-v1";
+const CODES = "USD,EUR";
+const TODAY_TTL_MS = 15 * 60 * 1000;
+
+interface PersistedEntry {
+  rates: Record<string, number>;
+  fetchedAt: number;
+}
+
+function todayKey(): string {
+  return formatLocalDay(Date.now());
+}
+
+function loadFromStorage() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as Record<string, PersistedEntry>;
+    const now = Date.now();
+    for (const [date, entry] of Object.entries(parsed)) {
+      // Today's rate has a TTL because NBG publishes mid-day. Historical
+      // dates are immutable so we trust them indefinitely.
+      if (date === todayKey() && now - entry.fetchedAt > TODAY_TTL_MS) continue;
+      cache.set(date, new Map(Object.entries(entry.rates)));
+    }
+  } catch {
+    /* corrupt cache — let live fetches overwrite */
+  }
+}
+
+function persistToStorage() {
+  try {
+    const obj: Record<string, PersistedEntry> = {};
+    for (const [date, rates] of cache) {
+      obj[date] = {
+        rates: Object.fromEntries(rates),
+        fetchedAt: Date.now(),
+      };
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(obj));
+  } catch {
+    /* private mode / quota exceeded — degrade silently */
+  }
+}
+
+if (typeof window !== "undefined") loadFromStorage();
+
+function notify() {
+  for (const fn of subscribers) fn();
+}
+
+async function fetchRatesForDate(dateStr: string): Promise<void> {
+  if (cache.has(dateStr)) return;
+  const existing = inflight.get(dateStr);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const res = await fetch(`/api/exchange-rate?date=${dateStr}&lang=en&codes=${CODES}`);
+      if (!res.ok) return;
+      const body = (await res.json()) as { rates?: Record<string, { rate: number }> };
+      const rates: RatesByCurrency = new Map();
+      for (const [code, info] of Object.entries(body.rates ?? {})) {
+        if (typeof info.rate === "number" && Number.isFinite(info.rate)) {
+          rates.set(code, info.rate);
+        }
+      }
+      cache.set(dateStr, rates);
+      persistToStorage();
+      notify();
+    } catch {
+      /* network/server error — cache stays empty, converter keeps
+         returning null, aggregators keep skipping */
+    } finally {
+      inflight.delete(dateStr);
+    }
+  })();
+  inflight.set(dateStr, promise);
+  return promise;
+}
+
+export type GelConverter = (amount: number, currency: string, dateMs: number) => number | null;
+
+export function useGelConverter(): GelConverter {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const fn = () => setTick((t) => t + 1);
+    subscribers.add(fn);
+    return () => {
+      subscribers.delete(fn);
+    };
+  }, []);
+
+  return useCallback((amount, currency, dateMs) => {
+    if (currency === "GEL") return amount;
+    const dateStr = formatLocalDay(dateMs);
+    const rates = cache.get(dateStr);
+    if (!rates) {
+      void fetchRatesForDate(dateStr);
+      return null;
+    }
+    const rate = rates.get(currency.toUpperCase());
+    return rate !== undefined ? amount * rate : null;
+  }, []);
+}

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -4,7 +4,7 @@ import { useTheme, useViewport } from "../ink/theme";
 import { Card, CardLabel, CardTitle, LinkBtn, PageHeader } from "../ink/primitives";
 import { AreaChart, Donut, HBar } from "../ink/charts";
 import { TxRow, type InkTx } from "../ink/TxRow";
-import { usePayments } from "../hooks/useTransactions";
+import { useConvertedPayments } from "../hooks/useTransactions";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { DEFAULT_CATEGORIES, categorizeId, getCategory, type InkCategory } from "../lib/utils";
 import { formatCompact, monthKey } from "../ink/format";
@@ -25,23 +25,24 @@ export function Categories() {
   const monthStart = startOfMonth(now);
   const monthEnd = endOfMonth(now);
 
-  const { payments } = usePayments();
+  const { payments } = useConvertedPayments();
   const trend = useMonthlyTrend(6);
   const [range, setRange] = useState("Month");
 
   const inMonth = (ts: number) => isWithinInterval(new Date(ts), { start: monthStart, end: monthEnd });
 
   const monthPayments = useMemo(
-    () => payments.filter((p) => inMonth(p.transactionDate) && p.currency === "GEL"),
+    () => payments.filter((p) => inMonth(p.transactionDate)),
     [payments]
   );
 
   const cats: CatAgg[] = useMemo(() => {
     const map: Record<string, CatAgg> = {};
     for (const p of monthPayments) {
+      if (p.gelAmount === null) continue;
       const cat = getCategory(p.merchant, p.rawMessage);
       if (!map[cat.id]) map[cat.id] = { cat: cat.id, total: 0, count: 0, meta: cat };
-      map[cat.id].total += p.amount;
+      map[cat.id].total += p.gelAmount;
       map[cat.id].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);
@@ -61,12 +62,12 @@ export function Categories() {
       perCat[c.id] = keys.map((k) => ({ key: k, value: 0 }));
     }
     for (const p of payments) {
-      if (p.currency !== "GEL") continue;
+      if (p.gelAmount === null) continue;
       const k = monthKey(p.transactionDate);
       const idx = keys.indexOf(k);
       if (idx === -1) continue;
       const catId = categorizeId(p.merchant, p.rawMessage);
-      if (perCat[catId]) perCat[catId][idx].value += p.amount;
+      if (perCat[catId]) perCat[catId][idx].value += p.gelAmount;
     }
     return { keys, perCat, labels: trend.map((m) => m.label.slice(0, 3)) };
   }, [payments, trend]);
@@ -74,11 +75,12 @@ export function Categories() {
   const selMerchants = useMemo(() => {
     const map: Record<string, { merchant: string; total: number; count: number }> = {};
     for (const p of monthPayments) {
+      if (p.gelAmount === null) continue;
       const cid = categorizeId(p.merchant, p.rawMessage);
       if (cid !== selectedId) continue;
       const m = p.merchant || "Unknown";
       if (!map[m]) map[m] = { merchant: m, total: 0, count: 0 };
-      map[m].total += p.amount;
+      map[m].total += p.gelAmount;
       map[m].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -3,7 +3,7 @@ import { useTheme, useViewport } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, LiveDot, LinkBtn, PageHeader } from "../ink/primitives";
 import { AreaChart, Donut, Sparkline } from "../ink/charts";
 import { TxRow, type InkTx } from "../ink/TxRow";
-import { usePayments, useFailedPayments } from "../hooks/useTransactions";
+import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
 import { useMonthStats, useMonthSpendingByDay, useMonthTopMerchants } from "../hooks/useMonthlyAnalytics";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { useCredits, useMonthCredits } from "../hooks/useCredits";
@@ -21,7 +21,7 @@ export function Dashboard() {
   const daily = useMonthSpendingByDay(my);
   const topMerchants = useMonthTopMerchants(my, 5);
   const trend = useMonthlyTrend(9);
-  const { payments } = usePayments();
+  const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
   const { credits } = useCredits();
   const monthCredits = useMonthCredits(my);
@@ -39,11 +39,11 @@ export function Dashboard() {
     const monthEnd = endOfMonth(now);
     const map: Record<string, { total: number; count: number; meta: typeof DEFAULT_CATEGORIES[number] }> = {};
     for (const p of payments) {
-      if (p.currency !== "GEL") continue;
+      if (p.gelAmount === null) continue;
       if (!isWithinInterval(new Date(p.transactionDate), { start: monthStart, end: monthEnd })) continue;
       const cat = getCategory(p.merchant, p.rawMessage);
       if (!map[cat.id]) map[cat.id] = { total: 0, count: 0, meta: cat };
-      map[cat.id].total += p.amount;
+      map[cat.id].total += p.gelAmount;
       map[cat.id].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);

--- a/client/src/pages/Income.tsx
+++ b/client/src/pages/Income.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
-import { useCredits, useMonthCredits } from "../hooks/useCredits";
+import { useConvertedCredits, useMonthCredits } from "../hooks/useCredits";
 import { useBankSenders } from "../hooks/useBankSenders";
 import { AreaChart } from "../ink/charts";
 import { currencySymbol, monthKey, monthLabel, formatLocalDay, parseLocalDay } from "../ink/format";
@@ -13,7 +13,7 @@ export function Income() {
   const vp = useViewport();
   const now = new Date();
   const my = { month: now.getMonth(), year: now.getFullYear() };
-  const { credits } = useCredits();
+  const { credits } = useConvertedCredits();
   const monthly = useMonthCredits(my);
   const { senders } = useBankSenders();
 
@@ -34,10 +34,10 @@ export function Income() {
     }
     const totals: Record<string, number> = {};
     for (const c of credits) {
-      if (c.currency !== "GEL") continue;
+      if (c.gelAmount === null) continue;
       const k = monthKey(c.transactionDate);
       if (!keys.includes(k)) continue;
-      totals[k] = (totals[k] || 0) + c.amount;
+      totals[k] = (totals[k] || 0) + c.gelAmount;
     }
     return keys.map((k) => ({ label: monthLabel(k).slice(0, 3), value: totals[k] || 0 }));
   }, [credits, now]);
@@ -98,11 +98,11 @@ export function Income() {
   const topSources = useMemo(() => {
     const map: Record<string, { name: string; total: number; count: number }> = {};
     for (const c of credits) {
-      if (c.currency !== "GEL") continue;
+      if (c.gelAmount === null) continue;
       if (!isWithinInterval(new Date(c.transactionDate), { start: monthStart, end: monthEnd })) continue;
       const name = c.counterparty || "—";
       if (!map[name]) map[name] = { name, total: 0, count: 0 };
-      map[name].total += c.amount;
+      map[name].total += c.gelAmount;
       map[name].count += 1;
     }
     return Object.values(map)
@@ -306,9 +306,13 @@ export function Income() {
               dayKeys.map((key) => {
                 const items = groups[key];
                 const d = parseLocalDay(key);
-                const dayTotal = items
-                  .filter((t) => t.currency === "GEL")
-                  .reduce((s, t) => s + (t.amount || 0), 0);
+                // Day totals are GEL-equivalent — same NBG-converted basis
+                // as the hero card so the totals reconcile. Day-list rows
+                // continue to render in their original currency below.
+                const dayTotal = items.reduce((s, t) => {
+                  const c = credits.find((cc) => cc.id === t.id);
+                  return s + (c?.gelAmount ?? 0);
+                }, 0);
                 const diff = Math.floor((today.getTime() - d.getTime()) / 86400000);
                 const label =
                   diff === 0

--- a/client/src/pages/Merchants.tsx
+++ b/client/src/pages/Merchants.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, PageHeader } from "../ink/primitives";
-import { usePayments } from "../hooks/useTransactions";
+import { useConvertedPayments } from "../hooks/useTransactions";
 import { getCategory } from "../lib/utils";
 import { isWithinInterval, startOfMonth, endOfMonth, format } from "date-fns";
 
@@ -11,7 +11,7 @@ export function Merchants() {
   const now = new Date();
   const monthStart = startOfMonth(now);
   const monthEnd = endOfMonth(now);
-  const { payments } = usePayments();
+  const { payments } = useConvertedPayments();
   const [search, setSearch] = useState("");
 
   const merchants = useMemo(() => {
@@ -29,7 +29,7 @@ export function Merchants() {
     };
     const map: Record<string, MerchantAgg> = {};
     for (const p of payments) {
-      if (p.currency !== "GEL") continue;
+      if (p.gelAmount === null) continue;
       if (!isWithinInterval(new Date(p.transactionDate), { start: monthStart, end: monthEnd })) continue;
       const key = p.merchant || "Unknown";
       const raw = p.rawMessage || "";
@@ -44,7 +44,7 @@ export function Merchants() {
       } else if (raw) {
         map[key].searchBlob += `\n${raw.toLowerCase()}`;
       }
-      map[key].total += p.amount;
+      map[key].total += p.gelAmount;
       map[key].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, CardLabel, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
-import { usePayments, useFailedPayments } from "../hooks/useTransactions";
+import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
 import { useBankSenders } from "../hooks/useBankSenders";
 import { DEFAULT_CATEGORIES, getCategory, categorizeId } from "../lib/utils";
 import { currencySymbol, formatLocalDay, parseLocalDay } from "../ink/format";
@@ -13,7 +13,7 @@ type TxKind = "all" | "payment" | "failed";
 export function Transactions() {
   const T = useTheme();
   const vp = useViewport();
-  const { payments } = usePayments();
+  const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
   const { senders } = useBankSenders();
 
@@ -249,16 +249,17 @@ export function Transactions() {
               dayKeys.map((key) => {
                 const items = groups[key];
                 const d = parseLocalDay(key);
-                // Day-header total only sums GEL successful payments; rows
-                // for foreign-currency purchases or declines are included
-                // in the list but can't be meaningfully added together, so
-                // the header is explicitly labelled as "GEL" to avoid
-                // claiming the total represents everything visible below.
-                const gelSuccessItems = items.filter(
-                  (t) => t.kind === "payment" && t.currency === "GEL" && t.amount !== null
-                );
-                const total = gelSuccessItems.reduce((s, t) => s + (t.amount || 0), 0);
-                const hasGelActivity = gelSuccessItems.length > 0;
+                // Day-header total sums every successful payment as a GEL
+                // equivalent (NBG rate for the row's date). Declines are
+                // skipped — they have no amount. Rows still waiting on a
+                // rate (gelAmount === null) are also skipped this render
+                // and snap into the total once the fetch resolves.
+                const successItems = items.filter((t) => t.kind === "payment");
+                const total = successItems.reduce((s, t) => {
+                  const p = payments.find((pp) => pp.id === t.id);
+                  return s + (p?.gelAmount ?? 0);
+                }, 0);
+                const hasGelActivity = total > 0;
                 const diff = Math.floor((today.getTime() - d.getTime()) / 86400000);
                 const label =
                   diff === 0

--- a/service/src/exchange-rate/__tests__/exchange-service.test.ts
+++ b/service/src/exchange-rate/__tests__/exchange-service.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { CONFIG_DIR } from "../../config";
+import { clearMemoryCache, getRateSheet } from "../exchange-service";
+import { formatTbilisiDate } from "../nbg-client";
+
+// Strip the disk cache between tests so the persistence layer is exercised
+// from a known state. We isolate to ~/.xarji/exchange-cache to keep blast
+// radius tiny — the only thing this test layer manages.
+const CACHE_DIR = join(CONFIG_DIR, "exchange-cache");
+
+const SAMPLE_PAYLOAD = (date: string) => [
+  {
+    date: `${date}T17:30:00.000Z`,
+    currencies: [
+      {
+        code: "USD",
+        rate: 2.7123,
+        quantity: 1,
+        name: "US Dollar",
+        diff: 0.001,
+        date: `${date}T17:30:00.000Z`,
+        validFromDate: `${date}T00:00:00.000Z`,
+      },
+    ],
+  },
+];
+
+function installFetchMock(payloadByDate: Record<string, unknown>) {
+  const calls: string[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push(url);
+    const m = url.match(/[?&]date=(\d{4}-\d{2}-\d{2})/);
+    const dateKey = m ? m[1] : "today";
+    const payload = payloadByDate[dateKey] ?? payloadByDate["today"];
+    return new Response(JSON.stringify(payload), { status: 200 });
+  }) as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function wipeDiskCache() {
+  if (existsSync(CACHE_DIR)) rmSync(CACHE_DIR, { recursive: true, force: true });
+}
+
+beforeEach(() => {
+  clearMemoryCache();
+  wipeDiskCache();
+  mkdirSync(CACHE_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  clearMemoryCache();
+  wipeDiskCache();
+});
+
+describe("getRateSheet", () => {
+  test("hits the network on first call and caches in memory", async () => {
+    const mock = installFetchMock({ "2026-04-23": SAMPLE_PAYLOAD("2026-04-23") });
+    try {
+      const a = await getRateSheet({ date: "2026-04-23", language: "en" });
+      const b = await getRateSheet({ date: "2026-04-23", language: "en" });
+      expect(a.rates.get("USD")?.rate).toBeCloseTo(2.7123, 4);
+      expect(b.rates.get("USD")?.rate).toBeCloseTo(2.7123, 4);
+      // Second call must not re-fetch.
+      expect(mock.calls.length).toBe(1);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  test("rehydrates a historical date from disk after a process restart", async () => {
+    const mock1 = installFetchMock({ "2026-04-23": SAMPLE_PAYLOAD("2026-04-23") });
+    try {
+      await getRateSheet({ date: "2026-04-23", language: "en" });
+      expect(mock1.calls.length).toBe(1);
+    } finally {
+      mock1.restore();
+    }
+
+    // Simulate a restart: drop in-memory cache, reinstall fetch mock, ask
+    // again. Disk cache should answer without a network call.
+    clearMemoryCache();
+    const mock2 = installFetchMock({ "2026-04-23": SAMPLE_PAYLOAD("2026-04-23") });
+    try {
+      const sheet = await getRateSheet({ date: "2026-04-23", language: "en" });
+      expect(sheet.rates.get("USD")?.rate).toBeCloseTo(2.7123, 4);
+      expect(mock2.calls.length).toBe(0);
+    } finally {
+      mock2.restore();
+    }
+  });
+
+  test("refresh: true forces a network round-trip past both caches", async () => {
+    const first = installFetchMock({ "2026-04-23": SAMPLE_PAYLOAD("2026-04-23") });
+    try {
+      await getRateSheet({ date: "2026-04-23", language: "en" });
+    } finally {
+      first.restore();
+    }
+
+    const second = installFetchMock({
+      "2026-04-23": [
+        {
+          ...SAMPLE_PAYLOAD("2026-04-23")[0],
+          currencies: [
+            { ...SAMPLE_PAYLOAD("2026-04-23")[0].currencies[0], rate: 2.8000 },
+          ],
+        },
+      ],
+    });
+    try {
+      const sheet = await getRateSheet({ date: "2026-04-23", language: "en", refresh: true });
+      expect(sheet.rates.get("USD")?.rate).toBeCloseTo(2.8, 4);
+      expect(second.calls.length).toBe(1);
+    } finally {
+      second.restore();
+    }
+  });
+
+  test("today's request omits ?date= so NBG can serve its edge cache", async () => {
+    const mock = installFetchMock({ today: SAMPLE_PAYLOAD(formatTbilisiDate(new Date())) });
+    try {
+      await getRateSheet({ language: "en" });
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0]).not.toContain("?date=");
+    } finally {
+      mock.restore();
+    }
+  });
+
+  test("language is part of the cache key — different langs hit network independently", async () => {
+    const mock = installFetchMock({ "2026-04-23": SAMPLE_PAYLOAD("2026-04-23") });
+    try {
+      await getRateSheet({ date: "2026-04-23", language: "en" });
+      await getRateSheet({ date: "2026-04-23", language: "ka" });
+      expect(mock.calls.length).toBe(2);
+      // And both should be cached afterwards.
+      await getRateSheet({ date: "2026-04-23", language: "en" });
+      await getRateSheet({ date: "2026-04-23", language: "ka" });
+      expect(mock.calls.length).toBe(2);
+    } finally {
+      mock.restore();
+    }
+  });
+});
+
+// Suppress the unused mock warning from bun:test when we only import it
+// for completeness (some IDEs flag the import otherwise).
+void mock;

--- a/service/src/exchange-rate/__tests__/nbg-client.test.ts
+++ b/service/src/exchange-rate/__tests__/nbg-client.test.ts
@@ -1,0 +1,236 @@
+import { describe, test, expect } from "bun:test";
+import {
+  fetchRate,
+  fetchRateSheet,
+  formatTbilisiDate,
+  NbgDateNotFoundError,
+  NbgFutureDateError,
+  NbgInvalidLanguageError,
+  NbgRequestFailedError,
+} from "../nbg-client";
+
+// A trimmed copy of the real NBG response shape. Quantity is deliberately
+// non-1 for JPY (per 100) and UZS (per 10000) so the normalisation
+// (rate / quantity) is actually exercised by tests.
+const SAMPLE_PAYLOAD = [
+  {
+    date: "2026-04-23T17:30:00.000Z",
+    currencies: [
+      {
+        code: "USD",
+        rate: 2.7123,
+        quantity: 1,
+        name: "US Dollar",
+        diff: 0.0034,
+        date: "2026-04-23T17:30:00.000Z",
+        validFromDate: "2026-04-24T00:00:00.000Z",
+      },
+      {
+        code: "EUR",
+        rate: 2.9412,
+        quantity: 1,
+        name: "Euro",
+        diff: -0.0021,
+        date: "2026-04-23T17:30:00.000Z",
+        validFromDate: "2026-04-24T00:00:00.000Z",
+      },
+      {
+        code: "JPY",
+        rate: 1.7890,
+        quantity: 100,
+        name: "Japanese Yen",
+        diff: 0,
+        date: "2026-04-23T17:30:00.000Z",
+        validFromDate: "2026-04-24T00:00:00.000Z",
+      },
+    ],
+  },
+];
+
+function fakeFetch(payload: unknown, init: { status?: number; nonJson?: boolean; throws?: boolean } = {}) {
+  return async () => {
+    if (init.throws) throw new Error("network down");
+    const status = init.status ?? 200;
+    if (init.nonJson) {
+      return new Response("not json", { status });
+    }
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+}
+
+describe("fetchRateSheet", () => {
+  test("parses the canonical NBG payload and normalises by quantity", async () => {
+    const sheet = await fetchRateSheet({
+      language: "en",
+      date: "2026-04-23",
+      fetcher: fakeFetch(SAMPLE_PAYLOAD) as unknown as typeof fetch,
+    });
+
+    expect(sheet.date).toBe("2026-04-23");
+    expect(sheet.language).toBe("en");
+
+    const usd = sheet.rates.get("USD");
+    expect(usd?.rate).toBeCloseTo(2.7123, 4);
+    expect(usd?.change).toBe(1);
+
+    const eur = sheet.rates.get("EUR");
+    expect(eur?.change).toBe(-1);
+
+    // Quantity normalisation: API quotes JPY per 100 → divide.
+    const jpy = sheet.rates.get("JPY");
+    expect(jpy?.rate).toBeCloseTo(0.017890, 6);
+    expect(jpy?.change).toBe(0);
+  });
+
+  test("uppercases lookups regardless of API casing", async () => {
+    const sheet = await fetchRateSheet({
+      language: "en",
+      date: "2026-04-23",
+      fetcher: fakeFetch([
+        { ...SAMPLE_PAYLOAD[0], currencies: [{ ...SAMPLE_PAYLOAD[0].currencies[0], code: "usd" }] },
+      ]) as unknown as typeof fetch,
+    });
+    expect(sheet.rates.get("USD")?.rate).toBeCloseTo(2.7123, 4);
+  });
+
+  test("rejects malformed YYYY-MM-DD strings before fetching", async () => {
+    let called = 0;
+    const fetcher = (async () => { called += 1; return new Response("{}"); }) as unknown as typeof fetch;
+    await expect(
+      fetchRateSheet({ language: "en", date: "23-04-2026", fetcher })
+    ).rejects.toBeInstanceOf(NbgRequestFailedError);
+    expect(called).toBe(0);
+  });
+
+  test("refuses future dates without hitting the network", async () => {
+    let called = 0;
+    const fetcher = (async () => { called += 1; return new Response("{}"); }) as unknown as typeof fetch;
+    const future = formatTbilisiDate(new Date(Date.now() + 7 * 86400000));
+    await expect(
+      fetchRateSheet({ language: "en", date: future, fetcher })
+    ).rejects.toBeInstanceOf(NbgFutureDateError);
+    expect(called).toBe(0);
+  });
+
+  test("surfaces NBG's misspelled langaugeCode error as a typed exception", async () => {
+    await expect(
+      fetchRateSheet({
+        language: "en",
+        date: "2026-04-23",
+        fetcher: fakeFetch({ errors: { key: "langaugeCode" } }) as unknown as typeof fetch,
+      })
+    ).rejects.toBeInstanceOf(NbgInvalidLanguageError);
+  });
+
+  test("throws DateNotFound when the response is empty", async () => {
+    await expect(
+      fetchRateSheet({
+        language: "en",
+        date: "2026-04-23",
+        fetcher: fakeFetch([]) as unknown as typeof fetch,
+      })
+    ).rejects.toBeInstanceOf(NbgDateNotFoundError);
+  });
+
+  test("throws RequestFailed for non-2xx responses", async () => {
+    await expect(
+      fetchRateSheet({
+        language: "en",
+        date: "2026-04-23",
+        fetcher: fakeFetch(null, { status: 503 }) as unknown as typeof fetch,
+      })
+    ).rejects.toBeInstanceOf(NbgRequestFailedError);
+  });
+
+  test("throws RequestFailed for non-JSON responses", async () => {
+    await expect(
+      fetchRateSheet({
+        language: "en",
+        date: "2026-04-23",
+        fetcher: fakeFetch(null, { nonJson: true }) as unknown as typeof fetch,
+      })
+    ).rejects.toBeInstanceOf(NbgRequestFailedError);
+  });
+
+  test("throws RequestFailed when the fetcher itself rejects", async () => {
+    await expect(
+      fetchRateSheet({
+        language: "en",
+        date: "2026-04-23",
+        fetcher: fakeFetch(null, { throws: true }) as unknown as typeof fetch,
+      })
+    ).rejects.toBeInstanceOf(NbgRequestFailedError);
+  });
+
+  test("omits ?date= when no date is given (lets NBG serve cached today)", async () => {
+    const seen: string[] = [];
+    const fetcher = (async (input: RequestInfo | URL) => {
+      seen.push(typeof input === "string" ? input : input.toString());
+      return new Response(JSON.stringify(SAMPLE_PAYLOAD));
+    }) as unknown as typeof fetch;
+
+    await fetchRateSheet({ language: "en", fetcher });
+
+    expect(seen[0]).toContain("/currencies/en/json");
+    expect(seen[0]).not.toContain("?date=");
+  });
+
+  test("includes ?date= when an explicit date is given", async () => {
+    const seen: string[] = [];
+    const fetcher = (async (input: RequestInfo | URL) => {
+      seen.push(typeof input === "string" ? input : input.toString());
+      return new Response(JSON.stringify(SAMPLE_PAYLOAD));
+    }) as unknown as typeof fetch;
+
+    await fetchRateSheet({ language: "en", date: "2026-04-23", fetcher });
+
+    expect(seen[0]).toContain("?date=2026-04-23");
+  });
+
+  test("accepts a Date object and converts to Tbilisi-local YYYY-MM-DD", async () => {
+    const seen: string[] = [];
+    const fetcher = (async (input: RequestInfo | URL) => {
+      seen.push(typeof input === "string" ? input : input.toString());
+      return new Response(JSON.stringify(SAMPLE_PAYLOAD));
+    }) as unknown as typeof fetch;
+
+    // 23 April 2026 22:00 UTC is 24 April 02:00 in Tbilisi (UTC+4).
+    await fetchRateSheet({
+      language: "en",
+      date: new Date("2026-04-23T22:00:00Z"),
+      fetcher,
+    });
+    expect(seen[0]).toContain("?date=2026-04-24");
+  });
+});
+
+describe("fetchRate", () => {
+  test("returns just the rate for a single currency code", async () => {
+    const rate = await fetchRate("eur", {
+      language: "en",
+      date: "2026-04-23",
+      fetcher: fakeFetch(SAMPLE_PAYLOAD) as unknown as typeof fetch,
+    });
+    expect(rate).toBeCloseTo(2.9412, 4);
+  });
+
+  test("throws when the currency is missing from the sheet", async () => {
+    await expect(
+      fetchRate("XYZ", {
+        language: "en",
+        date: "2026-04-23",
+        fetcher: fakeFetch(SAMPLE_PAYLOAD) as unknown as typeof fetch,
+      })
+    ).rejects.toBeInstanceOf(NbgDateNotFoundError);
+  });
+});
+
+describe("formatTbilisiDate", () => {
+  test("formats consistently to YYYY-MM-DD in Tbilisi time", () => {
+    expect(formatTbilisiDate(new Date("2026-04-23T22:00:00Z"))).toBe("2026-04-24");
+    expect(formatTbilisiDate(new Date("2026-04-23T19:00:00Z"))).toBe("2026-04-23");
+  });
+});

--- a/service/src/exchange-rate/exchange-service.ts
+++ b/service/src/exchange-rate/exchange-service.ts
@@ -1,0 +1,143 @@
+/**
+ * Caching wrapper around the NBG client. Two layers:
+ *
+ *   1. In-process Map keyed by `<date>-<language>`. Wiped on restart.
+ *   2. Disk cache at ~/.xarji/exchange-cache/<date>-<lang>.json.
+ *      Persists across launches so we don't re-hit NBG every cold start.
+ *
+ * NBG publishes once per business day, so a long TTL is safe. Today's
+ * sheet uses a short in-memory TTL (15 min) to pick up the morning
+ * publication; historical dates are immutable and cached forever.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { CONFIG_DIR } from "../config";
+import {
+  fetchRateSheet,
+  formatTbilisiDate,
+  type NbgCurrencyRate,
+  type NbgLanguage,
+  type NbgRateSheet,
+} from "./nbg-client";
+
+const TODAY_TTL_MS = 15 * 60 * 1000;
+const CACHE_DIR = join(CONFIG_DIR, "exchange-cache");
+
+type CacheEntry = { sheet: NbgRateSheet; fetchedAt: number };
+
+const memory = new Map<string, CacheEntry>();
+
+function cacheKey(date: string, language: NbgLanguage): string {
+  return `${date}-${language}`;
+}
+
+function cacheFilePath(date: string, language: NbgLanguage): string {
+  return join(CACHE_DIR, `${cacheKey(date, language)}.json`);
+}
+
+function ensureCacheDir() {
+  if (!existsSync(CACHE_DIR)) {
+    mkdirSync(CACHE_DIR, { recursive: true });
+  }
+}
+
+interface SerialisedSheet {
+  date: string;
+  language: NbgLanguage;
+  rates: NbgCurrencyRate[];
+  fetchedAt: number;
+}
+
+function serialise(sheet: NbgRateSheet, fetchedAt: number): SerialisedSheet {
+  return {
+    date: sheet.date,
+    language: sheet.language,
+    rates: Array.from(sheet.rates.values()),
+    fetchedAt,
+  };
+}
+
+function deserialise(raw: SerialisedSheet): CacheEntry {
+  const map = new Map<string, NbgCurrencyRate>();
+  for (const r of raw.rates) map.set(r.code, r);
+  return {
+    sheet: { date: raw.date, language: raw.language, rates: map },
+    fetchedAt: raw.fetchedAt,
+  };
+}
+
+function readDisk(date: string, language: NbgLanguage): CacheEntry | null {
+  const path = cacheFilePath(date, language);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as SerialisedSheet;
+    return deserialise(raw);
+  } catch {
+    // Corrupt cache — let the network refresh overwrite it.
+    return null;
+  }
+}
+
+function writeDisk(sheet: NbgRateSheet, fetchedAt: number) {
+  ensureCacheDir();
+  const path = cacheFilePath(sheet.date, sheet.language);
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(serialise(sheet, fetchedAt)), "utf8");
+  // Atomic rename so a crashed half-write never lingers as the final file.
+  renameSync(tmp, path);
+}
+
+interface GetSheetOptions {
+  date?: string; // YYYY-MM-DD; default = today (Tbilisi)
+  language?: NbgLanguage;
+  /** Force a network round-trip even if a fresh cache entry exists. */
+  refresh?: boolean;
+}
+
+export async function getRateSheet(opts: GetSheetOptions = {}): Promise<NbgRateSheet> {
+  const language: NbgLanguage = opts.language ?? "ka";
+  const date = opts.date ?? formatTbilisiDate(new Date());
+  const isToday = date === formatTbilisiDate(new Date());
+  const key = cacheKey(date, language);
+
+  if (!opts.refresh) {
+    const mem = memory.get(key);
+    if (mem && (!isToday || Date.now() - mem.fetchedAt < TODAY_TTL_MS)) {
+      return mem.sheet;
+    }
+    if (!isToday) {
+      const disk = readDisk(date, language);
+      if (disk) {
+        memory.set(key, disk);
+        return disk.sheet;
+      }
+    }
+  }
+
+  // The "today" branch always passes no `date` so NBG can serve its
+  // edge-cached default response; explicit dates always go through with
+  // ?date=YYYY-MM-DD.
+  const sheet = await fetchRateSheet(isToday ? { language } : { language, date });
+  const fetchedAt = Date.now();
+  memory.set(key, { sheet, fetchedAt });
+  writeDisk(sheet, fetchedAt);
+  return sheet;
+}
+
+export async function getRate(code: string, opts: GetSheetOptions = {}): Promise<number> {
+  const sheet = await getRateSheet(opts);
+  const rate = sheet.rates.get(code.toUpperCase());
+  if (!rate) {
+    throw new Error(`Currency ${code.toUpperCase()} not found in NBG sheet for ${sheet.date}`);
+  }
+  return rate.rate;
+}
+
+/**
+ * Drop in-process cache. Disk cache is left alone — restart re-hydrates
+ * from disk. Tests use this between cases.
+ */
+export function clearMemoryCache() {
+  memory.clear();
+}

--- a/service/src/exchange-rate/nbg-client.ts
+++ b/service/src/exchange-rate/nbg-client.ts
@@ -1,0 +1,226 @@
+/**
+ * Thin HTTP client for the National Bank of Georgia (NBG) currency
+ * endpoint. Mirrors the surface of the Stichoza/nbg-currency PHP library:
+ * fetch a day's full rate sheet for a given language, parse it into
+ * normalised per-currency entries, surface NBG's quirky error shapes as
+ * typed exceptions.
+ *
+ * Endpoint:
+ *   GET https://nbg.gov.ge/gw/api/ct/monetarypolicy/currencies/{lang}/json
+ *       [?date=YYYY-MM-DD]
+ *
+ * `lang` accepts "ka" (Georgian, default), "en", or "ru". Omitting the
+ * date returns today's rates in the Asia/Tbilisi timezone (NBG publishes
+ * once per business day).
+ *
+ * The raw payload quotes some currencies per N units (e.g. JPY per 100,
+ * UZS per 10000). The PHP lib divides `rate / quantity` to give a
+ * GEL-per-1-unit rate; we do the same so callers never have to think
+ * about quantity.
+ */
+
+export type NbgLanguage = "ka" | "en" | "ru";
+
+export const NBG_TIMEZONE = "Asia/Tbilisi";
+const NBG_URL = "https://nbg.gov.ge/gw/api/ct/monetarypolicy/currencies/%s/json";
+
+export interface NbgRawCurrency {
+  code: string;
+  rate: number;
+  quantity: number;
+  name: string;
+  diff: number;
+  date: string;
+  validFromDate: string;
+}
+
+interface NbgRawResponseEntry {
+  date: string;
+  currencies: NbgRawCurrency[];
+}
+
+export interface NbgCurrencyRate {
+  code: string;
+  rate: number; // GEL per 1 unit of the foreign currency
+  diff: number; // change vs previous publication, normalised by quantity
+  change: -1 | 0 | 1;
+  name: string;
+  date: string; // ISO date (when this rate was published)
+  validFrom: string; // ISO date (when this rate becomes valid)
+}
+
+export interface NbgRateSheet {
+  date: string; // YYYY-MM-DD in the requested timezone
+  language: NbgLanguage;
+  rates: Map<string, NbgCurrencyRate>;
+}
+
+export class NbgRequestFailedError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = "NbgRequestFailedError";
+  }
+}
+
+export class NbgInvalidLanguageError extends Error {
+  constructor(language: string) {
+    super(`NBG rejected language code "${language}"`);
+    this.name = "NbgInvalidLanguageError";
+  }
+}
+
+export class NbgDateNotFoundError extends Error {
+  constructor(date: string) {
+    super(`NBG returned no rates for ${date}`);
+    this.name = "NbgDateNotFoundError";
+  }
+}
+
+export class NbgFutureDateError extends Error {
+  constructor(date: string) {
+    super(`Cannot request future date ${date}`);
+    this.name = "NbgFutureDateError";
+  }
+}
+
+/**
+ * YYYY-MM-DD in Asia/Tbilisi for a Date instance. NBG publishes on its
+ * local calendar; using the user's local date would skew by hours when
+ * the user is in a different timezone (and rotate the day boundary
+ * around midnight Tbilisi).
+ */
+export function formatTbilisiDate(d: Date): string {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: NBG_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return fmt.format(d);
+}
+
+function todayTbilisi(): string {
+  return formatTbilisiDate(new Date());
+}
+
+function isFutureDate(yyyymmdd: string): boolean {
+  return yyyymmdd > todayTbilisi();
+}
+
+interface FetchRatesOptions {
+  language?: NbgLanguage;
+  date?: Date | string;
+  /** Override fetch (tests). */
+  fetcher?: typeof fetch;
+}
+
+/**
+ * Fetch a day's NBG rate sheet. `date` undefined → today (Tbilisi).
+ *
+ * The PHP library passes no query string at all when the date is "today"
+ * to hit NBG's edge-cached default response — same here. Explicit dates
+ * always go through with `?date=`.
+ */
+export async function fetchRateSheet(opts: FetchRatesOptions = {}): Promise<NbgRateSheet> {
+  const language: NbgLanguage = opts.language ?? "ka";
+  const fetcher = opts.fetcher ?? fetch;
+
+  let dateString: string | null;
+  if (opts.date === undefined) {
+    dateString = null;
+  } else if (typeof opts.date === "string") {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(opts.date)) {
+      throw new NbgRequestFailedError(`Date "${opts.date}" must be YYYY-MM-DD`);
+    }
+    dateString = opts.date;
+  } else {
+    dateString = formatTbilisiDate(opts.date);
+  }
+
+  if (dateString !== null && isFutureDate(dateString)) {
+    throw new NbgFutureDateError(dateString);
+  }
+
+  const url = NBG_URL.replace("%s", language) + (dateString ? `?date=${dateString}` : "");
+
+  let response: Response;
+  try {
+    response = await fetcher(url, { method: "GET" });
+  } catch (err) {
+    throw new NbgRequestFailedError(`Network error contacting NBG: ${String(err)}`, err);
+  }
+
+  if (!response.ok) {
+    throw new NbgRequestFailedError(`NBG returned HTTP ${response.status}`);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (err) {
+    throw new NbgRequestFailedError("NBG returned non-JSON response", err);
+  }
+
+  // NBG signals an invalid language by returning an object with an
+  // `errors.key` field — and the key itself is misspelled "langaugeCode"
+  // in the upstream API (sic). Surface it as a typed error so callers
+  // can recover (e.g. fall back to "ka").
+  if (payload && typeof payload === "object" && "errors" in payload) {
+    const errors = (payload as { errors?: { key?: string } }).errors;
+    if (errors?.key === "langaugeCode" || errors?.key === "languageCode") {
+      throw new NbgInvalidLanguageError(language);
+    }
+  }
+
+  if (!Array.isArray(payload) || payload.length === 0) {
+    throw new NbgDateNotFoundError(dateString ?? todayTbilisi());
+  }
+
+  const entry = payload[0] as Partial<NbgRawResponseEntry>;
+  if (!entry || typeof entry.date !== "string" || !Array.isArray(entry.currencies)) {
+    throw new NbgDateNotFoundError(dateString ?? todayTbilisi());
+  }
+
+  const rates = new Map<string, NbgCurrencyRate>();
+  for (const raw of entry.currencies) {
+    const normalised = normaliseCurrency(raw);
+    if (normalised) rates.set(normalised.code, normalised);
+  }
+
+  return {
+    date: dateString ?? entry.date.slice(0, 10),
+    language,
+    rates,
+  };
+}
+
+function normaliseCurrency(raw: Partial<NbgRawCurrency> | null | undefined): NbgCurrencyRate | null {
+  if (!raw || typeof raw.code !== "string" || raw.code.length === 0) return null;
+  if (typeof raw.rate !== "number" || !Number.isFinite(raw.rate)) return null;
+  const quantity = typeof raw.quantity === "number" && raw.quantity > 0 ? raw.quantity : 1;
+  const rate = raw.rate / quantity;
+  const diff = typeof raw.diff === "number" ? raw.diff / quantity : 0;
+  const change: -1 | 0 | 1 = diff > 0 ? 1 : diff < 0 ? -1 : 0;
+  return {
+    code: raw.code.toUpperCase(),
+    rate,
+    diff,
+    change,
+    name: raw.name ?? "",
+    date: typeof raw.date === "string" ? raw.date : "",
+    validFrom: typeof raw.validFromDate === "string" ? raw.validFromDate : "",
+  };
+}
+
+/**
+ * Convenience: fetch a single currency's rate. Mirrors `NbgCurrency::rate`
+ * in the PHP lib. Throws if the currency isn't published on that date.
+ */
+export async function fetchRate(code: string, opts: FetchRatesOptions = {}): Promise<number> {
+  const sheet = await fetchRateSheet(opts);
+  const rate = sheet.rates.get(code.toUpperCase());
+  if (!rate) {
+    throw new NbgDateNotFoundError(sheet.date);
+  }
+  return rate.rate;
+}

--- a/service/src/http.ts
+++ b/service/src/http.ts
@@ -21,6 +21,14 @@ import { CLIENT_ASSETS } from "./generated/client-assets";
 import { serializeSchema, type FieldMap } from "./setup/schema";
 import { applySetup } from "./setup/apply";
 import { previewSenders } from "./setup/preview";
+import { getRateSheet } from "./exchange-rate/exchange-service";
+import {
+  NbgDateNotFoundError,
+  NbgFutureDateError,
+  NbgInvalidLanguageError,
+  NbgRequestFailedError,
+  type NbgLanguage,
+} from "./exchange-rate/nbg-client";
 
 export interface HttpServerOptions {
   port: number;
@@ -304,6 +312,64 @@ export function startHttpServer(opts: HttpServerOptions): HttpServerHandle {
           );
         }
         return json(result);
+      }
+      if (path === "/api/exchange-rate" && req.method === "GET") {
+        const dateParam = url.searchParams.get("date");
+        const langParam = url.searchParams.get("lang");
+        const codesParam = url.searchParams.get("codes");
+
+        if (dateParam !== null && !/^\d{4}-\d{2}-\d{2}$/.test(dateParam)) {
+          return json({ error: "`date` must be YYYY-MM-DD" }, { status: 400 });
+        }
+        let language: NbgLanguage = "en";
+        if (langParam !== null) {
+          if (langParam !== "ka" && langParam !== "en" && langParam !== "ru") {
+            return json({ error: "`lang` must be ka, en, or ru" }, { status: 400 });
+          }
+          language = langParam;
+        }
+        const filterCodes = codesParam
+          ? codesParam.split(",").map((c) => c.trim().toUpperCase()).filter(Boolean)
+          : null;
+
+        try {
+          const sheet = await getRateSheet({
+            date: dateParam ?? undefined,
+            language,
+          });
+          const ratesObj: Record<string, { rate: number; diff: number; change: number; name: string; validFrom: string }> = {};
+          for (const [code, r] of sheet.rates) {
+            if (filterCodes && !filterCodes.includes(code)) continue;
+            ratesObj[code] = {
+              rate: r.rate,
+              diff: r.diff,
+              change: r.change,
+              name: r.name,
+              validFrom: r.validFrom,
+            };
+          }
+          return json({
+            ok: true,
+            base: "GEL",
+            date: sheet.date,
+            language: sheet.language,
+            rates: ratesObj,
+          });
+        } catch (err) {
+          if (err instanceof NbgFutureDateError) {
+            return json({ ok: false, error: err.message, errorKind: "future-date" }, { status: 400 });
+          }
+          if (err instanceof NbgDateNotFoundError) {
+            return json({ ok: false, error: err.message, errorKind: "no-rates" }, { status: 404 });
+          }
+          if (err instanceof NbgInvalidLanguageError) {
+            return json({ ok: false, error: err.message, errorKind: "bad-language" }, { status: 400 });
+          }
+          if (err instanceof NbgRequestFailedError) {
+            return json({ ok: false, error: err.message, errorKind: "upstream" }, { status: 502 });
+          }
+          return json({ ok: false, error: String(err), errorKind: "internal" }, { status: 500 });
+        }
       }
       if (path.startsWith("/api/")) {
         return json({ error: "unknown endpoint" }, { status: 404 });


### PR DESCRIPTION
Stacked on top of #13 (the NBG client). Wires the rates the previous PR fetches into every dashboard aggregate so foreign-currency rows actually count toward totals instead of being silently filtered out before summing.

A new `client/src/lib/exchangeRates.ts` owns the conversion. It lazily hits `/api/exchange-rate` the first time a given (date, currency) pair is needed, caches results in memory, and persists historical-date rates to localStorage so reloads don't re-fetch. Today's rate has a 15-minute TTL to pick up the morning publication.

`useConvertedPayments` and `useConvertedCredits` wrap the existing list hooks and decorate each row with `gelAmount`: the GEL-equivalent under NBG's rate for that row's `transactionDate`. The value is `number | null` — null while the rate is in flight. Every aggregate hook (`useMonthStats`, `useMonthCredits`, `useMonthlyTrend`, `useSignals`, `useMonthSpendingByDay`, `useMonthTopMerchants`, `useMonthCategoryAnalytics`) sums `gelAmount` and skips nulls.

The loading-window UX is intentional: rows still show in the list in their original currency, but their value sits out of the totals for the ~200ms it takes the rate fetch to resolve, then they snap in on re-render. Returning the raw amount during loading would briefly inflate totals with USD-denominated numbers added to GEL ones; returning 0 would have the same UX as null without the explicit "not loaded yet" signal.

Pages that had their own `currency === "GEL"` filter (Dashboard, Categories, Merchants, Transactions, Income) now go through the converted hooks and key off `gelAmount`. Day-header totals on Transactions and Income drop the explicit "GEL" label since they now legitimately represent every row visible below.

Caveat: the rate is looked up by the row's date in the user's local timezone via `formatLocalDay`. For users in Georgia (which is everyone, today) this is identical to NBG's Tbilisi calendar. Travelers could hit a 1-day skew, which doesn't materially change the rate.