### PR TITLE
AI Assistant + dashboard redesign + demo mode + favicon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -627,7 +627,58 @@ Used once during project bootstrap (`app-menubar/` creation) to scaffold the Swi
 
 ---
 
-## 12. Future work (explicitly deferred)
+## 12. AI Assistant — provider clients, tools, and the system prompt
+
+The Assistant feature lives under `client/src/lib/ai/` and `client/src/components/Assistant*.tsx`. Two providers (Anthropic + OpenAI), one orchestrator, one tool registry, one system prompt. Adding a new provider is one file under `lib/ai/providers/`; adding a new tool is one entry in a registry. The system prompt **auto-includes the registered tool list** — never edit it by hand.
+
+### Layout
+
+```
+client/src/lib/ai/
+├── types.ts                  ← shared protocol (AIStreamEvent, AIToolDefinition, AIProviderClient)
+├── provider.ts               ← dynamic-import factory; SDKs only land in the bundle when picked
+├── providers/
+│   ├── anthropic.ts          ← claude.messages.stream(), adaptive thinking
+│   └── openai.ts             ← chat.completions.create({ stream: true })
+├── tools/
+│   ├── types.ts              ← AITool + AIToolContext
+│   └── readonly.ts           ← read-only tools registry (`READONLY_TOOLS`)
+└── orchestrator.ts           ← provider→tool→provider loop, capped at 8 iterations
+
+client/src/hooks/useAgentRunner.ts
+   ↑ Bridges live React data into AIToolContext, owns the system prompt,
+     composes registries into the ALL_TOOLS list passed to the orchestrator.
+```
+
+### The "tools must appear in the system prompt" rule
+
+The system prompt at `useAgentRunner.ts` is built by `buildSystemPrompt(tools)` which appends an **Available tools:** section generated from each tool's `definition.name` + `definition.description`. The model sees the same source-of-truth list of tools that the orchestrator dispatches against — no hand-maintained duplicate to drift.
+
+**When you add a tool:** register it in the relevant tools file (e.g. push it onto `READONLY_TOOLS` in `lib/ai/tools/readonly.ts`). The prompt updates automatically on the next user prompt.
+
+**When you add a NEW tool registry** (e.g. `WRITE_TOOLS`, `GUIDED_TOOLS`, `EXPERIMENTAL_TOOLS`): export the array, then concatenate it into `ALL_TOOLS` in `useAgentRunner.ts`. Both effects (callable + listed in prompt) happen at once.
+
+### The "use the latest models" rule
+
+The provider model lists in `client/src/lib/aiConfig.ts` are user-facing — the picker in the Assistant onboarding + the Settings AI section read from this file. When a new Anthropic or OpenAI model ships, update `models` and `defaultModel` here. The `claude-api` skill (auto-loaded for Claude work) carries the current Anthropic catalog and migration guidance — defer to it for Claude model IDs and breaking-change notes (sampling params, `budget_tokens` removal, etc.).
+
+### Read-only-only
+
+Every tool today is read-only — purely a function over the live `AIToolContext` (payments, credits, categories, etc.). Write tools (create category, set budget, delete transaction) are deliberately deferred until we design a consent UX around them. If you add one, it must:
+
+1. Render a preview block (`CategoryCard` / `BudgetCard` / etc.) showing the proposed change.
+2. Wait for explicit user confirmation in the chat before committing.
+3. Only then call `db.transact(...)` against InstantDB.
+
+The orchestrator's `toBlock` hook on `AITool` is the seam for the preview step — the structured cards already exist in `AssistantChat.tsx`.
+
+### Where keys live
+
+The Anthropic / OpenAI API key is in `localStorage['xarji-ai']`, written by the onboarding form in `AssistantOnboarding.tsx`. Both SDK clients are constructed in the browser with `dangerouslyAllowBrowser: true` — acceptable here because Xarji is a single-user local-first app with no third-party scripts on the page (no XSS surface beyond what the user explicitly types). The matching UI copy ("keys never leave this Mac") is true: keys never reach `xarji-core` or any service Xarji owns; they go straight from the browser to `api.anthropic.com` / `api.openai.com`.
+
+---
+
+## 13. Future work (explicitly deferred)
 
 Things we considered and decided to skip for now. Re-evaluate when there's a concrete need, not before:
 
@@ -640,7 +691,7 @@ Things we considered and decided to skip for now. Re-evaluate when there's a con
 
 ---
 
-## 13. Quick reference
+## 14. Quick reference
 
 ```
 Dev:

--- a/client/bun.lock
+++ b/client/bun.lock
@@ -5,11 +5,13 @@
     "": {
       "name": "client",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
         "@instantdb/react": "^0.22.106",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.562.0",
         "motion": "^12.38.0",
+        "openai": "^6.34.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
@@ -37,6 +39,8 @@
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
 
@@ -69,6 +73,8 @@
     "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -502,6 +508,8 @@
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
@@ -553,6 +561,8 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "openai": ["openai@6.34.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -665,6 +675,8 @@
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 

--- a/client/bun.lock
+++ b/client/bun.lock
@@ -5,13 +5,11 @@
     "": {
       "name": "client",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.91.1",
         "@instantdb/react": "^0.22.106",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.562.0",
         "motion": "^12.38.0",
-        "openai": "^6.34.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
@@ -39,8 +37,6 @@
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
-
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
 
@@ -73,8 +69,6 @@
     "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
-
-    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -508,8 +502,6 @@
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
-    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
-
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
@@ -561,8 +553,6 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
-
-    "openai": ["openai@6.34.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -675,8 +665,6 @@
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
-
-    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 

--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/larifavicon.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- PWA: lets Chrome / Edge / Arc / Brave offer "Install Xarji…" and
          lets Safari's File → Add to Dock pick up the right name + icon. -->

--- a/client/package.json
+++ b/client/package.json
@@ -10,11 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.91.1",
     "@instantdb/react": "^0.22.106",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.562.0",
     "motion": "^12.38.0",
+    "openai": "^6.34.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.12.0",

--- a/client/package.json
+++ b/client/package.json
@@ -10,13 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.91.1",
     "@instantdb/react": "^0.22.106",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.562.0",
     "motion": "^12.38.0",
-    "openai": "^6.34.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.12.0",

--- a/client/public/favicon.svg
+++ b/client/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ff5a3a"/>
+      <stop offset="1" stop-color="#ff8560"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="9" fill="url(#g)"/>
+  <text x="16" y="22.5" text-anchor="middle"
+        font-family="Inter Tight, Inter, system-ui, -apple-system, sans-serif"
+        font-size="19" font-weight="800" letter-spacing="-0.8" fill="#fff">X</text>
+</svg>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Layout } from "./components/Layout";
-import { Dashboard, Transactions, Categories, Merchants, Income, Signals, Settings } from "./pages";
+import { Dashboard, Transactions, Categories, Merchants, Income, Signals, Settings, Assistant } from "./pages";
 
 function App() {
   return (
@@ -12,6 +12,7 @@ function App() {
           <Route path="income" element={<Income />} />
           <Route path="categories" element={<Categories />} />
           <Route path="merchants" element={<Merchants />} />
+          <Route path="assistant" element={<Assistant />} />
           <Route path="signals" element={<Signals />} />
           <Route path="manage" element={<Settings />} />
           {/* Compatibility redirects for the routes that existed in the

--- a/client/src/components/AssistantChat.tsx
+++ b/client/src/components/AssistantChat.tsx
@@ -1,0 +1,1336 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTheme, type InkTheme } from "../ink/theme";
+import { LiveDot } from "../ink/primitives";
+import { getProvider, type AIConfig } from "../lib/aiConfig";
+import {
+  createThread,
+  deleteThread,
+  deriveTitle,
+  loadActiveThreadId,
+  loadThreads,
+  onThreadsChange,
+  saveThreads,
+  setActiveThreadId,
+  timeAgo,
+  updateThread,
+  type AIBlock,
+  type AIBudgetBlock,
+  type AICategoryBlock,
+  type AIMessage,
+  type AIPlanBlock,
+  type AIThread,
+  type AIToolBlock,
+} from "../lib/aiThreads";
+import { useAgentRunner } from "../hooks/useAgentRunner";
+import type { AssistantEvent } from "../lib/ai/orchestrator";
+
+interface Suggestion {
+  icon: string;
+  label: string;
+  prompt: string;
+}
+
+const SUGGESTIONS: Suggestion[] = [
+  { icon: "◐", label: 'Create a "Coffee shops" category', prompt: 'Make a new category called "Coffee shops" and move all my Starbucks, Coffee LAB, and Skola transactions there.' },
+  { icon: "◆", label: "Set a ₾800 food budget", prompt: "Set a monthly budget of ₾800 for Food & Drink and warn me at 80%." },
+  { icon: "✦", label: "Plan to save for a Honda — $1,000", prompt: "I want to save $1,000 for a Honda by end of August. Make me a savings plan." },
+  { icon: "≡", label: "Filter all transit > ₾20 last 30 days", prompt: "Show me every transit transaction over ₾20 in the last 30 days, grouped by merchant." },
+  { icon: "◉", label: "Summarize my April spending", prompt: "Give me a one-paragraph summary of my April spending — what stood out vs. March?" },
+  { icon: "⚠", label: "Find subscriptions I'm not using", prompt: "Look at recurring charges and flag any I might want to cancel." },
+];
+
+export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: () => void }) {
+  const T = useTheme();
+  const provider = getProvider(config.provider);
+  const [model, setModel] = useState(config.model || provider.defaultModel);
+  const runAgent = useAgentRunner();
+
+  const [threads, setThreads] = useState<AIThread[]>(loadThreads);
+  const [activeId, setActiveIdState] = useState<string | null>(loadActiveThreadId);
+  const [busy, setBusy] = useState(false);
+  const [busyStatus, setBusyStatus] = useState<string>("Thinking…");
+  const [input, setInput] = useState("");
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(
+    () =>
+      onThreadsChange(() => {
+        setThreads(loadThreads());
+        setActiveIdState(loadActiveThreadId());
+      }),
+    []
+  );
+
+  const activeThread = useMemo(
+    () => threads.find((t) => t.id === activeId) ?? null,
+    [threads, activeId]
+  );
+
+  // Auto-run prompt seeded by ⌘K spotlight.
+  useEffect(() => {
+    if (!activeThread) return;
+    if (activeThread.autoRun && activeThread.pendingPrompt && !busy) {
+      const prompt = activeThread.pendingPrompt;
+      updateThread(activeThread.id, { autoRun: false, pendingPrompt: null });
+      setThreads(loadThreads());
+      runAgentForActive(prompt);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeThread?.id, activeThread?.autoRun]);
+
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [activeThread?.messages?.length, busy]);
+
+  const switchTo = (id: string) => {
+    setActiveThreadId(id);
+    setActiveIdState(id);
+    setInput("");
+  };
+
+  const newThread = () => {
+    const t = createThread({ title: "New conversation" });
+    setThreads(loadThreads());
+    setActiveIdState(t.id);
+    setInput("");
+  };
+
+  const removeThread = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    deleteThread(id);
+    setThreads(loadThreads());
+    setActiveIdState(loadActiveThreadId());
+  };
+
+  const send = (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed || busy) return;
+
+    let thread = activeThread;
+    if (!thread) {
+      thread = createThread({ title: deriveTitle(trimmed), firstUserPrompt: trimmed });
+      setThreads(loadThreads());
+      setActiveIdState(thread.id);
+    } else {
+      const msg: AIMessage = {
+        role: "user",
+        id: "u" + Date.now(),
+        blocks: [{ kind: "text", text: trimmed }],
+      };
+      const newMessages = [...thread.messages, msg];
+      const newTitle = thread.messages.length === 0 ? deriveTitle(trimmed) : thread.title;
+      updateThread(thread.id, { messages: newMessages, title: newTitle });
+      setThreads(loadThreads());
+    }
+    setInput("");
+    runAgentForActive(trimmed);
+  };
+
+  const runAgentForActive = (text: string) => {
+    setBusy(true);
+    setBusyStatus("Thinking…");
+    const handle = (event: AssistantEvent) => {
+      const id = loadActiveThreadId();
+      const list = loadThreads();
+      const idx = list.findIndex((t) => t.id === id);
+      if (idx === -1) return;
+      const t = list[idx];
+      let assistant = t.messages[t.messages.length - 1];
+      if (!assistant || assistant.role !== "assistant" || !assistant.streaming) {
+        assistant = {
+          role: "assistant",
+          id: "a" + Date.now() + Math.random().toString(36).slice(2, 5),
+          streaming: true,
+          blocks: [],
+        };
+        t.messages.push(assistant);
+      }
+
+      if (event.type === "text-delta") {
+        // Append into the trailing text block if there is one and the
+        // most recent emit was also text. Closing a text block happens
+        // implicitly when a non-text block arrives.
+        const lastBlock = assistant.blocks[assistant.blocks.length - 1];
+        if (lastBlock && lastBlock.kind === "text") {
+          lastBlock.text += event.text;
+        } else {
+          assistant.blocks.push({ kind: "text", text: event.text });
+        }
+      } else if (event.type === "block") {
+        assistant.blocks.push(event.block);
+      } else if (event.type === "status") {
+        setBusyStatus(event.text);
+        return;
+      }
+
+      saveThreads(list);
+      setThreads(list.slice());
+    };
+
+    const finalConfig = { ...config, model };
+    runAgent(finalConfig, text, handle)
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        handle({
+          type: "block",
+          block: { kind: "text", text: `_Agent error: ${message}_` },
+        });
+      })
+      .finally(() => {
+        const id = loadActiveThreadId();
+        const list = loadThreads();
+        const idx = list.findIndex((t) => t.id === id);
+        if (idx !== -1) {
+          const last = list[idx].messages[list[idx].messages.length - 1];
+          if (last) delete last.streaming;
+          saveThreads(list);
+          setThreads(list.slice());
+        }
+        setBusy(false);
+      });
+  };
+
+  // Header kebab menu
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [menuOpen]);
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "260px 1fr",
+        gap: 0,
+        flex: 1,
+        minHeight: 720,
+        background: T.panel,
+        borderRadius: T.rXl,
+        border: `1px solid ${T.line}`,
+        overflow: "hidden",
+      }}
+    >
+      <aside
+        style={{
+          borderRight: `1px solid ${T.line}`,
+          display: "flex",
+          flexDirection: "column",
+          background: T.bg,
+          minHeight: 0,
+        }}
+      >
+        <div
+          style={{
+            padding: "14px 14px",
+            borderBottom: `1px solid ${T.line}`,
+            display: "flex",
+            flexDirection: "column",
+            gap: 10,
+          }}
+        >
+          <button
+            onClick={newThread}
+            style={{
+              padding: "10px 12px",
+              borderRadius: 9,
+              background: T.accent,
+              color: "#fff",
+              border: "none",
+              cursor: "pointer",
+              fontSize: 12.5,
+              fontWeight: 700,
+              fontFamily: T.sans,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
+            }}
+          >
+            <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ fontSize: 14 }}>+</span> New conversation
+            </span>
+            <span
+              style={{
+                fontSize: 10,
+                fontFamily: T.mono,
+                fontWeight: 600,
+                opacity: 0.85,
+                padding: "2px 6px",
+                background: "rgba(255,255,255,0.18)",
+                borderRadius: 4,
+              }}
+            >
+              ⌘K
+            </span>
+          </button>
+        </div>
+
+        <div style={{ flex: 1, overflowY: "auto", padding: "8px 8px 16px" }}>
+          {threads.length === 0 ? (
+            <div style={{ padding: 18, fontSize: 12, color: T.muted, fontFamily: T.sans, lineHeight: 1.5 }}>
+              No conversations yet. Start one with the button above or press{" "}
+              <span
+                style={{
+                  fontFamily: T.mono,
+                  fontSize: 10.5,
+                  padding: "2px 6px",
+                  background: T.panelAlt,
+                  borderRadius: 4,
+                  color: T.text,
+                }}
+              >
+                ⌘K
+              </span>{" "}
+              from anywhere in Xarji.
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              {threads.map((t) => {
+                const active = t.id === activeId;
+                const lastUser = [...t.messages].reverse().find((m) => m.role === "user");
+                const firstBlock = lastUser?.blocks?.[0];
+                const preview =
+                  firstBlock && firstBlock.kind === "text" ? firstBlock.text : "No messages yet";
+                return (
+                  <div
+                    key={t.id}
+                    onClick={() => switchTo(t.id)}
+                    style={{
+                      padding: "10px 12px",
+                      borderRadius: 9,
+                      cursor: "pointer",
+                      position: "relative",
+                      background: active ? T.panel : "transparent",
+                      border: active ? `1px solid ${T.line}` : "1px solid transparent",
+                      transition: "background .15s ease",
+                    }}
+                    onMouseEnter={(e) => {
+                      if (!active) (e.currentTarget as HTMLDivElement).style.background = T.panel;
+                    }}
+                    onMouseLeave={(e) => {
+                      if (!active) (e.currentTarget as HTMLDivElement).style.background = "transparent";
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 3 }}>
+                      <span
+                        style={{
+                          fontSize: 12.5,
+                          fontWeight: 600,
+                          color: T.text,
+                          fontFamily: T.sans,
+                          whiteSpace: "nowrap",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          flex: 1,
+                        }}
+                      >
+                        {t.title}
+                      </span>
+                      <button
+                        onClick={(e) => removeThread(t.id, e)}
+                        title="Delete"
+                        style={{
+                          background: "transparent",
+                          border: "none",
+                          color: T.dim,
+                          cursor: "pointer",
+                          padding: 2,
+                          fontSize: 12,
+                          opacity: 0.7,
+                          fontFamily: T.sans,
+                        }}
+                      >
+                        ×
+                      </button>
+                    </div>
+                    <div
+                      style={{
+                        fontSize: 11,
+                        color: T.muted,
+                        fontFamily: T.sans,
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        lineHeight: 1.3,
+                      }}
+                    >
+                      {preview}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: 9.5,
+                        color: T.dim,
+                        fontFamily: T.mono,
+                        marginTop: 4,
+                        letterSpacing: 0.3,
+                      }}
+                    >
+                      {timeAgo(t.updatedAt)}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </aside>
+
+      <section style={{ display: "flex", flexDirection: "column", minHeight: 0 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "12px 16px",
+            borderBottom: `1px solid ${T.line}`,
+            gap: 12,
+            minWidth: 0,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0, flex: 1 }}>
+            <div
+              style={{
+                width: 26,
+                height: 26,
+                borderRadius: 7,
+                background: T.accent,
+                color: "#fff",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontWeight: 800,
+                fontSize: 12,
+                flexShrink: 0,
+              }}
+            >
+              X
+            </div>
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <div
+                style={{
+                  fontSize: 13.5,
+                  fontWeight: 700,
+                  color: T.text,
+                  fontFamily: T.sans,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {activeThread ? activeThread.title : "Xarji AI"}
+              </div>
+              <div
+                style={{
+                  fontSize: 10,
+                  color: T.dim,
+                  fontFamily: T.mono,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 5,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                <LiveDot color={T.green} />
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {provider.name} · {model}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0, position: "relative" }}
+            ref={menuRef}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 5,
+                padding: "4px 8px",
+                background: T.panelAlt,
+                borderRadius: 999,
+                border: `1px solid ${T.line}`,
+              }}
+            >
+              <span
+                style={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: 3,
+                  background: provider.color,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 7,
+                  color: "#fff",
+                  fontWeight: 800,
+                }}
+              >
+                {provider.name.charAt(0)}
+              </span>
+              <select
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  color: T.text,
+                  fontSize: 11,
+                  fontFamily: T.mono,
+                  fontWeight: 600,
+                  cursor: "pointer",
+                  outline: "none",
+                  maxWidth: 140,
+                }}
+              >
+                {provider.models.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              onClick={() => setMenuOpen((o) => !o)}
+              title="More"
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: 8,
+                background: "transparent",
+                border: `1px solid ${T.line}`,
+                color: T.muted,
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 14,
+                fontFamily: T.sans,
+                padding: 0,
+                lineHeight: 1,
+              }}
+            >
+              ⋯
+            </button>
+            {menuOpen && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: 36,
+                  right: 0,
+                  minWidth: 180,
+                  background: T.panel,
+                  borderRadius: 10,
+                  border: `1px solid ${T.line}`,
+                  boxShadow: "0 12px 30px rgba(0,0,0,0.4)",
+                  zIndex: 50,
+                  padding: 4,
+                }}
+              >
+                <button
+                  onClick={() => {
+                    setMenuOpen(false);
+                    if (window.confirm("Disconnect AI? Your key will be removed from this device.")) {
+                      onClear();
+                    }
+                  }}
+                  style={{
+                    width: "100%",
+                    padding: "8px 10px",
+                    textAlign: "left",
+                    background: "transparent",
+                    border: "none",
+                    borderRadius: 6,
+                    color: T.text,
+                    fontSize: 12.5,
+                    fontFamily: T.sans,
+                    cursor: "pointer",
+                    fontWeight: 500,
+                  }}
+                  onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.background = T.panelAlt;
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+                  }}
+                >
+                  Disconnect AI…
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {!activeThread || activeThread.messages.length === 0 ? (
+          <ChatLanding T={T} onPick={(prompt) => send(prompt)} />
+        ) : (
+          <div
+            ref={scrollRef}
+            style={{
+              flex: 1,
+              overflowY: "auto",
+              padding: "28px 36px",
+              display: "flex",
+              flexDirection: "column",
+              gap: 22,
+            }}
+          >
+            {activeThread.messages.map((m) => (
+              <Message key={m.id} message={m} T={T} />
+            ))}
+            {busy && <TypingDots T={T} status={busyStatus} />}
+          </div>
+        )}
+
+        <div style={{ borderTop: `1px solid ${T.line}`, padding: "16px 24px", background: T.bg }}>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              send(input);
+            }}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "5px 5px 5px 16px",
+              background: T.panel,
+              borderRadius: T.rLg,
+              border: `1px solid ${T.line}`,
+            }}
+          >
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder={busy ? "Thinking…" : "Ask anything — set a budget, plan savings, find unused subscriptions…"}
+              disabled={busy}
+              style={{
+                flex: 1,
+                padding: "10px 0",
+                background: "transparent",
+                border: "none",
+                color: T.text,
+                fontSize: 13.5,
+                fontFamily: T.sans,
+                outline: "none",
+              }}
+            />
+            <button
+              type="submit"
+              disabled={busy || !input.trim()}
+              style={{
+                padding: "9px 16px",
+                borderRadius: T.rMd,
+                border: "none",
+                cursor: input.trim() && !busy ? "pointer" : "not-allowed",
+                background: input.trim() && !busy ? T.accent : T.panelAlt,
+                color: input.trim() && !busy ? "#fff" : T.dim,
+                fontSize: 12.5,
+                fontWeight: 700,
+                fontFamily: T.sans,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+              }}
+            >
+              Send <span style={{ fontFamily: T.mono, fontSize: 11 }}>↵</span>
+            </button>
+          </form>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginTop: 9,
+              fontSize: 10.5,
+              color: T.dim,
+              fontFamily: T.mono,
+              letterSpacing: 0.3,
+            }}
+          >
+            <span>
+              ↵ send · ⇧↵ newline · <span style={{ color: T.muted }}>⌘K</span> spotlight
+            </span>
+            <span>connected to {provider.name} · keys never leave this Mac</span>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ChatLanding({ T, onPick }: { T: InkTheme; onPick: (prompt: string) => void }) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "40px 36px",
+        overflowY: "auto",
+      }}
+    >
+      <div
+        style={{
+          width: 64,
+          height: 64,
+          borderRadius: 16,
+          background: T.accent,
+          color: "#fff",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 26,
+          fontWeight: 800,
+          fontFamily: T.sans,
+          marginBottom: 18,
+        }}
+      >
+        X
+      </div>
+      <div
+        style={{
+          fontSize: 30,
+          fontFamily: T.serif,
+          color: T.text,
+          letterSpacing: -1,
+          marginBottom: 8,
+          textAlign: "center",
+          lineHeight: 1.1,
+        }}
+      >
+        What can Xarji do for you?
+      </div>
+      <div
+        style={{
+          fontSize: 13.5,
+          color: T.muted,
+          fontFamily: T.sans,
+          marginBottom: 30,
+          textAlign: "center",
+          maxWidth: 460,
+          lineHeight: 1.55,
+        }}
+      >
+        Pick a starter or type your own. Tip: press{" "}
+        <span
+          style={{
+            fontFamily: T.mono,
+            fontSize: 11.5,
+            padding: "2px 7px",
+            background: T.panelAlt,
+            borderRadius: 4,
+            color: T.text,
+          }}
+        >
+          ⌘K
+        </span>{" "}
+        from any screen to ask without leaving it.
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+          gap: 10,
+          width: "100%",
+          maxWidth: 720,
+        }}
+      >
+        {SUGGESTIONS.map((s) => (
+          <button
+            key={s.label}
+            onClick={() => onPick(s.prompt)}
+            style={{
+              textAlign: "left",
+              padding: "14px 16px",
+              borderRadius: T.rMd,
+              background: T.panel,
+              border: `1px solid ${T.line}`,
+              color: T.text,
+              cursor: "pointer",
+              fontFamily: T.sans,
+              transition: "all .15s",
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.borderColor = T.accent + "55";
+              (e.currentTarget as HTMLButtonElement).style.background = T.panelAlt;
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.borderColor = T.line;
+              (e.currentTarget as HTMLButtonElement).style.background = T.panel;
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 9, marginBottom: 5 }}>
+              <span
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: 6,
+                  background: T.accentSoft,
+                  color: T.accent,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 11,
+                  fontFamily: T.mono,
+                }}
+              >
+                {s.icon}
+              </span>
+              <div style={{ fontSize: 12.5, fontWeight: 700, color: T.text }}>{s.label}</div>
+            </div>
+            <div style={{ fontSize: 11.5, color: T.muted, lineHeight: 1.45 }}>{s.prompt}</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Message({ message, T }: { message: AIMessage; T: InkTheme }) {
+  if (message.role === "user") {
+    return (
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <div
+          style={{
+            maxWidth: "72%",
+            padding: "12px 18px",
+            background: T.accent,
+            color: "#fff",
+            borderRadius: "18px 18px 4px 18px",
+            fontSize: 14,
+            lineHeight: 1.55,
+            fontFamily: T.sans,
+            fontWeight: 500,
+          }}
+        >
+          {message.blocks.map((b, i) => (
+            <div key={i}>{b.kind === "text" ? b.text : ""}</div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", gap: 14 }}>
+      <div
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 10,
+          background: T.accent,
+          color: "#fff",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 12,
+          fontWeight: 800,
+          fontFamily: T.sans,
+          flexShrink: 0,
+        }}
+      >
+        X
+      </div>
+      <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 12 }}>
+        {message.blocks.map((b, i) => (
+          <Block key={i} block={b} T={T} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Block({ block, T }: { block: AIBlock; T: InkTheme }) {
+  if (block.kind === "text") {
+    const parts = block.text.split(/(\*\*[^*]+\*\*|`[^`]+`)/g);
+    return (
+      <div
+        style={{ fontSize: 14, lineHeight: 1.6, color: T.text, fontFamily: T.sans, maxWidth: 720 }}
+      >
+        {parts.map((p, i) => {
+          if (p.startsWith("**"))
+            return (
+              <strong key={i} style={{ fontWeight: 700, color: T.text }}>
+                {p.slice(2, -2)}
+              </strong>
+            );
+          if (p.startsWith("`"))
+            return (
+              <code
+                key={i}
+                style={{
+                  fontFamily: T.mono,
+                  fontSize: 12.5,
+                  padding: "2px 6px",
+                  background: T.panelAlt,
+                  borderRadius: 5,
+                  color: T.accent,
+                }}
+              >
+                {p.slice(1, -1)}
+              </code>
+            );
+          return <span key={i}>{p}</span>;
+        })}
+      </div>
+    );
+  }
+  if (block.kind === "tool") return <ToolCard tool={block} T={T} />;
+  if (block.kind === "plan") return <SavingsPlanCard plan={block} T={T} />;
+  if (block.kind === "budget") return <BudgetCard budget={block} T={T} />;
+  if (block.kind === "category") return <CategoryCard cat={block} T={T} />;
+  return null;
+}
+
+function ToolCard({ tool, T }: { tool: AIToolBlock; T: InkTheme }) {
+  const hasBody = !!tool.body && tool.body.trim().length > 0;
+  return (
+    <div
+      style={{
+        padding: hasBody ? "14px 16px" : "10px 14px",
+        background: T.panelAlt,
+        borderRadius: T.rMd,
+        border: `1px solid ${T.line}`,
+        maxWidth: 720,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          marginBottom: hasBody ? 8 : 0,
+        }}
+      >
+        <span
+          style={{
+            width: 22,
+            height: 22,
+            borderRadius: 6,
+            background: "rgba(75,217,162,0.15)",
+            color: T.green,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 11,
+            fontWeight: 800,
+            fontFamily: T.mono,
+          }}
+        >
+          ✓
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            color: T.dim,
+            fontFamily: T.mono,
+            letterSpacing: 0.4,
+            textTransform: "uppercase",
+          }}
+        >
+          tool call
+        </span>
+        <span style={{ fontSize: 12.5, color: T.text, fontFamily: T.mono, fontWeight: 700 }}>
+          {tool.name}
+        </span>
+        <span style={{ marginLeft: "auto", fontSize: 10.5, color: T.dim, fontFamily: T.mono }}>
+          {tool.duration}
+        </span>
+      </div>
+      {hasBody && (
+        <div
+          style={{
+            fontSize: 12,
+            color: T.muted,
+            fontFamily: T.mono,
+            lineHeight: 1.55,
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          {tool.body}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CategoryCard({ cat, T }: { cat: AICategoryBlock; T: InkTheme }) {
+  return (
+    <div
+      style={{
+        padding: "18px 20px",
+        background: T.panel,
+        borderRadius: T.rMd,
+        border: `1px solid ${T.accent}33`,
+        maxWidth: 540,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 12 }}>
+        <div
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 10,
+            background: cat.color,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 16,
+            color: "#fff",
+          }}
+        >
+          {cat.glyph}
+        </div>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 700, color: T.text, fontFamily: T.sans }}>
+            {cat.name}
+          </div>
+          <div style={{ fontSize: 11, color: T.muted, fontFamily: T.mono }}>
+            {cat.matched} transactions matched · ₾{cat.total} total
+          </div>
+        </div>
+        <span
+          style={{
+            marginLeft: "auto",
+            padding: "4px 10px",
+            borderRadius: 999,
+            background: "rgba(75,217,162,0.14)",
+            color: T.green,
+            fontSize: 10,
+            fontWeight: 800,
+            letterSpacing: 0.5,
+            textTransform: "uppercase",
+            fontFamily: T.sans,
+          }}
+        >
+          created
+        </span>
+      </div>
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        {cat.merchants.map((m) => (
+          <span
+            key={m}
+            style={{
+              padding: "5px 10px",
+              borderRadius: 6,
+              background: T.panelAlt,
+              fontSize: 11,
+              color: T.muted,
+              fontFamily: T.mono,
+            }}
+          >
+            {m}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BudgetCard({ budget, T }: { budget: AIBudgetBlock; T: InkTheme }) {
+  const pct = Math.min(100, (budget.spent / budget.limit) * 100);
+  return (
+    <div
+      style={{
+        padding: "18px 20px",
+        background: T.panel,
+        borderRadius: T.rMd,
+        border: `1px solid ${T.accent}33`,
+        maxWidth: 540,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: 10 }}>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 700, color: T.text, fontFamily: T.sans }}>
+            Budget · {budget.category}
+          </div>
+          <div style={{ fontSize: 11, color: T.muted, fontFamily: T.mono, marginTop: 2 }}>
+            monthly cap · warns at {budget.warnAt}%
+          </div>
+        </div>
+        <div
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            color: T.text,
+            fontFamily: T.sans,
+            fontVariantNumeric: "tabular-nums",
+            letterSpacing: -0.6,
+          }}
+        >
+          ₾{budget.limit}
+        </div>
+      </div>
+      <div
+        style={{
+          height: 8,
+          borderRadius: 4,
+          background: T.panelAlt,
+          overflow: "hidden",
+          marginBottom: 6,
+        }}
+      >
+        <div
+          style={{
+            height: "100%",
+            width: pct + "%",
+            background: pct > budget.warnAt ? T.accent : T.green,
+            borderRadius: 4,
+          }}
+        />
+      </div>
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 11, color: T.muted, fontFamily: T.mono }}>
+        <span>
+          ₾{budget.spent} spent · {Math.round(pct)}%
+        </span>
+        <span>₾{budget.limit - budget.spent} remaining</span>
+      </div>
+    </div>
+  );
+}
+
+function SavingsPlanCard({ plan, T }: { plan: AIPlanBlock; T: InkTheme }) {
+  return (
+    <div
+      style={{
+        padding: "20px 22px",
+        background: T.panel,
+        borderRadius: T.rMd,
+        border: `1px solid ${T.accent}33`,
+        maxWidth: 600,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
+        <div
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 10,
+            background: T.accentSoft,
+            color: T.accent,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 18,
+          }}
+        >
+          ✦
+        </div>
+        <div style={{ flex: 1 }}>
+          <div
+            style={{
+              fontSize: 11,
+              color: T.dim,
+              fontFamily: T.mono,
+              letterSpacing: 0.6,
+              textTransform: "uppercase",
+            }}
+          >
+            savings plan · drafted
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700, color: T.text, fontFamily: T.sans, marginTop: 2 }}>
+            {plan.goal}
+          </div>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <div
+            style={{
+              fontSize: 22,
+              fontWeight: 700,
+              color: T.accent,
+              fontFamily: T.sans,
+              letterSpacing: -0.6,
+            }}
+          >
+            ${plan.target}
+          </div>
+          <div style={{ fontSize: 10, color: T.muted, fontFamily: T.mono }}>by {plan.deadline}</div>
+        </div>
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: 10,
+          marginBottom: 14,
+        }}
+      >
+        {plan.steps.map((s, i) => (
+          <div key={i} style={{ padding: 12, background: T.panelAlt, borderRadius: 10 }}>
+            <div
+              style={{
+                fontSize: 10,
+                color: T.dim,
+                fontFamily: T.mono,
+                letterSpacing: 0.4,
+                textTransform: "uppercase",
+              }}
+            >
+              {s.month}
+            </div>
+            <div
+              style={{
+                fontSize: 17,
+                fontWeight: 700,
+                color: T.text,
+                fontFamily: T.sans,
+                marginTop: 4,
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              ₾{s.amount}
+            </div>
+            <div style={{ fontSize: 11, color: T.muted, fontFamily: T.sans, marginTop: 4, lineHeight: 1.4 }}>
+              {s.note}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ display: "flex", gap: 8 }}>
+        <button
+          style={{
+            padding: "9px 14px",
+            borderRadius: 8,
+            border: "none",
+            background: T.accent,
+            color: "#fff",
+            fontSize: 12,
+            fontWeight: 700,
+            fontFamily: T.sans,
+            cursor: "pointer",
+          }}
+        >
+          Accept plan
+        </button>
+        <button
+          style={{
+            padding: "9px 14px",
+            borderRadius: 8,
+            border: `1px solid ${T.line}`,
+            background: "transparent",
+            color: T.text,
+            fontSize: 12,
+            fontWeight: 600,
+            fontFamily: T.sans,
+            cursor: "pointer",
+          }}
+        >
+          Tweak amounts
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Generic verbs the indicator cycles through when nothing more specific
+// is happening (i.e. the model is silently thinking with no tool call
+// and no streaming text yet). Tool-specific text from the orchestrator
+// pre-empts this list.
+const IDLE_THINKING_VERBS = [
+  "Thinking…",
+  "Working through it…",
+  "Connecting dots…",
+  "Pondering…",
+  "Crunching numbers…",
+  "Looking it up…",
+  "Reading between the lines…",
+  "Following the thread…",
+];
+
+function TypingDots({ T, status }: { T: InkTheme; status: string }) {
+  // When the orchestrator hasn't pushed a context-aware status in a
+  // while, rotate through a few generic verbs so the indicator feels
+  // alive (Claude-Code-style). The cycle resets every time the
+  // orchestrator emits a fresh status — so a tool call instantly takes
+  // priority over the rotation.
+  const [displayed, setDisplayed] = useState(status);
+  const idleStartRef = useRef<number>(Date.now());
+
+  useEffect(() => {
+    setDisplayed(status);
+    idleStartRef.current = Date.now();
+    const id = setInterval(() => {
+      // Only rotate while the status is one of the generic "thinking"
+      // strings — anything tool-specific stays put.
+      const elapsed = Date.now() - idleStartRef.current;
+      const idx = Math.floor(elapsed / 1800) % IDLE_THINKING_VERBS.length;
+      const next = IDLE_THINKING_VERBS[idx];
+      // Don't overwrite a tool-specific status that arrived after the
+      // initial mount.
+      setDisplayed((prev) =>
+        IDLE_THINKING_VERBS.includes(prev) || prev === status ? next : prev
+      );
+    }, 1800);
+    return () => clearInterval(id);
+  }, [status]);
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+      <div
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 10,
+          background: T.accent,
+          color: "#fff",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 12,
+          fontWeight: 800,
+          fontFamily: T.sans,
+          flexShrink: 0,
+        }}
+      >
+        X
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "10px 16px",
+          background: T.panel,
+          borderRadius: T.rMd,
+        }}
+      >
+        <div style={{ display: "flex", gap: 4 }}>
+          {[0, 1, 2].map((i) => (
+            <span
+              key={i}
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: 3,
+                background: T.muted,
+                opacity: 0.6,
+                animation: `xj-bounce 1s ${i * 0.15}s infinite ease-in-out`,
+              }}
+            />
+          ))}
+        </div>
+        <span
+          style={{
+            fontSize: 12.5,
+            color: T.muted,
+            fontFamily: T.sans,
+            fontWeight: 500,
+            letterSpacing: 0.1,
+          }}
+        >
+          {displayed}
+        </span>
+        <style>{`@keyframes xj-bounce { 0%,100% { transform: translateY(0); opacity: 0.4 } 50% { transform: translateY(-3px); opacity: 1 } }`}</style>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/AssistantChat.tsx
+++ b/client/src/components/AssistantChat.tsx
@@ -49,6 +49,11 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
   const [activeId, setActiveIdState] = useState<string | null>(loadActiveThreadId);
   const [busy, setBusy] = useState(false);
   const [busyStatus, setBusyStatus] = useState<string>("Thinking…");
+  // Which thread the in-flight run originated from. Drives whether the
+  // typing indicator shows up at all when the user is viewing a
+  // different thread — without this, switching to an idle conversation
+  // shows a phantom "Thinking…" pill that belongs to a sibling thread.
+  const [busyThreadId, setBusyThreadId] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -127,12 +132,22 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
   };
 
   const runAgentForActive = (text: string) => {
+    // Capture the originating thread id at send time so streamed
+    // events route to that conversation even if the user switches
+    // threads mid-response. Without this, every event handler called
+    // `loadActiveThreadId()` and would have leaked the in-flight
+    // response into whichever thread happened to be active when the
+    // delta arrived. Same fix applies to the finalize step that
+    // clears `streaming`.
+    const originThreadId = loadActiveThreadId();
     setBusy(true);
+    setBusyThreadId(originThreadId);
     setBusyStatus("Thinking…");
+
     const handle = (event: AssistantEvent) => {
-      const id = loadActiveThreadId();
+      if (!originThreadId) return;
       const list = loadThreads();
-      const idx = list.findIndex((t) => t.id === id);
+      const idx = list.findIndex((t) => t.id === originThreadId);
       if (idx === -1) return;
       const t = list[idx];
       let assistant = t.messages[t.messages.length - 1];
@@ -159,7 +174,13 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
       } else if (event.type === "block") {
         assistant.blocks.push(event.block);
       } else if (event.type === "status") {
-        setBusyStatus(event.text);
+        // Status only updates the loading-indicator pill which only
+        // shows when the *current* active thread is busy, so reading
+        // setBusyStatus from any in-flight run is fine — but only if
+        // the user is still looking at the thread that started it.
+        if (loadActiveThreadId() === originThreadId) {
+          setBusyStatus(event.text);
+        }
         return;
       }
 
@@ -177,16 +198,18 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
         });
       })
       .finally(() => {
-        const id = loadActiveThreadId();
-        const list = loadThreads();
-        const idx = list.findIndex((t) => t.id === id);
-        if (idx !== -1) {
-          const last = list[idx].messages[list[idx].messages.length - 1];
-          if (last) delete last.streaming;
-          saveThreads(list);
-          setThreads(list.slice());
+        if (originThreadId) {
+          const list = loadThreads();
+          const idx = list.findIndex((t) => t.id === originThreadId);
+          if (idx !== -1) {
+            const last = list[idx].messages[list[idx].messages.length - 1];
+            if (last) delete last.streaming;
+            saveThreads(list);
+            setThreads(list.slice());
+          }
         }
         setBusy(false);
+        setBusyThreadId(null);
       });
   };
 
@@ -586,7 +609,7 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
             {activeThread.messages.map((m) => (
               <Message key={m.id} message={m} T={T} />
             ))}
-            {busy && <TypingDots T={T} status={busyStatus} />}
+            {busy && busyThreadId === activeId && <TypingDots T={T} status={busyStatus} />}
           </div>
         )}
 

--- a/client/src/components/AssistantChat.tsx
+++ b/client/src/components/AssistantChat.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTheme, type InkTheme } from "../ink/theme";
 import { LiveDot } from "../ink/primitives";
-import { getProvider, type AIConfig } from "../lib/aiConfig";
+import { deleteProviderKey, getProvider, type AIConfig } from "../lib/aiConfig";
 import {
   createThread,
   deleteThread,
@@ -559,11 +559,16 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
                 }}
               >
                 <button
-                  onClick={() => {
+                  onClick={async () => {
                     setMenuOpen(false);
-                    if (window.confirm("Disconnect AI? Your key will be removed from this device.")) {
-                      onClear();
+                    if (!window.confirm(`Disconnect ${provider.name}? The key will be removed from this Mac.`)) return;
+                    try {
+                      await deleteProviderKey(config.provider);
+                    } catch (err) {
+                      window.alert(err instanceof Error ? err.message : String(err));
+                      return;
                     }
+                    onClear();
                   }}
                   style={{
                     width: "100%",

--- a/client/src/components/AssistantOnboarding.tsx
+++ b/client/src/components/AssistantOnboarding.tsx
@@ -1,0 +1,308 @@
+import { useState } from "react";
+import { useTheme } from "../ink/theme";
+import { Card, CardLabel, Pill, PageHeader } from "../ink/primitives";
+import { AI_PROVIDERS, getProvider, type AIConfig, type AIProviderId } from "../lib/aiConfig";
+
+export function AssistantOnboarding({ onSave }: { onSave: (cfg: AIConfig) => void }) {
+  const T = useTheme();
+  const [provider, setProvider] = useState<AIProviderId>("anthropic");
+  const [apiKey, setApiKey] = useState("");
+  const [revealed, setRevealed] = useState(false);
+
+  const p = getProvider(provider);
+  const validKey = apiKey.trim().startsWith(p.keyPrefix) && apiKey.trim().length >= 20;
+
+  const handleSave = () => {
+    if (!validKey) return;
+    onSave({ provider, apiKey: apiKey.trim(), model: p.defaultModel });
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
+      <PageHeader
+        eyebrow="Agentic assistant · local · private"
+        title="Meet Xarji AI"
+        ranges={null}
+        rightSlot={
+          <Pill bg={T.accentSoft} color={T.accent}>
+            setup needed
+          </Pill>
+        }
+      />
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1.1fr 0.9fr",
+          gap: T.density.gap,
+          alignItems: "stretch",
+          minHeight: 0,
+        }}
+      >
+        <Card pad="36px 38px" glow style={{ display: "flex", flexDirection: "column", gap: 26 }}>
+          <div>
+            <div
+              style={{
+                fontSize: 11,
+                color: T.muted,
+                fontFamily: T.mono,
+                letterSpacing: 1.5,
+                textTransform: "uppercase",
+              }}
+            >
+              What it does
+            </div>
+            <div
+              style={{
+                fontSize: 38,
+                fontFamily: T.serif,
+                color: T.text,
+                letterSpacing: -1.4,
+                lineHeight: 1.05,
+                marginTop: 10,
+                fontWeight: 400,
+              }}
+            >
+              Talk to your money.
+              <br />
+              <span style={{ fontStyle: "italic", color: T.accent }}>Xarji listens.</span>
+            </div>
+            <div
+              style={{
+                fontSize: 14.5,
+                color: T.muted,
+                lineHeight: 1.55,
+                marginTop: 18,
+                maxWidth: 480,
+                fontFamily: T.sans,
+              }}
+            >
+              An assistant that can actually{" "}
+              <em style={{ color: T.text, fontStyle: "normal", fontWeight: 600 }}>do things</em> in
+              your dashboard — not just chat. Create categories, set budgets, build filters, draft
+              savings plans. It runs locally; your bank data never leaves this machine.
+            </div>
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+            {[
+              { g: "◐", t: "Categorize", d: "Create, merge, or auto-assign categories from natural language." },
+              { g: "◆", t: "Budget", d: "Set monthly limits per category with smart thresholds." },
+              { g: "≡", t: "Filter & query", d: 'Find any transaction with a sentence — "transit over ₾20 last week".' },
+              { g: "✦", t: "Plan & save", d: "Draft savings plans for goals: a Honda, a vacation, an emergency fund." },
+            ].map((c) => (
+              <div
+                key={c.t}
+                style={{
+                  padding: "16px 18px",
+                  background: T.panelAlt,
+                  borderRadius: T.rMd,
+                  border: `1px solid ${T.line}`,
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
+                  <span
+                    style={{
+                      width: 24,
+                      height: 24,
+                      borderRadius: 7,
+                      background: T.accentSoft,
+                      color: T.accent,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontSize: 12,
+                      fontFamily: T.mono,
+                    }}
+                  >
+                    {c.g}
+                  </span>
+                  <div style={{ fontSize: 13.5, fontWeight: 700, color: T.text, fontFamily: T.sans }}>
+                    {c.t}
+                  </div>
+                </div>
+                <div style={{ fontSize: 12, color: T.muted, lineHeight: 1.5, fontFamily: T.sans }}>
+                  {c.d}
+                </div>
+              </div>
+            ))}
+          </div>
+
+        </Card>
+
+        <Card
+          pad="32px 32px"
+          style={{ display: "flex", flexDirection: "column", gap: 22, justifyContent: "space-between" }}
+        >
+          <div>
+            <CardLabel>Step 1 · Pick your provider</CardLabel>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10, marginTop: 12 }}>
+              {AI_PROVIDERS.map((pp) => {
+                const active = pp.id === provider;
+                return (
+                  <button
+                    key={pp.id}
+                    onClick={() => setProvider(pp.id)}
+                    style={{
+                      padding: "18px 16px",
+                      borderRadius: T.rMd,
+                      cursor: "pointer",
+                      textAlign: "left",
+                      background: active ? T.panelAlt : "transparent",
+                      border: `1px solid ${active ? T.accent + "55" : T.line}`,
+                      transition: "all .15s ease",
+                      position: "relative",
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
+                      <div
+                        style={{
+                          width: 28,
+                          height: 28,
+                          borderRadius: 8,
+                          background: pp.color,
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          fontSize: 13,
+                          fontWeight: 800,
+                          color: "#fff",
+                          fontFamily: T.sans,
+                        }}
+                      >
+                        {pp.name.charAt(0)}
+                      </div>
+                      <div>
+                        <div style={{ fontSize: 13.5, fontWeight: 700, color: T.text, fontFamily: T.sans }}>
+                          {pp.name}
+                        </div>
+                        <div style={{ fontSize: 10, color: T.dim, fontFamily: T.mono }}>by {pp.by}</div>
+                      </div>
+                      {active && (
+                        <span
+                          style={{
+                            marginLeft: "auto",
+                            width: 16,
+                            height: 16,
+                            borderRadius: 8,
+                            background: T.accent,
+                            color: "#fff",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            fontSize: 9,
+                            fontWeight: 800,
+                          }}
+                        >
+                          ✓
+                        </span>
+                      )}
+                    </div>
+                    <div style={{ fontSize: 10.5, color: T.muted, fontFamily: T.mono }}>
+                      default · {pp.defaultModel}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <CardLabel>Step 2 · Paste your API key</CardLabel>
+            <div style={{ position: "relative", marginTop: 10 }}>
+              <input
+                type={revealed ? "text" : "password"}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={p.keyPrefix + "••••••••••••••••••••"}
+                autoComplete="off"
+                style={{
+                  width: "100%",
+                  padding: "14px 64px 14px 16px",
+                  borderRadius: T.rMd,
+                  background: T.panelAlt,
+                  border: `1px solid ${apiKey && !validKey ? T.accent + "55" : T.line}`,
+                  color: T.text,
+                  fontSize: 13,
+                  fontFamily: T.mono,
+                  letterSpacing: 0.4,
+                  outline: "none",
+                }}
+              />
+              <button
+                onClick={() => setRevealed((r) => !r)}
+                style={{
+                  position: "absolute",
+                  right: 10,
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  padding: "5px 10px",
+                  fontSize: 10,
+                  fontFamily: T.mono,
+                  fontWeight: 700,
+                  letterSpacing: 0.5,
+                  textTransform: "uppercase",
+                  background: "transparent",
+                  border: `1px solid ${T.line}`,
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  color: T.muted,
+                }}
+              >
+                {revealed ? "hide" : "show"}
+              </button>
+            </div>
+            <div
+              style={{
+                fontSize: 11,
+                color: T.muted,
+                marginTop: 8,
+                fontFamily: T.sans,
+                lineHeight: 1.5,
+              }}
+            >
+              {p.keyHint} · Generate one at{" "}
+              <span style={{ color: T.accent, fontFamily: T.mono }}>{p.docs}</span>
+            </div>
+          </div>
+
+          <div>
+            <button
+              onClick={handleSave}
+              disabled={!validKey}
+              style={{
+                width: "100%",
+                padding: "14px 18px",
+                borderRadius: T.rMd,
+                border: "none",
+                cursor: validKey ? "pointer" : "not-allowed",
+                background: validKey ? T.accent : T.panelAlt,
+                color: validKey ? "#fff" : T.dim,
+                fontSize: 14,
+                fontWeight: 700,
+                fontFamily: T.sans,
+                letterSpacing: -0.1,
+                transition: "all .15s ease",
+              }}
+            >
+              {validKey ? `Connect ${p.name} →` : "Paste a valid key to continue"}
+            </button>
+            <div
+              style={{
+                fontSize: 10.5,
+                color: T.dim,
+                marginTop: 10,
+                textAlign: "center",
+                fontFamily: T.sans,
+                lineHeight: 1.5,
+              }}
+            >
+              You can change provider or revoke the key any time in{" "}
+              <span style={{ color: T.muted, fontWeight: 600 }}>Manage → AI Assistant</span>.
+            </div>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/AssistantOnboarding.tsx
+++ b/client/src/components/AssistantOnboarding.tsx
@@ -1,20 +1,41 @@
 import { useState } from "react";
 import { useTheme } from "../ink/theme";
 import { Card, CardLabel, Pill, PageHeader } from "../ink/primitives";
-import { AI_PROVIDERS, getProvider, type AIConfig, type AIProviderId } from "../lib/aiConfig";
+import {
+  AI_PROVIDERS,
+  getProvider,
+  saveAIConfig,
+  saveProviderKey,
+  type AIProviderId,
+} from "../lib/aiConfig";
 
-export function AssistantOnboarding({ onSave }: { onSave: (cfg: AIConfig) => void }) {
+export function AssistantOnboarding({ onSaved }: { onSaved: () => void }) {
   const T = useTheme();
   const [provider, setProvider] = useState<AIProviderId>("anthropic");
   const [apiKey, setApiKey] = useState("");
   const [revealed, setRevealed] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const p = getProvider(provider);
   const validKey = apiKey.trim().startsWith(p.keyPrefix) && apiKey.trim().length >= 20;
 
-  const handleSave = () => {
-    if (!validKey) return;
-    onSave({ provider, apiKey: apiKey.trim(), model: p.defaultModel });
+  const handleSave = async () => {
+    if (!validKey || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      // Key goes straight to xarji-core via /api/ai/keys; never touches
+      // localStorage or the JS bundle context. Local AIConfig only
+      // remembers which provider and model the user picked.
+      await saveProviderKey(provider, apiKey.trim());
+      saveAIConfig({ provider, model: p.defaultModel });
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -269,13 +290,13 @@ export function AssistantOnboarding({ onSave }: { onSave: (cfg: AIConfig) => voi
           <div>
             <button
               onClick={handleSave}
-              disabled={!validKey}
+              disabled={!validKey || saving}
               style={{
                 width: "100%",
                 padding: "14px 18px",
                 borderRadius: T.rMd,
                 border: "none",
-                cursor: validKey ? "pointer" : "not-allowed",
+                cursor: validKey && !saving ? "pointer" : "not-allowed",
                 background: validKey ? T.accent : T.panelAlt,
                 color: validKey ? "#fff" : T.dim,
                 fontSize: 14,
@@ -283,10 +304,28 @@ export function AssistantOnboarding({ onSave }: { onSave: (cfg: AIConfig) => voi
                 fontFamily: T.sans,
                 letterSpacing: -0.1,
                 transition: "all .15s ease",
+                opacity: saving ? 0.7 : 1,
               }}
             >
-              {validKey ? `Connect ${p.name} →` : "Paste a valid key to continue"}
+              {saving
+                ? "Saving…"
+                : validKey
+                  ? `Connect ${p.name} →`
+                  : "Paste a valid key to continue"}
             </button>
+            {error && (
+              <div
+                style={{
+                  marginTop: 8,
+                  fontSize: 12,
+                  color: T.accent,
+                  fontFamily: T.sans,
+                  textAlign: "center",
+                }}
+              >
+                {error}
+              </div>
+            )}
             <div
               style={{
                 fontSize: 10.5,

--- a/client/src/components/CategoryPicker.tsx
+++ b/client/src/components/CategoryPicker.tsx
@@ -1,0 +1,190 @@
+// Inline dropdown that lets the user move a transaction's merchant
+// into a different category. Persists the choice via the
+// useMerchantOverrides hook (writes a row to InstantDB's
+// merchantCategoryOverrides table). The choice applies to *every*
+// transaction from that merchant — past and future — because the
+// override is per-merchant, not per-transaction.
+
+import { useEffect, useRef, useState } from "react";
+import { useTheme, type InkTheme } from "../ink/theme";
+import { DEFAULT_CATEGORIES, type InkCategory } from "../lib/utils";
+import { useMerchantOverrides } from "../hooks/useMerchantOverrides";
+
+export function CategoryPicker({
+  merchant,
+  current,
+  onClose,
+}: {
+  merchant: string;
+  current: InkCategory;
+  onClose: () => void;
+}) {
+  const T = useTheme();
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { byMerchant, setOverride, clearOverride } = useMerchantOverrides();
+  const [busy, setBusy] = useState(false);
+  const hasOverride = !!byMerchant.get(merchant.trim().toLowerCase());
+
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  const pick = async (cat: InkCategory) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await setOverride(merchant, cat.id);
+      onClose();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reset = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await clearOverride(merchant);
+      onClose();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: "absolute",
+        top: "calc(100% + 6px)",
+        left: 0,
+        zIndex: 100,
+        minWidth: 240,
+        background: T.panel,
+        border: `1px solid ${T.lineStrong}`,
+        borderRadius: 12,
+        boxShadow: "0 12px 30px rgba(0,0,0,0.4)",
+        padding: 8,
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+      }}
+    >
+      <div
+        style={{
+          padding: "6px 10px 4px",
+          fontSize: 10,
+          color: T.dim,
+          fontFamily: T.mono,
+          letterSpacing: 0.6,
+          textTransform: "uppercase",
+        }}
+      >
+        Move {merchant} to
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", maxHeight: 280, overflowY: "auto" }}>
+        {DEFAULT_CATEGORIES.map((cat) => (
+          <CategoryRow
+            key={cat.id}
+            T={T}
+            cat={cat}
+            active={cat.id === current.id}
+            onPick={pick}
+          />
+        ))}
+      </div>
+      {hasOverride && (
+        <button
+          onClick={reset}
+          disabled={busy}
+          style={{
+            marginTop: 6,
+            padding: "8px 10px",
+            background: "transparent",
+            border: `1px solid ${T.line}`,
+            borderRadius: 8,
+            color: T.muted,
+            fontSize: 11.5,
+            fontFamily: T.sans,
+            cursor: busy ? "not-allowed" : "pointer",
+            textAlign: "left",
+          }}
+        >
+          Clear override · use the auto category
+        </button>
+      )}
+    </div>
+  );
+}
+
+function CategoryRow({
+  T,
+  cat,
+  active,
+  onPick,
+}: {
+  T: InkTheme;
+  cat: InkCategory;
+  active: boolean;
+  onPick: (cat: InkCategory) => void;
+}) {
+  return (
+    <button
+      onClick={() => onPick(cat)}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "8px 10px",
+        background: active ? T.panelAlt : "transparent",
+        border: "none",
+        borderRadius: 8,
+        cursor: "pointer",
+        textAlign: "left",
+        color: T.text,
+        fontFamily: T.sans,
+      }}
+      onMouseEnter={(e) => {
+        if (!active) (e.currentTarget as HTMLButtonElement).style.background = T.panelAlt;
+      }}
+      onMouseLeave={(e) => {
+        if (!active) (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+      }}
+    >
+      <span
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: 5,
+          background: cat.color,
+          flexShrink: 0,
+        }}
+      />
+      <span style={{ flex: 1, fontSize: 13, fontWeight: active ? 700 : 500 }}>{cat.name}</span>
+      {active && (
+        <span
+          style={{
+            fontSize: 10,
+            color: T.muted,
+            fontFamily: T.mono,
+            letterSpacing: 0.4,
+            textTransform: "uppercase",
+          }}
+        >
+          current
+        </span>
+      )}
+    </button>
+  );
+}

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { Sidebar } from "../ink/Sidebar";
 import { TweaksPanel } from "../ink/TweaksPanel";
+import { SpotlightHost } from "./Spotlight";
 import {
   ThemeContext,
   TweaksContext,
@@ -117,6 +118,7 @@ function ConfiguredShell() {
         </main>
       </div>
       <TweaksPanel />
+      <SpotlightHost />
     </>
   );
 }

--- a/client/src/components/SettingsAISection.tsx
+++ b/client/src/components/SettingsAISection.tsx
@@ -1,0 +1,497 @@
+// "AI Assistant" card for the Manage screen. When no key is connected
+// it shows a primary "Set up assistant →" CTA that navigates to the
+// Assistant onboarding. When connected it shows the provider, model
+// picker, masked key, and a Replace / Disconnect path.
+
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTheme } from "../ink/theme";
+import { Card, CardTitle } from "../ink/primitives";
+import {
+  AI_PROVIDERS,
+  clearAIConfig,
+  getProvider,
+  loadAIConfig,
+  maskApiKey,
+  onAIConfigChange,
+  saveAIConfig,
+  type AIConfig,
+  type AIProviderId,
+} from "../lib/aiConfig";
+
+type Mode = "view" | "replace";
+
+export function SettingsAISection() {
+  const T = useTheme();
+  const navigate = useNavigate();
+  const [config, setConfig] = useState<AIConfig | null>(loadAIConfig);
+  const [mode, setMode] = useState<Mode>("view");
+  const [editProvider, setEditProvider] = useState<AIProviderId>("anthropic");
+  const [editKey, setEditKey] = useState("");
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => onAIConfigChange(() => setConfig(loadAIConfig())), []);
+
+  const provider = useMemo(() => (config ? getProvider(config.provider) : null), [config]);
+  const editProviderObj = getProvider(editProvider);
+  const validKey =
+    editKey.trim().startsWith(editProviderObj.keyPrefix) && editKey.trim().length >= 20;
+
+  const startReplace = () => {
+    setMode("replace");
+    setEditProvider(config?.provider ?? "anthropic");
+    setEditKey("");
+    setRevealed(false);
+  };
+
+  const cancelReplace = () => {
+    setMode("view");
+    setEditKey("");
+  };
+
+  const saveReplace = () => {
+    if (!validKey) return;
+    saveAIConfig({
+      provider: editProvider,
+      apiKey: editKey.trim(),
+      model: editProviderObj.defaultModel,
+    });
+    setMode("view");
+  };
+
+  const updateModel = (model: string) => {
+    if (!config) return;
+    saveAIConfig({ ...config, model });
+  };
+
+  const disconnect = () => {
+    if (window.confirm("Disconnect AI? Your key will be removed from this device.")) {
+      clearAIConfig();
+      setMode("view");
+    }
+  };
+
+  return (
+    <Card pad="24px 26px">
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 16,
+          gap: 12,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 8,
+              background: T.accent,
+              color: "#fff",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 15,
+              fontWeight: 800,
+              fontFamily: T.sans,
+            }}
+          >
+            ✧
+          </div>
+          <div>
+            <CardTitle>AI Assistant</CardTitle>
+            <div style={{ fontSize: 12, color: T.muted, marginTop: 2, fontFamily: T.sans }}>
+              Provider, model, and API key. The key never leaves this device.
+            </div>
+          </div>
+        </div>
+        {config && (
+          <span
+            style={{
+              padding: "4px 10px",
+              borderRadius: 999,
+              background: "rgba(75,217,162,0.14)",
+              color: T.green,
+              fontSize: 10,
+              fontWeight: 800,
+              letterSpacing: 0.5,
+              textTransform: "uppercase",
+              fontFamily: T.sans,
+            }}
+          >
+            connected
+          </span>
+        )}
+      </div>
+
+      {!config && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 14,
+            padding: "16px 18px",
+            background: T.accentSoft,
+            border: `1px solid ${T.accent}33`,
+            borderRadius: T.rMd,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 12.5,
+              color: T.text,
+              fontFamily: T.sans,
+              flex: 1,
+              lineHeight: 1.5,
+            }}
+          >
+            Connect Claude or OpenAI to unlock the agentic chat. Plans, budgets, filters, and
+            categories — created from natural-language prompts.
+          </div>
+          <button
+            onClick={() => navigate("/assistant")}
+            style={{
+              padding: "10px 16px",
+              borderRadius: T.rMd,
+              border: "none",
+              background: T.accent,
+              color: "#fff",
+              fontSize: 12.5,
+              fontWeight: 700,
+              fontFamily: T.sans,
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+            }}
+          >
+            Set up assistant →
+          </button>
+        </div>
+      )}
+
+      {config && provider && mode === "view" && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 12,
+            }}
+          >
+            <ProviderTile provider={provider} active />
+            <div
+              style={{
+                padding: "16px 18px",
+                background: T.panelAlt,
+                borderRadius: T.rMd,
+                border: `1px solid ${T.line}`,
+                display: "flex",
+                flexDirection: "column",
+                gap: 10,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 10,
+                  color: T.dim,
+                  fontFamily: T.mono,
+                  letterSpacing: 0.6,
+                  textTransform: "uppercase",
+                }}
+              >
+                Model
+              </div>
+              <select
+                value={config.model}
+                onChange={(e) => updateModel(e.target.value)}
+                style={{
+                  background: T.panel,
+                  border: `1px solid ${T.line}`,
+                  color: T.text,
+                  fontSize: 13,
+                  fontFamily: T.mono,
+                  padding: "9px 12px",
+                  borderRadius: 8,
+                  outline: "none",
+                  cursor: "pointer",
+                }}
+              >
+                {provider.models.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+              <div style={{ fontSize: 11, color: T.muted, fontFamily: T.sans, lineHeight: 1.4 }}>
+                Used for new conversations. Active threads keep their model.
+              </div>
+            </div>
+          </div>
+
+          <div
+            style={{
+              padding: "16px 18px",
+              background: T.panelAlt,
+              borderRadius: T.rMd,
+              border: `1px solid ${T.line}`,
+              display: "flex",
+              alignItems: "center",
+              gap: 14,
+              flexWrap: "wrap",
+            }}
+          >
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  fontSize: 10,
+                  color: T.dim,
+                  fontFamily: T.mono,
+                  letterSpacing: 0.6,
+                  textTransform: "uppercase",
+                }}
+              >
+                API key
+              </div>
+              <div
+                style={{
+                  fontSize: 14,
+                  color: T.text,
+                  fontFamily: T.mono,
+                  fontWeight: 600,
+                  marginTop: 4,
+                  letterSpacing: 0.4,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {maskApiKey(config.apiKey)}
+              </div>
+            </div>
+            <div style={{ display: "flex", gap: 6 }}>
+              <button
+                onClick={startReplace}
+                style={{
+                  padding: "9px 14px",
+                  borderRadius: 8,
+                  border: `1px solid ${T.line}`,
+                  background: "transparent",
+                  color: T.text,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  fontFamily: T.sans,
+                  cursor: "pointer",
+                }}
+              >
+                Replace
+              </button>
+              <button
+                onClick={disconnect}
+                style={{
+                  padding: "9px 14px",
+                  borderRadius: 8,
+                  border: `1px solid ${T.accent}55`,
+                  background: T.accentSoft,
+                  color: T.accent,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  fontFamily: T.sans,
+                  cursor: "pointer",
+                }}
+              >
+                Disconnect
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {config && mode === "replace" && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div
+            style={{
+              fontSize: 11,
+              color: T.dim,
+              fontFamily: T.mono,
+              letterSpacing: 0.6,
+              textTransform: "uppercase",
+            }}
+          >
+            Replace credentials
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+            {AI_PROVIDERS.map((pp) => (
+              <ProviderTile
+                key={pp.id}
+                provider={pp}
+                active={pp.id === editProvider}
+                onSelect={() => setEditProvider(pp.id)}
+              />
+            ))}
+          </div>
+          <div style={{ position: "relative" }}>
+            <input
+              type={revealed ? "text" : "password"}
+              value={editKey}
+              onChange={(e) => setEditKey(e.target.value)}
+              placeholder={editProviderObj.keyPrefix + "••••••••••••••••••••"}
+              autoComplete="off"
+              style={{
+                width: "100%",
+                padding: "12px 64px 12px 16px",
+                borderRadius: T.rMd,
+                background: T.panelAlt,
+                border: `1px solid ${editKey && !validKey ? T.accent + "55" : T.line}`,
+                color: T.text,
+                fontSize: 13,
+                fontFamily: T.mono,
+                letterSpacing: 0.4,
+                outline: "none",
+              }}
+            />
+            <button
+              onClick={() => setRevealed((r) => !r)}
+              style={{
+                position: "absolute",
+                right: 10,
+                top: "50%",
+                transform: "translateY(-50%)",
+                padding: "5px 10px",
+                fontSize: 10,
+                fontFamily: T.mono,
+                fontWeight: 700,
+                letterSpacing: 0.5,
+                textTransform: "uppercase",
+                background: "transparent",
+                border: `1px solid ${T.line}`,
+                borderRadius: 6,
+                cursor: "pointer",
+                color: T.muted,
+              }}
+            >
+              {revealed ? "hide" : "show"}
+            </button>
+          </div>
+          <div style={{ fontSize: 11, color: T.muted, fontFamily: T.sans, lineHeight: 1.5 }}>
+            {editProviderObj.keyHint} · Generate one at{" "}
+            <span style={{ color: T.accent, fontFamily: T.mono }}>{editProviderObj.docs}</span>
+          </div>
+          <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+            <button
+              onClick={cancelReplace}
+              style={{
+                padding: "9px 16px",
+                borderRadius: 8,
+                border: `1px solid ${T.line}`,
+                background: "transparent",
+                color: T.muted,
+                fontSize: 12,
+                fontWeight: 600,
+                fontFamily: T.sans,
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={saveReplace}
+              disabled={!validKey}
+              style={{
+                padding: "9px 16px",
+                borderRadius: 8,
+                border: "none",
+                background: validKey ? T.accent : T.panelAlt,
+                color: validKey ? "#fff" : T.dim,
+                fontSize: 12,
+                fontWeight: 700,
+                fontFamily: T.sans,
+                cursor: validKey ? "pointer" : "not-allowed",
+              }}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function ProviderTile({
+  provider,
+  active,
+  onSelect,
+}: {
+  provider: (typeof AI_PROVIDERS)[number];
+  active: boolean;
+  onSelect?: () => void;
+}) {
+  const T = useTheme();
+  const interactive = !!onSelect;
+  return (
+    <button
+      onClick={onSelect}
+      disabled={!interactive}
+      style={{
+        padding: "16px 18px",
+        borderRadius: T.rMd,
+        cursor: interactive ? "pointer" : "default",
+        textAlign: "left",
+        background: active ? T.panelAlt : "transparent",
+        border: `1px solid ${active ? T.accent + "55" : T.line}`,
+        transition: "all .15s ease",
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <div
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 8,
+            background: provider.color,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 13,
+            fontWeight: 800,
+            color: "#fff",
+            fontFamily: T.sans,
+          }}
+        >
+          {provider.name.charAt(0)}
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 13.5, fontWeight: 700, color: T.text, fontFamily: T.sans }}>
+            {provider.name}
+          </div>
+          <div style={{ fontSize: 10, color: T.dim, fontFamily: T.mono }}>by {provider.by}</div>
+        </div>
+        {active && interactive && (
+          <span
+            style={{
+              width: 16,
+              height: 16,
+              borderRadius: 8,
+              background: T.accent,
+              color: "#fff",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 9,
+              fontWeight: 800,
+            }}
+          >
+            ✓
+          </span>
+        )}
+      </div>
+      <div style={{ fontSize: 10.5, color: T.muted, fontFamily: T.mono }}>
+        default · {provider.defaultModel}
+      </div>
+    </button>
+  );
+}

--- a/client/src/components/SettingsAISection.tsx
+++ b/client/src/components/SettingsAISection.tsx
@@ -1,7 +1,9 @@
-// "AI Assistant" card for the Manage screen. When no key is connected
-// it shows a primary "Set up assistant →" CTA that navigates to the
-// Assistant onboarding. When connected it shows the provider, model
-// picker, masked key, and a Replace / Disconnect path.
+// "AI Assistant" card for the Manage screen. Shows status for each
+// provider (Anthropic / OpenAI), lets the user connect / replace /
+// disconnect each key independently, and exposes a model picker for
+// the active provider. Keys live on the service in
+// ~/.xarji/config.json — this card never sees the actual key value,
+// just the boolean "is configured" from /api/ai/keys.
 
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -9,54 +11,70 @@ import { useTheme } from "../ink/theme";
 import { Card, CardTitle } from "../ink/primitives";
 import {
   AI_PROVIDERS,
-  clearAIConfig,
+  deleteProviderKey,
   getProvider,
   loadAIConfig,
-  maskApiKey,
   onAIConfigChange,
   saveAIConfig,
+  saveProviderKey,
   type AIConfig,
   type AIProviderId,
 } from "../lib/aiConfig";
-
-type Mode = "view" | "replace";
+import { useAIKeyStatus } from "../hooks/useAIKeyStatus";
 
 export function SettingsAISection() {
   const T = useTheme();
   const navigate = useNavigate();
+  const { status, isLoading } = useAIKeyStatus();
   const [config, setConfig] = useState<AIConfig | null>(loadAIConfig);
-  const [mode, setMode] = useState<Mode>("view");
-  const [editProvider, setEditProvider] = useState<AIProviderId>("anthropic");
+  const [editingProvider, setEditingProvider] = useState<AIProviderId | null>(null);
   const [editKey, setEditKey] = useState("");
   const [revealed, setRevealed] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => onAIConfigChange(() => setConfig(loadAIConfig())), []);
 
-  const provider = useMemo(() => (config ? getProvider(config.provider) : null), [config]);
-  const editProviderObj = getProvider(editProvider);
-  const validKey =
-    editKey.trim().startsWith(editProviderObj.keyPrefix) && editKey.trim().length >= 20;
+  const activeProvider = useMemo(() => (config ? getProvider(config.provider) : null), [config]);
+  const connectedCount = (status.anthropic ? 1 : 0) + (status.openai ? 1 : 0);
 
-  const startReplace = () => {
-    setMode("replace");
-    setEditProvider(config?.provider ?? "anthropic");
+  const editingObj = editingProvider ? getProvider(editingProvider) : null;
+  const validEditKey = editingObj
+    ? editKey.trim().startsWith(editingObj.keyPrefix) && editKey.trim().length >= 20
+    : false;
+
+  const startEdit = (id: AIProviderId) => {
+    setEditingProvider(id);
     setEditKey("");
     setRevealed(false);
+    setError(null);
   };
 
-  const cancelReplace = () => {
-    setMode("view");
+  const cancelEdit = () => {
+    setEditingProvider(null);
     setEditKey("");
+    setError(null);
   };
 
-  const saveReplace = () => {
-    if (!validKey) return;
-    saveAIConfig({
-      provider: editProvider,
-      apiKey: editKey.trim(),
-      model: editProviderObj.defaultModel,
-    });
-    setMode("view");
+  const saveEdit = async () => {
+    if (!validEditKey || !editingProvider || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await saveProviderKey(editingProvider, editKey.trim());
+      // If this was the user's first key, snap the local active config
+      // to the provider they just connected.
+      if (!config || !status[config.provider]) {
+        const obj = getProvider(editingProvider);
+        saveAIConfig({ provider: editingProvider, model: obj.defaultModel });
+      }
+      setEditingProvider(null);
+      setEditKey("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
   };
 
   const updateModel = (model: string) => {
@@ -64,10 +82,20 @@ export function SettingsAISection() {
     saveAIConfig({ ...config, model });
   };
 
-  const disconnect = () => {
-    if (window.confirm("Disconnect AI? Your key will be removed from this device.")) {
-      clearAIConfig();
-      setMode("view");
+  const disconnect = async (id: AIProviderId) => {
+    if (!window.confirm(`Disconnect ${getProvider(id).name}? The key will be removed from this device.`)) {
+      return;
+    }
+    try {
+      await deleteProviderKey(id);
+      // If the active provider lost its key, drop the local pointer so
+      // the chat UI re-routes (or shows the onboarding gate).
+      if (config?.provider === id) {
+        saveAIConfig({ provider: id, model: getProvider(id).defaultModel });
+        setConfig(null);
+      }
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : String(err));
     }
   };
 
@@ -103,11 +131,11 @@ export function SettingsAISection() {
           <div>
             <CardTitle>AI Assistant</CardTitle>
             <div style={{ fontSize: 12, color: T.muted, marginTop: 2, fontFamily: T.sans }}>
-              Provider, model, and API key. The key never leaves this device.
+              Provider keys live on this Mac in <code style={{ fontFamily: T.mono }}>~/.xarji/config.json</code>. The browser never sees them.
             </div>
           </div>
         </div>
-        {config && (
+        {!isLoading && connectedCount > 0 && (
           <span
             style={{
               padding: "4px 10px",
@@ -121,12 +149,12 @@ export function SettingsAISection() {
               fontFamily: T.sans,
             }}
           >
-            connected
+            {connectedCount} of 2 connected
           </span>
         )}
       </div>
 
-      {!config && (
+      {!isLoading && connectedCount === 0 && (
         <div
           style={{
             display: "flex",
@@ -136,6 +164,7 @@ export function SettingsAISection() {
             background: T.accentSoft,
             border: `1px solid ${T.accent}33`,
             borderRadius: T.rMd,
+            marginBottom: 14,
           }}
         >
           <div
@@ -147,8 +176,8 @@ export function SettingsAISection() {
               lineHeight: 1.5,
             }}
           >
-            Connect Claude or OpenAI to unlock the agentic chat. Plans, budgets, filters, and
-            categories — created from natural-language prompts.
+            Connect Claude or OpenAI to unlock the agentic chat. Plans, summaries, transaction
+            search — created from natural-language prompts.
           </div>
           <button
             onClick={() => navigate("/assistant")}
@@ -170,328 +199,258 @@ export function SettingsAISection() {
         </div>
       )}
 
-      {config && provider && mode === "view" && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "1fr 1fr",
-              gap: 12,
-            }}
-          >
-            <ProviderTile provider={provider} active />
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {AI_PROVIDERS.map((pp) => {
+          const isConnected = status[pp.id];
+          const isEditing = editingProvider === pp.id;
+          return (
             <div
+              key={pp.id}
               style={{
-                padding: "16px 18px",
+                padding: "14px 16px",
                 background: T.panelAlt,
                 borderRadius: T.rMd,
                 border: `1px solid ${T.line}`,
                 display: "flex",
                 flexDirection: "column",
-                gap: 10,
+                gap: 12,
               }}
             >
-              <div
-                style={{
-                  fontSize: 10,
-                  color: T.dim,
-                  fontFamily: T.mono,
-                  letterSpacing: 0.6,
-                  textTransform: "uppercase",
-                }}
-              >
-                Model
+              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                <div
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: 8,
+                    background: pp.color,
+                    color: "#fff",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: 14,
+                    fontWeight: 800,
+                    fontFamily: T.sans,
+                  }}
+                >
+                  {pp.name.charAt(0)}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13.5, fontWeight: 700, color: T.text, fontFamily: T.sans }}>
+                    {pp.name} <span style={{ color: T.dim, fontWeight: 500, fontFamily: T.mono, fontSize: 11 }}>· by {pp.by}</span>
+                  </div>
+                  <div style={{ fontSize: 11, color: T.muted, fontFamily: T.mono, marginTop: 2 }}>
+                    {isConnected ? "Configured · key on disk" : "Not configured"}
+                  </div>
+                </div>
+                <div style={{ display: "flex", gap: 6 }}>
+                  {isConnected ? (
+                    <>
+                      <button
+                        onClick={() => startEdit(pp.id)}
+                        disabled={isEditing}
+                        style={{
+                          padding: "8px 12px",
+                          borderRadius: 8,
+                          border: `1px solid ${T.line}`,
+                          background: "transparent",
+                          color: T.text,
+                          fontSize: 12,
+                          fontWeight: 600,
+                          fontFamily: T.sans,
+                          cursor: isEditing ? "default" : "pointer",
+                          opacity: isEditing ? 0.5 : 1,
+                        }}
+                      >
+                        Replace
+                      </button>
+                      <button
+                        onClick={() => disconnect(pp.id)}
+                        style={{
+                          padding: "8px 12px",
+                          borderRadius: 8,
+                          border: `1px solid ${T.accent}55`,
+                          background: T.accentSoft,
+                          color: T.accent,
+                          fontSize: 12,
+                          fontWeight: 700,
+                          fontFamily: T.sans,
+                          cursor: "pointer",
+                        }}
+                      >
+                        Disconnect
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      onClick={() => startEdit(pp.id)}
+                      disabled={isEditing}
+                      style={{
+                        padding: "8px 14px",
+                        borderRadius: 8,
+                        border: "none",
+                        background: T.accent,
+                        color: "#fff",
+                        fontSize: 12,
+                        fontWeight: 700,
+                        fontFamily: T.sans,
+                        cursor: isEditing ? "default" : "pointer",
+                        opacity: isEditing ? 0.5 : 1,
+                      }}
+                    >
+                      Connect
+                    </button>
+                  )}
+                </div>
               </div>
-              <select
-                value={config.model}
-                onChange={(e) => updateModel(e.target.value)}
-                style={{
-                  background: T.panel,
-                  border: `1px solid ${T.line}`,
-                  color: T.text,
-                  fontSize: 13,
-                  fontFamily: T.mono,
-                  padding: "9px 12px",
-                  borderRadius: 8,
-                  outline: "none",
-                  cursor: "pointer",
-                }}
-              >
-                {provider.models.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </select>
-              <div style={{ fontSize: 11, color: T.muted, fontFamily: T.sans, lineHeight: 1.4 }}>
-                Used for new conversations. Active threads keep their model.
-              </div>
-            </div>
-          </div>
 
-          <div
-            style={{
-              padding: "16px 18px",
-              background: T.panelAlt,
-              borderRadius: T.rMd,
-              border: `1px solid ${T.line}`,
-              display: "flex",
-              alignItems: "center",
-              gap: 14,
-              flexWrap: "wrap",
-            }}
-          >
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div
-                style={{
-                  fontSize: 10,
-                  color: T.dim,
-                  fontFamily: T.mono,
-                  letterSpacing: 0.6,
-                  textTransform: "uppercase",
-                }}
-              >
-                API key
-              </div>
-              <div
-                style={{
-                  fontSize: 14,
-                  color: T.text,
-                  fontFamily: T.mono,
-                  fontWeight: 600,
-                  marginTop: 4,
-                  letterSpacing: 0.4,
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                }}
-              >
-                {maskApiKey(config.apiKey)}
-              </div>
+              {isEditing && editingObj && (
+                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                  <div style={{ position: "relative" }}>
+                    <input
+                      type={revealed ? "text" : "password"}
+                      value={editKey}
+                      onChange={(e) => setEditKey(e.target.value)}
+                      placeholder={editingObj.keyPrefix + "••••••••••••••••••••"}
+                      autoComplete="off"
+                      style={{
+                        width: "100%",
+                        padding: "10px 60px 10px 14px",
+                        borderRadius: T.rMd,
+                        background: T.panel,
+                        border: `1px solid ${editKey && !validEditKey ? T.accent + "55" : T.line}`,
+                        color: T.text,
+                        fontSize: 13,
+                        fontFamily: T.mono,
+                        letterSpacing: 0.4,
+                        outline: "none",
+                      }}
+                    />
+                    <button
+                      onClick={() => setRevealed((r) => !r)}
+                      style={{
+                        position: "absolute",
+                        right: 8,
+                        top: "50%",
+                        transform: "translateY(-50%)",
+                        padding: "4px 8px",
+                        fontSize: 9.5,
+                        fontFamily: T.mono,
+                        fontWeight: 700,
+                        letterSpacing: 0.5,
+                        textTransform: "uppercase",
+                        background: "transparent",
+                        border: `1px solid ${T.line}`,
+                        borderRadius: 5,
+                        cursor: "pointer",
+                        color: T.muted,
+                      }}
+                    >
+                      {revealed ? "hide" : "show"}
+                    </button>
+                  </div>
+                  <div style={{ fontSize: 11, color: T.muted, fontFamily: T.sans, lineHeight: 1.4 }}>
+                    {editingObj.keyHint} · Generate one at{" "}
+                    <span style={{ color: T.accent, fontFamily: T.mono }}>{editingObj.docs}</span>
+                  </div>
+                  {error && (
+                    <div style={{ fontSize: 11, color: T.accent, fontFamily: T.sans }}>{error}</div>
+                  )}
+                  <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+                    <button
+                      onClick={cancelEdit}
+                      style={{
+                        padding: "8px 14px",
+                        borderRadius: 8,
+                        border: `1px solid ${T.line}`,
+                        background: "transparent",
+                        color: T.muted,
+                        fontSize: 12,
+                        fontWeight: 600,
+                        fontFamily: T.sans,
+                        cursor: "pointer",
+                      }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={saveEdit}
+                      disabled={!validEditKey || saving}
+                      style={{
+                        padding: "8px 14px",
+                        borderRadius: 8,
+                        border: "none",
+                        background: validEditKey ? T.accent : T.panelAlt,
+                        color: validEditKey ? "#fff" : T.dim,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        fontFamily: T.sans,
+                        cursor: validEditKey && !saving ? "pointer" : "not-allowed",
+                        opacity: saving ? 0.7 : 1,
+                      }}
+                    >
+                      {saving ? "Saving…" : "Save"}
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
-            <div style={{ display: "flex", gap: 6 }}>
-              <button
-                onClick={startReplace}
-                style={{
-                  padding: "9px 14px",
-                  borderRadius: 8,
-                  border: `1px solid ${T.line}`,
-                  background: "transparent",
-                  color: T.text,
-                  fontSize: 12,
-                  fontWeight: 600,
-                  fontFamily: T.sans,
-                  cursor: "pointer",
-                }}
-              >
-                Replace
-              </button>
-              <button
-                onClick={disconnect}
-                style={{
-                  padding: "9px 14px",
-                  borderRadius: 8,
-                  border: `1px solid ${T.accent}55`,
-                  background: T.accentSoft,
-                  color: T.accent,
-                  fontSize: 12,
-                  fontWeight: 700,
-                  fontFamily: T.sans,
-                  cursor: "pointer",
-                }}
-              >
-                Disconnect
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+          );
+        })}
+      </div>
 
-      {config && mode === "replace" && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-          <div
-            style={{
-              fontSize: 11,
-              color: T.dim,
-              fontFamily: T.mono,
-              letterSpacing: 0.6,
-              textTransform: "uppercase",
-            }}
-          >
-            Replace credentials
-          </div>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-            {AI_PROVIDERS.map((pp) => (
-              <ProviderTile
-                key={pp.id}
-                provider={pp}
-                active={pp.id === editProvider}
-                onSelect={() => setEditProvider(pp.id)}
-              />
-            ))}
-          </div>
-          <div style={{ position: "relative" }}>
-            <input
-              type={revealed ? "text" : "password"}
-              value={editKey}
-              onChange={(e) => setEditKey(e.target.value)}
-              placeholder={editProviderObj.keyPrefix + "••••••••••••••••••••"}
-              autoComplete="off"
+      {activeProvider && status[activeProvider.id] && (
+        <div
+          style={{
+            marginTop: 14,
+            padding: "14px 16px",
+            background: T.panelAlt,
+            borderRadius: T.rMd,
+            border: `1px solid ${T.line}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 14,
+            flexWrap: "wrap",
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
               style={{
-                width: "100%",
-                padding: "12px 64px 12px 16px",
-                borderRadius: T.rMd,
-                background: T.panelAlt,
-                border: `1px solid ${editKey && !validKey ? T.accent + "55" : T.line}`,
-                color: T.text,
-                fontSize: 13,
-                fontFamily: T.mono,
-                letterSpacing: 0.4,
-                outline: "none",
-              }}
-            />
-            <button
-              onClick={() => setRevealed((r) => !r)}
-              style={{
-                position: "absolute",
-                right: 10,
-                top: "50%",
-                transform: "translateY(-50%)",
-                padding: "5px 10px",
                 fontSize: 10,
+                color: T.dim,
                 fontFamily: T.mono,
-                fontWeight: 700,
-                letterSpacing: 0.5,
+                letterSpacing: 0.6,
                 textTransform: "uppercase",
-                background: "transparent",
-                border: `1px solid ${T.line}`,
-                borderRadius: 6,
-                cursor: "pointer",
-                color: T.muted,
               }}
             >
-              {revealed ? "hide" : "show"}
-            </button>
+              Active model · {activeProvider.name}
+            </div>
+            <div style={{ fontSize: 11, color: T.muted, fontFamily: T.sans, marginTop: 4, lineHeight: 1.4 }}>
+              Used for new conversations. Active threads keep their model.
+            </div>
           </div>
-          <div style={{ fontSize: 11, color: T.muted, fontFamily: T.sans, lineHeight: 1.5 }}>
-            {editProviderObj.keyHint} · Generate one at{" "}
-            <span style={{ color: T.accent, fontFamily: T.mono }}>{editProviderObj.docs}</span>
-          </div>
-          <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-            <button
-              onClick={cancelReplace}
-              style={{
-                padding: "9px 16px",
-                borderRadius: 8,
-                border: `1px solid ${T.line}`,
-                background: "transparent",
-                color: T.muted,
-                fontSize: 12,
-                fontWeight: 600,
-                fontFamily: T.sans,
-                cursor: "pointer",
-              }}
-            >
-              Cancel
-            </button>
-            <button
-              onClick={saveReplace}
-              disabled={!validKey}
-              style={{
-                padding: "9px 16px",
-                borderRadius: 8,
-                border: "none",
-                background: validKey ? T.accent : T.panelAlt,
-                color: validKey ? "#fff" : T.dim,
-                fontSize: 12,
-                fontWeight: 700,
-                fontFamily: T.sans,
-                cursor: validKey ? "pointer" : "not-allowed",
-              }}
-            >
-              Save
-            </button>
-          </div>
+          <select
+            value={config?.model ?? activeProvider.defaultModel}
+            onChange={(e) => updateModel(e.target.value)}
+            style={{
+              background: T.panel,
+              border: `1px solid ${T.line}`,
+              color: T.text,
+              fontSize: 13,
+              fontFamily: T.mono,
+              padding: "8px 12px",
+              borderRadius: 8,
+              outline: "none",
+              cursor: "pointer",
+            }}
+          >
+            {activeProvider.models.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
         </div>
       )}
     </Card>
-  );
-}
-
-function ProviderTile({
-  provider,
-  active,
-  onSelect,
-}: {
-  provider: (typeof AI_PROVIDERS)[number];
-  active: boolean;
-  onSelect?: () => void;
-}) {
-  const T = useTheme();
-  const interactive = !!onSelect;
-  return (
-    <button
-      onClick={onSelect}
-      disabled={!interactive}
-      style={{
-        padding: "16px 18px",
-        borderRadius: T.rMd,
-        cursor: interactive ? "pointer" : "default",
-        textAlign: "left",
-        background: active ? T.panelAlt : "transparent",
-        border: `1px solid ${active ? T.accent + "55" : T.line}`,
-        transition: "all .15s ease",
-        display: "flex",
-        flexDirection: "column",
-        gap: 10,
-      }}
-    >
-      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-        <div
-          style={{
-            width: 28,
-            height: 28,
-            borderRadius: 8,
-            background: provider.color,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontSize: 13,
-            fontWeight: 800,
-            color: "#fff",
-            fontFamily: T.sans,
-          }}
-        >
-          {provider.name.charAt(0)}
-        </div>
-        <div style={{ flex: 1 }}>
-          <div style={{ fontSize: 13.5, fontWeight: 700, color: T.text, fontFamily: T.sans }}>
-            {provider.name}
-          </div>
-          <div style={{ fontSize: 10, color: T.dim, fontFamily: T.mono }}>by {provider.by}</div>
-        </div>
-        {active && interactive && (
-          <span
-            style={{
-              width: 16,
-              height: 16,
-              borderRadius: 8,
-              background: T.accent,
-              color: "#fff",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 9,
-              fontWeight: 800,
-            }}
-          >
-            ✓
-          </span>
-        )}
-      </div>
-      <div style={{ fontSize: 10.5, color: T.muted, fontFamily: T.mono }}>
-        default · {provider.defaultModel}
-      </div>
-    </button>
   );
 }

--- a/client/src/components/Spotlight.tsx
+++ b/client/src/components/Spotlight.tsx
@@ -1,0 +1,505 @@
+// ⌘K command palette. Opens from anywhere; types a prompt; on submit
+// either jumps to a route or creates a new AI thread with autoRun and
+// navigates to the assistant.
+
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTheme, type InkTheme } from "../ink/theme";
+import { LiveDot } from "../ink/primitives";
+import {
+  AI_PROVIDERS,
+  loadAIConfig,
+  onAIConfigChange,
+  type AIConfig,
+} from "../lib/aiConfig";
+import { createThread, deriveTitle } from "../lib/aiThreads";
+
+interface RouteEntry {
+  id: string;
+  to: string;
+  name: string;
+  glyph: string;
+  sub: string;
+}
+
+const ROUTES: RouteEntry[] = [
+  { id: "overview", to: "/", name: "Overview", glyph: "◉", sub: "Spending hero, cashflow, signals" },
+  { id: "transactions", to: "/transactions", name: "Transactions", glyph: "≡", sub: "Full list, filters, declined" },
+  { id: "categories", to: "/categories", name: "Categories", glyph: "◐", sub: "Breakdown by category" },
+  { id: "merchants", to: "/merchants", name: "Merchants", glyph: "◆", sub: "Top merchants, leaderboard" },
+  { id: "ai", to: "/assistant", name: "Assistant", glyph: "✧", sub: "Open AI chat" },
+  { id: "signals", to: "/signals", name: "Signals", glyph: "✦", sub: "Anomalies and nudges" },
+  { id: "manage", to: "/manage", name: "Manage", glyph: "⚙", sub: "Banks, rules, AI keys" },
+];
+
+interface AISuggestion {
+  icon: string;
+  label: string;
+  prompt: string;
+}
+
+const AI_PROMPTS: AISuggestion[] = [
+  { icon: "✦", label: "Plan to save for a Honda — $1,000", prompt: "I want to save $1,000 for a Honda by end of August. Make me a savings plan." },
+  { icon: "◐", label: 'Create a "Coffee shops" category', prompt: 'Make a new category called "Coffee shops" and move all my Starbucks, Coffee LAB, and Skola transactions there.' },
+  { icon: "◆", label: "Set a ₾800 food budget", prompt: "Set a monthly budget of ₾800 for Food & Drink and warn me at 80%." },
+  { icon: "⚠", label: "Find unused subscriptions", prompt: "Look at recurring charges and flag any I might want to cancel." },
+  { icon: "◉", label: "Summarize my April spending", prompt: "Give me a one-paragraph summary of my April spending — what stood out vs. March?" },
+];
+
+type SpotItem =
+  | { kind: "ask"; label: string }
+  | ({ kind: "ai-suggestion" } & AISuggestion)
+  | ({ kind: "route" } & RouteEntry);
+
+export function SpotlightHost() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  useEffect(() => {
+    const trigger = () => setOpen(true);
+    window.addEventListener("xarji-spotlight-open", trigger);
+    return () => window.removeEventListener("xarji-spotlight-open", trigger);
+  }, []);
+
+  return <Spotlight open={open} onClose={() => setOpen(false)} />;
+}
+
+function Spotlight({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const T = useTheme();
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [q, setQ] = useState("");
+  const [sel, setSel] = useState(0);
+  const [config, setConfig] = useState<AIConfig | null>(loadAIConfig);
+
+  useEffect(() => onAIConfigChange(() => setConfig(loadAIConfig())), []);
+
+  useEffect(() => {
+    if (open) {
+      setConfig(loadAIConfig());
+      setQ("");
+      setSel(0);
+      const id = setTimeout(() => inputRef.current?.focus(), 30);
+      return () => clearTimeout(id);
+    }
+  }, [open]);
+
+  const trimmed = q.trim();
+  const lower = trimmed.toLowerCase();
+
+  const routeMatches = !trimmed
+    ? ROUTES.slice(0, 4)
+    : ROUTES.filter((r) => r.name.toLowerCase().includes(lower) || r.id.includes(lower)).slice(0, 4);
+
+  const aiSuggestions = !trimmed
+    ? AI_PROMPTS.slice(0, 3)
+    : AI_PROMPTS.filter(
+        (p) => p.label.toLowerCase().includes(lower) || p.prompt.toLowerCase().includes(lower)
+      ).slice(0, 3);
+
+  const askItem: SpotItem | null = trimmed ? { kind: "ask", label: trimmed } : null;
+
+  const items: SpotItem[] = [];
+  if (askItem) items.push(askItem);
+  aiSuggestions.forEach((p) => items.push({ kind: "ai-suggestion", ...p }));
+  routeMatches.forEach((r) => items.push({ kind: "route", ...r }));
+
+  useEffect(() => {
+    setSel(0);
+  }, [q]);
+
+  const run = (item: SpotItem | undefined) => {
+    if (!item) return;
+    if (item.kind === "route") {
+      navigate(item.to);
+      onClose();
+      return;
+    }
+    if (item.kind === "ai-suggestion" || item.kind === "ask") {
+      const prompt = item.kind === "ask" ? item.label : item.prompt;
+      if (!config) {
+        navigate("/assistant");
+        onClose();
+        return;
+      }
+      createThread({ firstUserPrompt: prompt, autoRun: true, title: deriveTitle(prompt) });
+      navigate("/assistant");
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSel((s) => Math.min(s + 1, items.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSel((s) => Math.max(s - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        run(items[sel]);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, items, sel]);
+
+  if (!open) return null;
+
+  const providerName = config && AI_PROVIDERS.find((p) => p.id === config.provider)?.name;
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 9000,
+        background: "rgba(6,6,8,0.55)",
+        backdropFilter: "blur(6px)",
+        WebkitBackdropFilter: "blur(6px)",
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        paddingTop: "13vh",
+        animation: "spot-fade .14s ease-out",
+      }}
+    >
+      <style>{`
+        @keyframes spot-fade { from { opacity: 0 } to { opacity: 1 } }
+        @keyframes spot-rise { from { transform: translateY(-8px); opacity: 0 } to { transform: translateY(0); opacity: 1 } }
+      `}</style>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: "min(92vw, 680px)",
+          background: T.panel,
+          borderRadius: 16,
+          border: `1px solid ${T.line}`,
+          boxShadow: "0 30px 80px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.02)",
+          overflow: "hidden",
+          animation: "spot-rise .18s ease-out",
+        }}
+      >
+        <div
+          style={{
+            padding: "16px 22px",
+            borderBottom: `1px solid ${T.line}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 14,
+          }}
+        >
+          <span style={{ fontSize: 18, color: T.accent, lineHeight: 1 }}>✦</span>
+          <input
+            ref={inputRef}
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Ask Xarji or jump anywhere…"
+            style={{
+              flex: 1,
+              background: "transparent",
+              border: "none",
+              color: T.text,
+              fontSize: 17,
+              fontFamily: T.sans,
+              outline: "none",
+            }}
+          />
+          <span
+            style={{
+              fontSize: 10,
+              fontFamily: T.mono,
+              color: T.dim,
+              padding: "3px 8px",
+              background: T.panelAlt,
+              borderRadius: 5,
+              border: `1px solid ${T.line}`,
+            }}
+          >
+            esc
+          </span>
+        </div>
+
+        <div style={{ maxHeight: "min(60vh, 460px)", overflowY: "auto", padding: "8px 8px 14px" }}>
+          {!config && trimmed && (
+            <div
+              style={{
+                padding: "10px 14px",
+                margin: "6px 6px 4px",
+                borderRadius: 9,
+                background: T.accentSoft,
+                border: `1px solid ${T.accent}33`,
+                fontSize: 12,
+                color: T.text,
+                fontFamily: T.sans,
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+              }}
+            >
+              <span
+                style={{
+                  width: 18,
+                  height: 18,
+                  borderRadius: 5,
+                  background: T.accent,
+                  color: "#fff",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 10,
+                  fontWeight: 800,
+                }}
+              >
+                !
+              </span>
+              <span style={{ flex: 1 }}>
+                Connect an AI key first to ask the assistant.{" "}
+                <span style={{ color: T.accent, fontWeight: 700 }}>↵ Open setup →</span>
+              </span>
+            </div>
+          )}
+
+          {askItem && (
+            <SpotSection title="Ask Xarji" T={T}>
+              <SpotItemRow
+                item={askItem}
+                idx={0}
+                sel={sel}
+                onHover={setSel}
+                onRun={run}
+                T={T}
+                provider={providerName ?? undefined}
+              />
+            </SpotSection>
+          )}
+
+          {aiSuggestions.length > 0 && (
+            <SpotSection title={trimmed ? "Suggested prompts" : "Quick prompts"} T={T}>
+              {aiSuggestions.map((s, i) => {
+                const idx = (askItem ? 1 : 0) + i;
+                return (
+                  <SpotItemRow
+                    key={s.label}
+                    item={{ kind: "ai-suggestion", ...s }}
+                    idx={idx}
+                    sel={sel}
+                    onHover={setSel}
+                    onRun={run}
+                    T={T}
+                  />
+                );
+              })}
+            </SpotSection>
+          )}
+
+          {routeMatches.length > 0 && (
+            <SpotSection title="Jump to" T={T}>
+              {routeMatches.map((r, i) => {
+                const idx = (askItem ? 1 : 0) + aiSuggestions.length + i;
+                return (
+                  <SpotItemRow
+                    key={r.id}
+                    item={{ kind: "route", ...r }}
+                    idx={idx}
+                    sel={sel}
+                    onHover={setSel}
+                    onRun={run}
+                    T={T}
+                  />
+                );
+              })}
+            </SpotSection>
+          )}
+
+          {items.length === 0 && (
+            <div
+              style={{
+                padding: "40px 20px",
+                textAlign: "center",
+                color: T.muted,
+                fontSize: 12,
+                fontFamily: T.sans,
+              }}
+            >
+              No matches. Press ↵ to ask Xarji directly.
+            </div>
+          )}
+        </div>
+
+        <div
+          style={{
+            padding: "10px 18px",
+            borderTop: `1px solid ${T.line}`,
+            background: T.bg,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontSize: 10.5,
+            color: T.dim,
+            fontFamily: T.mono,
+            letterSpacing: 0.3,
+          }}
+        >
+          <span>↑↓ navigate · ↵ run · esc close</span>
+          <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <LiveDot color={config ? T.green : T.dim} />
+            {config ? `${providerName} connected` : "no AI key"}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SpotSection({ title, children, T }: { title: string; children: React.ReactNode; T: InkTheme }) {
+  return (
+    <div style={{ marginTop: 6 }}>
+      <div
+        style={{
+          padding: "6px 14px 4px",
+          fontSize: 10,
+          fontFamily: T.mono,
+          color: T.dim,
+          textTransform: "uppercase",
+          letterSpacing: 0.8,
+        }}
+      >
+        {title}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function SpotItemRow({
+  item,
+  idx,
+  sel,
+  onHover,
+  onRun,
+  T,
+  provider,
+}: {
+  item: SpotItem;
+  idx: number;
+  sel: number;
+  onHover: (idx: number) => void;
+  onRun: (item: SpotItem) => void;
+  T: InkTheme;
+  provider?: string;
+}) {
+  const active = idx === sel;
+  const isAsk = item.kind === "ask";
+  const isAi = item.kind === "ai-suggestion" || isAsk;
+  const isRoute = item.kind === "route";
+
+  const icon = isAsk ? "✦" : item.kind === "ai-suggestion" ? item.icon : item.glyph;
+
+  return (
+    <div
+      onMouseEnter={() => onHover(idx)}
+      onClick={() => onRun(item)}
+      style={{
+        padding: "10px 14px",
+        margin: "0 6px",
+        borderRadius: 9,
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        background: active ? T.panelAlt : "transparent",
+        border: active ? `1px solid ${T.line}` : "1px solid transparent",
+      }}
+    >
+      <span
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 8,
+          background: isAsk ? T.accent : isAi ? T.accentSoft : T.panelAlt,
+          color: isAsk ? "#fff" : isAi ? T.accent : T.muted,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: T.mono,
+          fontSize: 13,
+          fontWeight: 700,
+          flexShrink: 0,
+        }}
+      >
+        {icon}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: 13.5,
+            fontWeight: isAsk ? 700 : 600,
+            color: isAsk ? T.accent : T.text,
+            fontFamily: T.sans,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {isAsk ? (
+            <>
+              Ask Xarji: <span style={{ color: T.text, fontWeight: 600 }}>"{item.label}"</span>
+            </>
+          ) : item.kind === "ai-suggestion" ? (
+            item.label
+          ) : (
+            item.name
+          )}
+        </div>
+        {!isAsk && (
+          <div
+            style={{
+              fontSize: 11,
+              color: T.muted,
+              fontFamily: T.sans,
+              marginTop: 2,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {item.kind === "ai-suggestion" ? item.prompt : item.sub}
+          </div>
+        )}
+      </div>
+      <span
+        style={{
+          fontSize: 10,
+          fontFamily: T.mono,
+          color: active ? T.muted : T.dim,
+          padding: "3px 7px",
+          background: active ? T.panel : "transparent",
+          border: active ? `1px solid ${T.line}` : "1px solid transparent",
+          borderRadius: 5,
+          letterSpacing: 0.4,
+          textTransform: "uppercase",
+        }}
+      >
+        {isRoute ? "jump" : isAsk ? (provider || "AI") + " ↵" : "AI ↵"}
+      </span>
+    </div>
+  );
+}

--- a/client/src/components/Spotlight.tsx
+++ b/client/src/components/Spotlight.tsx
@@ -11,7 +11,9 @@ import {
   loadAIConfig,
   onAIConfigChange,
   type AIConfig,
+  type AIProviderId,
 } from "../lib/aiConfig";
+import { useAIKeyStatus } from "../hooks/useAIKeyStatus";
 import { createThread, deriveTitle } from "../lib/aiThreads";
 
 interface RouteEntry {
@@ -81,6 +83,11 @@ function Spotlight({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [q, setQ] = useState("");
   const [sel, setSel] = useState(0);
   const [config, setConfig] = useState<AIConfig | null>(loadAIConfig);
+  const { status: keyStatus } = useAIKeyStatus();
+  // "AI is connected" now means the service has a key for SOME
+  // provider, not that the local AIConfig has an apiKey field — the
+  // browser doesn't see keys at all anymore.
+  const hasAnyKey = keyStatus.anthropic || keyStatus.openai;
 
   useEffect(() => onAIConfigChange(() => setConfig(loadAIConfig())), []);
 
@@ -127,7 +134,9 @@ function Spotlight({ open, onClose }: { open: boolean; onClose: () => void }) {
     }
     if (item.kind === "ai-suggestion" || item.kind === "ask") {
       const prompt = item.kind === "ask" ? item.label : item.prompt;
-      if (!config) {
+      if (!hasAnyKey) {
+        // No provider key on the service yet — land them on the
+        // assistant page, which will render the onboarding gate.
         navigate("/assistant");
         onClose();
         return;
@@ -162,7 +171,18 @@ function Spotlight({ open, onClose }: { open: boolean; onClose: () => void }) {
 
   if (!open) return null;
 
-  const providerName = config && AI_PROVIDERS.find((p) => p.id === config.provider)?.name;
+  // Display the active provider name when (a) the user has a local
+  // pref + (b) that provider has a key on the service. Otherwise pick
+  // any connected provider so the footer doesn't say "no AI key" when
+  // one is actually configured.
+  const activeProviderId: AIProviderId | null = config?.provider && keyStatus[config.provider]
+    ? config.provider
+    : keyStatus.anthropic
+      ? "anthropic"
+      : keyStatus.openai
+        ? "openai"
+        : null;
+  const providerName = activeProviderId ? AI_PROVIDERS.find((p) => p.id === activeProviderId)?.name : null;
 
   return (
     <div
@@ -238,7 +258,7 @@ function Spotlight({ open, onClose }: { open: boolean; onClose: () => void }) {
         </div>
 
         <div style={{ maxHeight: "min(60vh, 460px)", overflowY: "auto", padding: "8px 8px 14px" }}>
-          {!config && trimmed && (
+          {!hasAnyKey && trimmed && (
             <div
               style={{
                 padding: "10px 14px",
@@ -360,8 +380,8 @@ function Spotlight({ open, onClose }: { open: boolean; onClose: () => void }) {
         >
           <span>↑↓ navigate · ↵ run · esc close</span>
           <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <LiveDot color={config ? T.green : T.dim} />
-            {config ? `${providerName} connected` : "no AI key"}
+            <LiveDot color={hasAnyKey ? T.green : T.dim} />
+            {hasAnyKey ? `${providerName} connected` : "no AI key"}
           </span>
         </div>
       </div>

--- a/client/src/dev/demoData.ts
+++ b/client/src/dev/demoData.ts
@@ -1,0 +1,424 @@
+// Rich, deterministic demo dataset. Anchored to "now" at module load so
+// the dashboard always shows current-month data regardless of recording
+// date. Every default category is represented; the current month is
+// crafted to trigger every signal in `useSignals`.
+//
+// Tree-shaken from the production bundle: only loaded via dynamic import
+// from `./demoDb`, which itself is only reached behind a static
+// `import.meta.env.DEV && isDemoMode()` gate in `lib/instant.ts`.
+
+import type { Payment, FailedPayment, Credit, Category, BankSender } from "../lib/instant";
+import { DEFAULT_CATEGORIES } from "../lib/utils";
+
+function mulberry32(seed: number) {
+  return function () {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick<T>(rng: () => number, arr: T[]): T {
+  return arr[Math.floor(rng() * arr.length)];
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+const SENDERS: BankSender[] = [
+  { id: "bs-solo", senderId: "SOLO", displayName: "SOLO", enabled: true, createdAt: Date.now() - 9 * 30 * 86400000 },
+  { id: "bs-tbc", senderId: "TBC", displayName: "TBC SMS", enabled: true, createdAt: Date.now() - 9 * 30 * 86400000 },
+  { id: "bs-bog", senderId: "BOG", displayName: "Main", enabled: true, createdAt: Date.now() - 9 * 30 * 86400000 },
+];
+
+const CATEGORIES: Category[] = DEFAULT_CATEGORIES.map((c) => ({
+  id: `cat-${c.id}`,
+  name: c.name,
+  color: c.color,
+  icon: c.icon,
+  isDefault: true,
+}));
+
+// Merchants chosen to match every regex bucket in lib/utils.ts so the
+// donut populates all 11 default categories. Amount ranges in GEL.
+type MerchantSpec = { name: string; raw: string; range: [number, number] };
+
+const MERCHANTS: MerchantSpec[] = [
+  // groceries
+  { name: "Carrefour", raw: "CARREFOUR EAST POINT TBILISI", range: [22, 180] },
+  { name: "Goodwill", raw: "GOODWILL VAKE TBILISI GE", range: [18, 140] },
+  { name: "Spar", raw: "SPAR SABURTALO TBILISI GE", range: [8, 64] },
+  { name: "Nikora", raw: "NIKORA SHOP 0143 TBILISI", range: [6, 42] },
+  // dining
+  { name: "Lolita", raw: "LOLITA CHAVCHAVADZE 37", range: [28, 95] },
+  { name: "Shavi Lomi", raw: "SHAVI LOMI 23 AMAGHLEBA", range: [45, 160] },
+  { name: "Stamba Cafe", raw: "STAMBA HOTEL RESTAURANT", range: [22, 88] },
+  { name: "Cafe Litera", raw: "CAFE LITERA RUSTAVELI", range: [18, 46] },
+  // delivery (food)
+  { name: "Wolt", raw: "WOLT.COM/HELSINKI FI", range: [12, 58] },
+  { name: "Glovo", raw: "GLOVO TBILISI GE", range: [10, 42] },
+  // transport
+  { name: "Bolt", raw: "BOLT.EU/RYY TALLINN EE", range: [4, 22] },
+  { name: "Yandex Go", raw: "YANDEX.GO MOSCOW RU", range: [5, 28] },
+  { name: "SOCAR", raw: "SOCAR PETROL ST. 042", range: [60, 180] },
+  { name: "Gulf", raw: "GULF GEORGIA GLDANI", range: [55, 160] },
+  // shopping
+  { name: "H&M", raw: "H&M EAST POINT TBILISI", range: [45, 280] },
+  { name: "Zara", raw: "ZARA GALLERIA TBILISI", range: [65, 340] },
+  { name: "Elit Electronics", raw: "ELIT ELECTRONICS 02", range: [40, 1200] },
+  // travel
+  { name: "Booking.com", raw: "BOOKING.COM AMSTERDAM NL", range: [180, 620] },
+  { name: "Wizz Air", raw: "WIZZAIR.COM BUDAPEST HU", range: [240, 580] },
+  // utilities
+  { name: "Magti", raw: "MAGTICOM BILL PAYMENT", range: [35, 72] },
+  { name: "Silknet", raw: "SILKNET INTERNET MONTHLY", range: [48, 48] },
+  // health
+  { name: "Silk Pharmacy", raw: "SILK PHARMACY VAKE 14", range: [14, 78] },
+  { name: "PSP Pharmacy", raw: "PSP PHARMACY 024 TBILISI", range: [9, 65] },
+  { name: "Fitness House", raw: "FITNESS HOUSE VAKE", range: [85, 85] },
+  // entertainment (fun)
+  { name: "Cinema City", raw: "CINEMA CITY GALLERIA", range: [18, 42] },
+  // cash
+  { name: "ATM", raw: "ATM SOLO VAKE BRANCH", range: [100, 500] },
+  // loans (curated parser string)
+  { name: "Loan repayment", raw: "TBC LOAN REPAYMENT MONTHLY", range: [320, 320] },
+];
+
+// Recurring monthly subscriptions — same amount every month so the
+// Subscriptions category bucket fills predictably and the recurring
+// pattern is visible in the merchant detail view.
+const RECURRING_SUBS: { name: string; raw: string; amount: number; dayOfMonth: number }[] = [
+  { name: "Spotify", raw: "SPOTIFY P2FA1B9C STOCKHOLM", amount: 17, dayOfMonth: 5 },
+  { name: "Netflix", raw: "NETFLIX.COM LOS GATOS US", amount: 32, dayOfMonth: 11 },
+  { name: "Claude", raw: "ANTHROPIC CLAUDE SF US", amount: 56, dayOfMonth: 15 },
+  { name: "GitHub", raw: "GITHUB.COM SAN FRANCISCO", amount: 11, dayOfMonth: 22 },
+  { name: "iCloud+", raw: "APPLE.COM/BILL ITUNES", amount: 8, dayOfMonth: 3 },
+  { name: "Figma", raw: "FIGMA.COM SAN FRANCISCO", amount: 42, dayOfMonth: 18 },
+];
+
+const CARDS = ["1423", "8891", "2230"];
+const FAIL_REASONS = [
+  "insufficient funds",
+  "card blocked",
+  "daily limit exceeded",
+  "3D-Secure timeout",
+];
+
+function buildPayments(rng: () => number, now: Date): Payment[] {
+  const out: Payment[] = [];
+  let n = 0;
+
+  // 9 months of organic transactions.
+  for (let daysBack = 0; daysBack < 270; daysBack++) {
+    const date = new Date(now.getTime() - daysBack * 86400000);
+    const weekday = date.getDay();
+    const weekMul = weekday === 0 || weekday === 6 ? 1.3 : 1.0;
+    const recencyMul = daysBack < 45 ? 1.0 : 0.85;
+    const count = Math.max(0, Math.round((2 + rng() * 5) * weekMul * recencyMul));
+
+    for (let i = 0; i < count; i++) {
+      const m = pick(rng, MERCHANTS);
+      const baseAmount = round2(m.range[0] + rng() * (m.range[1] - m.range[0]));
+      const hour = 8 + Math.floor(rng() * 14);
+      const minute = Math.floor(rng() * 60);
+      date.setHours(hour, minute, Math.floor(rng() * 60));
+
+      // ~7% USD, ~3% EUR — exercises currency filters in stats hooks.
+      const r = rng();
+      const currency = r < 0.07 ? "USD" : r < 0.10 ? "EUR" : "GEL";
+      const amount = currency === "USD" ? round2(baseAmount / 2.7) : currency === "EUR" ? round2(baseAmount / 2.95) : baseAmount;
+      const card = pick(rng, CARDS);
+      const sender = pick(rng, SENDERS);
+
+      const id = `pay-${n}-${date.getTime()}`;
+      n += 1;
+      out.push({
+        id,
+        transactionId: id,
+        transactionType: "payment",
+        amount,
+        currency,
+        merchant: m.name,
+        cardLastDigits: card,
+        transactionDate: date.getTime(),
+        messageTimestamp: date.getTime(),
+        syncedAt: Date.now(),
+        plusEarned: currency === "GEL" ? Math.floor(amount * 0.5) : 0,
+        bankSenderId: sender.senderId,
+        rawMessage: `${sender.senderId}: ${m.raw}. თანხა: ${amount} ${currency}. ბარათი *${card}`,
+      });
+    }
+  }
+
+  // Recurring subs — one entry per month for the last 9 months.
+  for (let monthBack = 0; monthBack < 9; monthBack++) {
+    const monthDate = new Date(now.getFullYear(), now.getMonth() - monthBack, 1);
+    for (const sub of RECURRING_SUBS) {
+      const day = Math.min(sub.dayOfMonth, new Date(monthDate.getFullYear(), monthDate.getMonth() + 1, 0).getDate());
+      const date = new Date(monthDate.getFullYear(), monthDate.getMonth(), day, 9, 30);
+      // Skip future dates within the current month.
+      if (date.getTime() > now.getTime()) continue;
+      const id = `sub-${sub.name.toLowerCase()}-${monthDate.getFullYear()}-${monthDate.getMonth() + 1}`;
+      out.push({
+        id,
+        transactionId: id,
+        transactionType: "payment",
+        amount: sub.amount,
+        currency: "GEL",
+        merchant: sub.name,
+        cardLastDigits: "1423",
+        transactionDate: date.getTime(),
+        messageTimestamp: date.getTime(),
+        syncedAt: Date.now(),
+        plusEarned: 0,
+        bankSenderId: "SOLO",
+        rawMessage: `SOLO: ${sub.raw}. თანხა: ${sub.amount} GEL. ბარათი *1423`,
+      });
+    }
+  }
+
+  // Current-month bait for `useSignals`:
+  //   - One large outlier so largeTx[0] is dominant
+  //   - One brand-new merchant absent from the prior 90 days
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const dayInMonth = Math.max(1, Math.floor((now.getTime() - monthStart.getTime()) / 86400000) - 2);
+
+  const largeId = `pay-outlier-${monthStart.getTime()}`;
+  out.push({
+    id: largeId,
+    transactionId: largeId,
+    transactionType: "payment",
+    amount: 4280,
+    currency: "GEL",
+    merchant: "IKEA",
+    cardLastDigits: "1423",
+    transactionDate: monthStart.getTime() + dayInMonth * 86400000 + 14 * 3600000,
+    messageTimestamp: monthStart.getTime() + dayInMonth * 86400000 + 14 * 3600000,
+    syncedAt: Date.now(),
+    plusEarned: 2140,
+    bankSenderId: "BOG",
+    rawMessage: "BOG: IKEA GLDANI 0017. თანხა: 4280 GEL. ბარათი *1423",
+  });
+
+  const newMerchantId = `pay-new-${monthStart.getTime()}`;
+  out.push({
+    id: newMerchantId,
+    transactionId: newMerchantId,
+    transactionType: "payment",
+    amount: 95,
+    currency: "GEL",
+    merchant: "Pulse Fitness",
+    cardLastDigits: "1423",
+    transactionDate: now.getTime() - 2 * 86400000,
+    messageTimestamp: now.getTime() - 2 * 86400000,
+    syncedAt: Date.now(),
+    plusEarned: 47,
+    bankSenderId: "SOLO",
+    rawMessage: "SOLO: PULSE FITNESS GYM. თანხა: 95 GEL. ბარათი *1423",
+  });
+
+  out.sort((a, b) => b.transactionDate - a.transactionDate);
+  return out;
+}
+
+function buildFailedPayments(rng: () => number, now: Date): FailedPayment[] {
+  const out: FailedPayment[] = [];
+  let n = 0;
+
+  for (let daysBack = 0; daysBack < 270; daysBack++) {
+    if (rng() > 0.18) continue;
+    const date = new Date(now.getTime() - daysBack * 86400000);
+    const m = pick(rng, MERCHANTS);
+    const card = pick(rng, CARDS);
+    const sender = pick(rng, SENDERS);
+    const reason = pick(rng, FAIL_REASONS);
+    date.setHours(8 + Math.floor(rng() * 12), Math.floor(rng() * 60));
+    const id = `fail-${n}-${date.getTime()}`;
+    n += 1;
+    out.push({
+      id,
+      transactionId: id,
+      transactionType: "payment_failed",
+      currency: "GEL",
+      merchant: m.name,
+      cardLastDigits: card,
+      failureReason: reason,
+      balance: round2(rng() * 200),
+      transactionDate: date.getTime(),
+      messageTimestamp: date.getTime(),
+      syncedAt: Date.now(),
+      bankSenderId: sender.senderId,
+      rawMessage: `${sender.senderId}: ტრანზაქცია უარყოფილია. ${m.raw}. მიზეზი: ${reason}`,
+    });
+  }
+
+  // Current-month signal bait: 2 declines at "Wolt" within 24h on the
+  // same card so `repeatedDeclines` fires.
+  const base = now.getTime() - 86400000;
+  for (let i = 0; i < 2; i++) {
+    const id = `fail-wolt-${i}`;
+    out.push({
+      id,
+      transactionId: id,
+      transactionType: "payment_failed",
+      currency: "GEL",
+      merchant: "Wolt",
+      cardLastDigits: "8891",
+      failureReason: "insufficient funds",
+      balance: 4.5,
+      transactionDate: base + i * 4 * 3600000,
+      messageTimestamp: base + i * 4 * 3600000,
+      syncedAt: Date.now(),
+      bankSenderId: "SOLO",
+      rawMessage: "SOLO: ტრანზაქცია უარყოფილია. WOLT.COM/HELSINKI FI. მიზეზი: insufficient funds",
+    });
+  }
+
+  out.sort((a, b) => b.transactionDate - a.transactionDate);
+  return out;
+}
+
+function buildCredits(rng: () => number, now: Date): Credit[] {
+  const out: Credit[] = [];
+  let n = 0;
+
+  // Recurring salary: 1st and 15th of every month for 9 months.
+  for (let monthBack = 0; monthBack < 9; monthBack++) {
+    for (const day of [1, 15]) {
+      const date = new Date(now.getFullYear(), now.getMonth() - monthBack, day, 10, 0);
+      if (date.getTime() > now.getTime()) continue;
+      const id = `salary-${date.getFullYear()}-${date.getMonth() + 1}-${day}`;
+      out.push({
+        id,
+        transactionId: id,
+        transactionType: "credit",
+        amount: 4800,
+        currency: "GEL",
+        counterparty: "Tech Co LLC",
+        cardLastDigits: "1423",
+        transactionDate: date.getTime(),
+        messageTimestamp: date.getTime(),
+        syncedAt: Date.now(),
+        bankSenderId: "BOG",
+        rawMessage: `BOG: ჩარიცხვა Tech Co LLC. თანხა: 4800 GEL.`,
+      });
+    }
+  }
+
+  // Mid-month freelance invoices (variable counterparty) for variety.
+  const freelanceClients = ["Design Studio", "Acme GmbH", "Northwind", "Studio Twelve", "Civic Lab"];
+  for (let monthBack = 0; monthBack < 9; monthBack++) {
+    const date = new Date(now.getFullYear(), now.getMonth() - monthBack, 11, 14, 30);
+    if (date.getTime() > now.getTime()) continue;
+    const amount = round2(800 + rng() * 1400);
+    const counterparty = freelanceClients[monthBack % freelanceClients.length];
+    const id = `freelance-${date.getFullYear()}-${date.getMonth() + 1}`;
+    out.push({
+      id,
+      transactionId: id,
+      transactionType: "credit",
+      amount,
+      currency: "GEL",
+      counterparty,
+      cardLastDigits: "1423",
+      transactionDate: date.getTime(),
+      messageTimestamp: date.getTime(),
+      syncedAt: Date.now(),
+      bankSenderId: "BOG",
+      rawMessage: `BOG: ჩარიცხვა ${counterparty}. თანხა: ${amount} GEL.`,
+    });
+    n += 1;
+  }
+
+  // Current-month diversity: refunds + P2P transfers. Together with the
+  // 2 salaries + freelance, this puts the current month at 5+ distinct
+  // counterparties, enough to make the Income page's top-sources view
+  // non-trivial. Plus one USD credit so the GEL filter has work to do.
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const extras: Array<Omit<Credit, "id" | "transactionId" | "syncedAt">> = [
+    {
+      transactionType: "credit",
+      amount: 18,
+      currency: "GEL",
+      counterparty: "Wolt refund",
+      cardLastDigits: "1423",
+      transactionDate: monthStart.getTime() + 5 * 86400000 + 12 * 3600000,
+      messageTimestamp: monthStart.getTime() + 5 * 86400000 + 12 * 3600000,
+      bankSenderId: "SOLO",
+      rawMessage: "SOLO: დაბრუნება Wolt. თანხა: 18 GEL.",
+    },
+    {
+      transactionType: "credit",
+      amount: 52,
+      currency: "GEL",
+      counterparty: "Carrefour refund",
+      cardLastDigits: "1423",
+      transactionDate: monthStart.getTime() + 9 * 86400000 + 9 * 3600000,
+      messageTimestamp: monthStart.getTime() + 9 * 86400000 + 9 * 3600000,
+      bankSenderId: "SOLO",
+      rawMessage: "SOLO: დაბრუნება Carrefour. თანხა: 52 GEL.",
+    },
+    {
+      transactionType: "credit",
+      amount: 300,
+      currency: "GEL",
+      counterparty: "Mom",
+      cardLastDigits: "1423",
+      transactionDate: monthStart.getTime() + 12 * 86400000 + 18 * 3600000,
+      messageTimestamp: monthStart.getTime() + 12 * 86400000 + 18 * 3600000,
+      bankSenderId: "BOG",
+      rawMessage: "BOG: P2P გადარიცხვა Mom. თანხა: 300 GEL.",
+    },
+    {
+      transactionType: "credit",
+      amount: 200,
+      currency: "USD",
+      counterparty: "Stripe Payout",
+      cardLastDigits: "1423",
+      transactionDate: monthStart.getTime() + 7 * 86400000 + 16 * 3600000,
+      messageTimestamp: monthStart.getTime() + 7 * 86400000 + 16 * 3600000,
+      bankSenderId: "BOG",
+      rawMessage: "BOG: ჩარიცხვა Stripe Payout. თანხა: 200 USD.",
+    },
+  ];
+  for (const e of extras) {
+    if (e.transactionDate > now.getTime()) continue;
+    const id = `credit-extra-${n}-${e.transactionDate}`;
+    n += 1;
+    out.push({ ...e, id, transactionId: id, syncedAt: Date.now() });
+  }
+
+  out.sort((a, b) => b.transactionDate - a.transactionDate);
+  return out;
+}
+
+export interface DemoDataset {
+  payments: Payment[];
+  failedPayments: FailedPayment[];
+  credits: Credit[];
+  categories: Category[];
+  bankSenders: BankSender[];
+}
+
+export function buildDemoDataset(seed: "default" | "empty"): DemoDataset {
+  if (seed === "empty") {
+    return {
+      payments: [],
+      failedPayments: [],
+      credits: [],
+      categories: [],
+      bankSenders: [],
+    };
+  }
+  const rng = mulberry32(20260424);
+  const now = new Date();
+  return {
+    payments: buildPayments(rng, now),
+    failedPayments: buildFailedPayments(rng, now),
+    credits: buildCredits(rng, now),
+    categories: CATEGORIES,
+    bankSenders: SENDERS,
+  };
+}

--- a/client/src/dev/demoDb.ts
+++ b/client/src/dev/demoDb.ts
@@ -1,0 +1,131 @@
+// Mutable in-memory `db` shaped like @instantdb/react's init() return.
+// Implements the subset the client actually uses: useQuery, transact, tx.
+// Mutations apply to a module-level store and notify subscribers via
+// useSyncExternalStore so toggling a bank sender or deleting a category
+// re-renders consumers — important for demo recordings to look real.
+
+import { useSyncExternalStore } from "react";
+import { buildDemoDataset, type DemoDataset } from "./demoData";
+
+type AnyRecord = { id: string; [k: string]: unknown };
+type Collection = keyof DemoDataset;
+
+type Op =
+  | { __op: true; collection: Collection; id: string; kind: "update"; value: Record<string, unknown> }
+  | { __op: true; collection: Collection; id: string; kind: "delete" };
+
+const store = new Map<Collection, AnyRecord[]>();
+const listeners = new Set<() => void>();
+const EMPTY: readonly AnyRecord[] = Object.freeze([]);
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+function seed(dataset: DemoDataset) {
+  store.set("payments", dataset.payments as unknown as AnyRecord[]);
+  store.set("failedPayments", dataset.failedPayments as unknown as AnyRecord[]);
+  store.set("credits", dataset.credits as unknown as AnyRecord[]);
+  store.set("categories", dataset.categories as unknown as AnyRecord[]);
+  store.set("bankSenders", dataset.bankSenders as unknown as AnyRecord[]);
+}
+
+function getSnapshot(collection: Collection): readonly AnyRecord[] {
+  return store.get(collection) ?? EMPTY;
+}
+
+function applyOp(op: Op) {
+  const current = store.get(op.collection) ?? [];
+  if (op.kind === "delete") {
+    store.set(op.collection, current.filter((r) => r.id !== op.id));
+    return;
+  }
+  const idx = current.findIndex((r) => r.id === op.id);
+  if (idx >= 0) {
+    const next = current.slice();
+    next[idx] = { ...next[idx], ...op.value };
+    store.set(op.collection, next);
+  } else {
+    store.set(op.collection, [...current, { id: op.id, ...op.value } as AnyRecord]);
+  }
+}
+
+// Mirrors the chainable shape of `db.tx.<collection>[id].update({...})`
+// so existing call sites compile and produce op records `transact` can
+// consume.
+const tx = new Proxy(
+  {},
+  {
+    get(_target, collectionName: string) {
+      return new Proxy(
+        {},
+        {
+          get(_t, recordId: string) {
+            return {
+              update: (value: Record<string, unknown>): Op => ({
+                __op: true,
+                collection: collectionName as Collection,
+                id: recordId,
+                kind: "update",
+                value,
+              }),
+              merge: (value: Record<string, unknown>): Op => ({
+                __op: true,
+                collection: collectionName as Collection,
+                id: recordId,
+                kind: "update",
+                value,
+              }),
+              delete: (): Op => ({
+                __op: true,
+                collection: collectionName as Collection,
+                id: recordId,
+                kind: "delete",
+              }),
+            };
+          },
+        }
+      );
+    },
+  }
+);
+
+function isOp(value: unknown): value is Op {
+  return typeof value === "object" && value !== null && (value as { __op?: unknown }).__op === true;
+}
+
+async function transact(input: unknown | unknown[]): Promise<null> {
+  const ops = Array.isArray(input) ? input : [input];
+  let mutated = false;
+  for (const op of ops) {
+    if (isOp(op)) {
+      applyOp(op);
+      mutated = true;
+    }
+  }
+  if (mutated) notify();
+  return null;
+}
+
+function useQuery(query: Record<string, unknown>) {
+  const collection = Object.keys(query)[0] as Collection;
+  const data = useSyncExternalStore(
+    subscribe,
+    () => getSnapshot(collection),
+    () => getSnapshot(collection)
+  );
+  return { data: { [collection]: data }, isLoading: false, error: undefined };
+}
+
+export function makeDemoDb(seedKind: "default" | "empty") {
+  store.clear();
+  seed(buildDemoDataset(seedKind));
+  return { useQuery, transact, tx };
+}

--- a/client/src/dev/demoMode.ts
+++ b/client/src/dev/demoMode.ts
@@ -1,0 +1,94 @@
+// Dev-only switchable demo data. Replaces InstantDB-backed `db` with an
+// in-memory fake (see ./demoDb) when active. Resolution and writes guard
+// on `import.meta.env.DEV` so production builds tree-shake this module
+// out entirely.
+
+const STORAGE_KEY = "xarji-demo-mode";
+
+export type DemoSeed = "default" | "empty";
+export type DemoSelection = DemoSeed | "off";
+
+function readUrlOverride(): DemoSelection | null {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has("demo")) return null;
+  const raw = (params.get("demo") || "").toLowerCase();
+
+  let result: DemoSelection;
+  if (raw === "0" || raw === "off" || raw === "false") result = "off";
+  else if (raw === "empty") result = "empty";
+  else result = "default";
+
+  // Strip the param so it doesn't end up in screen captures of the demo.
+  params.delete("demo");
+  const search = params.toString();
+  const url = `${window.location.pathname}${search ? `?${search}` : ""}${window.location.hash}`;
+  window.history.replaceState({}, "", url);
+  return result;
+}
+
+function readStorage(): DemoSeed | null {
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    if (v === "default" || v === "empty") return v;
+  } catch {
+    /* private browsing / storage disabled — treat as off */
+  }
+  return null;
+}
+
+function writeStorage(value: DemoSeed | null) {
+  try {
+    if (value === null) window.localStorage.removeItem(STORAGE_KEY);
+    else window.localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    /* ignore */
+  }
+}
+
+let cached: DemoSeed | null = null;
+let resolved = false;
+
+function resolve(): DemoSeed | null {
+  if (resolved) return cached;
+  resolved = true;
+  if (!import.meta.env.DEV) {
+    cached = null;
+    return cached;
+  }
+
+  const url = readUrlOverride();
+  if (url === "off") {
+    writeStorage(null);
+    cached = null;
+    return cached;
+  }
+  if (url !== null) {
+    writeStorage(url);
+    cached = url;
+    return cached;
+  }
+  cached = readStorage();
+  return cached;
+}
+
+export function isDemoMode(): boolean {
+  return resolve() !== null;
+}
+
+export function getDemoSeed(): DemoSeed {
+  return resolve() ?? "default";
+}
+
+export function getCurrentDemoSelection(): DemoSelection {
+  return resolve() ?? "off";
+}
+
+// Persists the choice and reloads the page. The dashboard owns long-lived
+// InstantDB subscriptions; swapping the client live would risk leaking
+// listeners, so we always reload to get a clean module evaluation.
+export function setDemoMode(value: DemoSelection): void {
+  if (!import.meta.env.DEV) return;
+  writeStorage(value === "off" ? null : value);
+  window.location.reload();
+}

--- a/client/src/hooks/useAIKeyStatus.ts
+++ b/client/src/hooks/useAIKeyStatus.ts
@@ -1,0 +1,29 @@
+// Tracks which provider keys are configured on the service. Source of
+// truth is /api/ai/keys; we re-fetch on mount and on the `xarji-ai-keys
+// -changed` event the save/delete helpers dispatch.
+
+import { useEffect, useState } from "react";
+import { fetchKeyStatus, onKeyStatusChange, type AIKeyStatus } from "../lib/aiConfig";
+
+export function useAIKeyStatus(): { status: AIKeyStatus; isLoading: boolean; refresh: () => void } {
+  const [status, setStatus] = useState<AIKeyStatus>({ anthropic: false, openai: false });
+  const [isLoading, setIsLoading] = useState(true);
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    fetchKeyStatus().then((next) => {
+      if (cancelled) return;
+      setStatus(next);
+      setIsLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [version]);
+
+  useEffect(() => onKeyStatusChange(() => setVersion((v) => v + 1)), []);
+
+  return { status, isLoading, refresh: () => setVersion((v) => v + 1) };
+}

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -7,6 +7,7 @@ import { useConvertedPayments, useFailedPayments } from "./useTransactions";
 import { useConvertedCredits } from "./useCredits";
 import { useCategories } from "./useCategories";
 import { useBankSenders } from "./useBankSenders";
+import { useCategorizer } from "./useCategorizer";
 import { getProviderClient } from "../lib/ai/provider";
 import { runAgent, type AssistantEvent } from "../lib/ai/orchestrator";
 import { READONLY_TOOLS } from "../lib/ai/tools/readonly";
@@ -113,6 +114,7 @@ export function useAgentRunner() {
   const { failedPayments } = useFailedPayments();
   const { categories } = useCategories();
   const { senders } = useBankSenders();
+  const { categorizeName } = useCategorizer();
 
   return useCallback(
     async (
@@ -135,11 +137,12 @@ export function useAgentRunner() {
           categories,
           bankSenders: senders,
           now: new Date(),
+          categorizeName,
         },
         emit,
         signal,
       });
     },
-    [payments, credits, failedPayments, categories, senders]
+    [payments, credits, failedPayments, categories, senders, categorizeName]
   );
 }

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -1,0 +1,145 @@
+// Bridges the live React-side data (payments, credits, categories,
+// etc.) into the provider-agnostic orchestrator. Returns a `runAgent`
+// function the AssistantChat calls per user prompt.
+
+import { useCallback } from "react";
+import { useConvertedPayments, useFailedPayments } from "./useTransactions";
+import { useConvertedCredits } from "./useCredits";
+import { useCategories } from "./useCategories";
+import { useBankSenders } from "./useBankSenders";
+import { getProviderClient } from "../lib/ai/provider";
+import { runAgent, type AssistantEvent } from "../lib/ai/orchestrator";
+import { READONLY_TOOLS } from "../lib/ai/tools/readonly";
+import type { AITool } from "../lib/ai/tools/types";
+import type { AIConfig } from "../lib/aiConfig";
+
+// Tool registries the agent has access to. Adding a tool to one of
+// these lists automatically (a) makes it callable by the model and
+// (b) appends it to the "Available tools" section of the system
+// prompt — see buildSystemPrompt() below. Adding a NEW registry?
+// Concatenate it into ALL_TOOLS so both effects happen.
+const ALL_TOOLS: AITool[] = [...READONLY_TOOLS];
+
+const BASE_SYSTEM_PROMPT = `You are Xarji's AI Assistant, a personal finance assistant embedded inside the Xarji dashboard.
+
+Xarji context:
+- Xarji is a private, local-first personal finance app.
+- It parses Georgian bank SMS notifications from banks such as TBC, Bank of Georgia, SOLO, and others.
+- Parsed SMS messages become transactions stored locally on the user's own machine.
+- The user is one person looking at their own spending, income, transfers, balances, merchants, and categories.
+- There are no teams, shared workspaces, company accounts, or multi-user permissions.
+- All money values shown to the user should be treated as GEL equivalents.
+- If a transaction was originally in USD, EUR, or another currency, Xarji converts it using the National Bank of Georgia exchange rate for the transaction date.
+- Assume the dashboard data is the source of truth when tools are available.
+
+Core behavior:
+- Help the user understand their money clearly.
+- Explain spending, income, trends, categories, merchants, unusual changes, and possible savings.
+- Be practical, not theoretical.
+- Prefer simple explanations that a normal person can understand.
+- Avoid sounding like a financial analyst unless the user asks for deep analysis.
+- Percentages and numbers are important, but explain what they mean in plain language.
+- When giving analysis, connect numbers to real-life meaning.
+
+Tool usage:
+- Use tools whenever the user asks about real data, exact numbers, transactions, balances, categories, merchants, trends, comparisons, or time periods.
+- Do not guess specific financial numbers from memory.
+- Do not invent transactions, merchants, totals, dates, categories, or exchange rates.
+- For purely conversational, educational, or general budgeting questions, a tool call is not required.
+- Tools are read-only. Do not claim that you changed, deleted, categorized, edited, or created anything.
+
+Answer style:
+- Be concise and clear.
+- Use simple language.
+- Use short paragraphs.
+- Use markdown sparingly.
+- Use bullet lists only when they make the answer easier to read.
+- Use **bold** only for important labels or conclusions.
+- Use \`backticks\` for amounts, merchants, categories, and transaction names when helpful.
+- Do not use em dashes. Use commas, periods, or parentheses instead.
+- Avoid complicated mathematical wording.
+- Avoid long financial jargon.
+- If you mention percentages, also explain them in human terms.
+- Prefer saying "You spent 18% more on restaurants, mostly because of 3 larger payments" instead of "Restaurant expenditure increased by 18% due to outlier-driven variance."
+
+Tone:
+- Friendly, calm, and direct.
+- Sound like a helpful money coach, not a bank, accountant, or enterprise BI tool.
+- Do not shame the user for spending.
+- Be honest about uncertainty.
+- If the data is incomplete, say so clearly.
+- If something looks unusual, describe it as unusual rather than suspicious unless there is strong evidence.
+
+Financial guidance boundaries:
+- You may help with budgeting, spending awareness, saving ideas, and personal finance organization.
+- Do not give regulated investment, tax, legal, or accounting advice.
+- Do not tell the user what investment to buy or sell.
+- If the user asks for serious financial, tax, legal, or debt advice, give general guidance and recommend checking with a qualified professional.
+
+Reasoning approach:
+- First understand what the user is asking.
+- If exact dashboard data is needed, call the relevant tool.
+- Compare against the right period when useful, for example previous month, same period last month, or category average.
+- Highlight the biggest drivers first.
+- Avoid over-explaining small changes.
+- Prefer practical conclusions over raw tables.
+- End analytical answers with one specific actionable suggestion when useful.
+
+Examples of good responses:
+- "You spent \`₾420\` on restaurants this month. That is \`₾95\` more than last month, about \`29%\` higher. Most of the increase came from two larger payments at \`Restaurant X\` and \`Cafe Y\`."
+- "Your transport spending is stable. It changed by only \`₾12\`, so there is probably nothing important to fix there."
+- "The easiest saving opportunity is delivery food. Cutting just two orders per week would likely save around \`₾120-₾180\` per month."
+
+Your goal:
+Make the user's financial data understandable, useful, and actionable without making them feel judged or overwhelmed.`;
+
+// Composes the final system prompt sent to the provider: the static
+// BASE prompt above, plus a generated "Available tools" section so the
+// model has every registered tool's name + description in context. The
+// generated list is the source of truth — there is no hand-maintained
+// duplicate to drift.
+function buildSystemPrompt(tools: AITool[]): string {
+  if (tools.length === 0) return BASE_SYSTEM_PROMPT;
+  const lines = tools.map((t) => `- \`${t.definition.name}\` — ${t.definition.description}`);
+  return `${BASE_SYSTEM_PROMPT}
+
+Available tools:
+${lines.join("\n")}`;
+}
+
+export function useAgentRunner() {
+  const { payments } = useConvertedPayments();
+  const { credits } = useConvertedCredits();
+  const { failedPayments } = useFailedPayments();
+  const { categories } = useCategories();
+  const { senders } = useBankSenders();
+
+  return useCallback(
+    async (
+      config: AIConfig,
+      userPrompt: string,
+      emit: (event: AssistantEvent) => void,
+      signal?: AbortSignal
+    ): Promise<void> => {
+      const provider = await getProviderClient(config.provider, config.apiKey);
+      await runAgent({
+        provider,
+        model: config.model,
+        systemPrompt: buildSystemPrompt(ALL_TOOLS),
+        userPrompt,
+        tools: ALL_TOOLS,
+        toolContext: {
+          payments,
+          credits,
+          failedPayments,
+          categories,
+          bankSenders: senders,
+          now: new Date(),
+        },
+        emit,
+        signal,
+      });
+    },
+    [payments, credits, failedPayments, categories, senders]
+  );
+}

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -121,7 +121,7 @@ export function useAgentRunner() {
       emit: (event: AssistantEvent) => void,
       signal?: AbortSignal
     ): Promise<void> => {
-      const provider = await getProviderClient(config.provider, config.apiKey);
+      const provider = getProviderClient(config.provider);
       await runAgent({
         provider,
         model: config.model,

--- a/client/src/hooks/useCategories.ts
+++ b/client/src/hooks/useCategories.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { db, type Category } from "../lib/instant";
-import { DEFAULT_CATEGORIES, autoCategorize } from "../lib/utils";
+import { DEFAULT_CATEGORIES } from "../lib/utils";
+import { useCategorizer } from "./useCategorizer";
 import { id } from "@instantdb/react";
 
 export function useCategories() {
@@ -56,6 +57,7 @@ export function useCategoryActions() {
 export function useCategoryAnalytics() {
   const { categories } = useCategories();
   const { data: paymentsData } = db.useQuery({ payments: {} });
+  const { categorizeName } = useCategorizer();
 
   return useMemo(() => {
     const payments = paymentsData?.payments || [];
@@ -78,9 +80,11 @@ export function useCategoryAnalytics() {
       categoryTotals["Other"] = { total: 0, count: 0, color: "#6b7280" };
     }
 
-    // Categorize payments
+    // Categorize payments — uses the override-aware categoriser so a
+    // user's manual "Spotify → Subscriptions" override propagates here
+    // even though the regex default puts it under "Other".
     for (const payment of payments) {
-      const categoryName = autoCategorize(payment.merchant ?? null);
+      const categoryName = categorizeName(payment.merchant ?? null);
       if (categoryTotals[categoryName]) {
         categoryTotals[categoryName].total += payment.amount;
         categoryTotals[categoryName].count += 1;
@@ -106,5 +110,5 @@ export function useCategoryAnalytics() {
         percentage: totalSpent > 0 ? (cat.total / totalSpent) * 100 : 0,
       })),
     };
-  }, [categories, paymentsData?.payments]);
+  }, [categories, paymentsData?.payments, categorizeName]);
 }

--- a/client/src/hooks/useCategorizer.ts
+++ b/client/src/hooks/useCategorizer.ts
@@ -1,0 +1,64 @@
+// Override-aware categoriser. Looks up the merchant's manual override
+// first; falls back to the regex-based default. Both `categorize` (id)
+// and `getCategory` (full record) are returned so call sites can keep
+// the same shape they had with the static helpers in lib/utils.ts.
+//
+// Use this anywhere a single transaction needs a category, in place of
+// the static `getCategory(merchant, raw)` / `categorizeId(...)` from
+// lib/utils.ts. The static helpers stay around for code paths that
+// need a synchronous answer without React state (e.g. data seeders).
+
+import { useCallback, useMemo } from "react";
+import {
+  DEFAULT_CATEGORIES,
+  categorizeId,
+  getCategory as defaultGetCategory,
+  type InkCategory,
+} from "../lib/utils";
+import { useMerchantOverrides } from "./useMerchantOverrides";
+
+export interface Categorizer {
+  /** Returns the category id (e.g. "groceries") for a merchant. */
+  categorize: (merchant: string | null | undefined, raw?: string | null) => string;
+  /** Returns the full InkCategory record with name + color + icon. */
+  getCategory: (merchant: string | null | undefined, raw?: string | null) => InkCategory;
+  /** Convenience for places that historically called `autoCategorize`
+   *  to get the human-facing category name (e.g. "Groceries"). */
+  categorizeName: (merchant: string | null | undefined) => string;
+}
+
+export function useCategorizer(): Categorizer {
+  const { byMerchant } = useMerchantOverrides();
+
+  const getCategory = useCallback(
+    (merchant: string | null | undefined, raw?: string | null): InkCategory => {
+      if (merchant) {
+        const override = byMerchant.get(merchant.trim().toLowerCase());
+        if (override) {
+          const hit = DEFAULT_CATEGORIES.find((c) => c.id === override.categoryId);
+          if (hit) return hit;
+        }
+      }
+      return defaultGetCategory(merchant, raw);
+    },
+    [byMerchant]
+  );
+
+  const categorize = useCallback(
+    (merchant: string | null | undefined, raw?: string | null): string => {
+      if (merchant) {
+        const override = byMerchant.get(merchant.trim().toLowerCase());
+        if (override) return override.categoryId;
+      }
+      return categorizeId(merchant, raw);
+    },
+    [byMerchant]
+  );
+
+  const categorizeName = useCallback(
+    (merchant: string | null | undefined): string => getCategory(merchant).name,
+    [getCategory]
+  );
+
+  return useMemo(() => ({ categorize, getCategory, categorizeName }), [categorize, getCategory, categorizeName]);
+}

--- a/client/src/hooks/useMerchantOverrides.ts
+++ b/client/src/hooks/useMerchantOverrides.ts
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import { id as instantId } from "@instantdb/react";
+import { db, type MerchantCategoryOverride } from "../lib/instant";
+
+export function useMerchantOverrides() {
+  const { data } = db.useQuery({ merchantCategoryOverrides: {} });
+
+  const overrides = useMemo<MerchantCategoryOverride[]>(
+    () => data?.merchantCategoryOverrides ?? [],
+    [data?.merchantCategoryOverrides]
+  );
+
+  // Indexed-by-merchant lookup. Merchant names land in user-visible
+  // strings so we lower-case for matching, otherwise "Wolt" and "wolt"
+  // would override independently and the UI would silently disagree
+  // with itself.
+  const byMerchant = useMemo(() => {
+    const m = new Map<string, MerchantCategoryOverride>();
+    for (const o of overrides) m.set(o.merchant.toLowerCase(), o);
+    return m;
+  }, [overrides]);
+
+  const setOverride = async (merchant: string, categoryId: string): Promise<void> => {
+    const key = merchant.trim();
+    if (!key) return;
+    const existing = byMerchant.get(key.toLowerCase());
+    const opId = existing?.id ?? instantId();
+    await db.transact(
+      db.tx.merchantCategoryOverrides[opId].update({
+        merchant: key,
+        categoryId,
+        createdAt: existing?.createdAt ?? Date.now(),
+      })
+    );
+  };
+
+  const clearOverride = async (merchant: string): Promise<void> => {
+    const existing = byMerchant.get(merchant.trim().toLowerCase());
+    if (!existing) return;
+    await db.transact(db.tx.merchantCategoryOverrides[existing.id].delete());
+  };
+
+  return { overrides, byMerchant, setOverride, clearOverride };
+}

--- a/client/src/hooks/useMonthlyAnalytics.ts
+++ b/client/src/hooks/useMonthlyAnalytics.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { db } from "../lib/instant";
-import { DEFAULT_CATEGORIES, autoCategorize } from "../lib/utils";
+import { DEFAULT_CATEGORIES } from "../lib/utils";
+import { useCategorizer } from "./useCategorizer";
 import { formatLocalDay } from "../ink/format";
 import { useConvertedPayments } from "./useTransactions";
 import {
@@ -167,6 +168,7 @@ export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
 export function useMonthCategoryAnalytics(my: MonthYear) {
   const { payments } = useConvertedPayments();
   const { data: catData } = db.useQuery({ categories: {} });
+  const { categorizeName } = useCategorizer();
 
   return useMemo(() => {
     const categories = catData?.categories || [];
@@ -188,7 +190,7 @@ export function useMonthCategoryAnalytics(my: MonthYear) {
 
     for (const payment of monthPayments) {
       if (payment.gelAmount === null) continue;
-      const categoryName = autoCategorize(payment.merchant ?? null);
+      const categoryName = categorizeName(payment.merchant ?? null);
       if (categoryTotals[categoryName]) {
         categoryTotals[categoryName].total += payment.gelAmount;
         categoryTotals[categoryName].count += 1;
@@ -213,5 +215,5 @@ export function useMonthCategoryAnalytics(my: MonthYear) {
         percentage: totalSpent > 0 ? (cat.total / totalSpent) * 100 : 0,
       })),
     };
-  }, [payments, catData?.categories, my.month, my.year]);
+  }, [payments, catData?.categories, my.month, my.year, categorizeName]);
 }

--- a/client/src/ink/Sidebar.tsx
+++ b/client/src/ink/Sidebar.tsx
@@ -8,6 +8,7 @@ interface SidebarItem {
   name: string;
   glyph: string;
   badge?: string;
+  pillBadge?: string;
 }
 
 export function Sidebar({
@@ -27,6 +28,7 @@ export function Sidebar({
     { to: "/income", name: "Income", glyph: "↓", badge: incomeCount ? incomeCount.toLocaleString("en-US") : undefined },
     { to: "/categories", name: "Categories", glyph: "◐" },
     { to: "/merchants", name: "Merchants", glyph: "◆" },
+    { to: "/assistant", name: "Assistant", glyph: "✧", pillBadge: "NEW" },
     { to: "/signals", name: "Signals", glyph: "✦", badge: signalsCount ? String(signalsCount) : undefined },
     { to: "/manage", name: "Manage", glyph: "⚙" },
   ];
@@ -75,6 +77,22 @@ export function Sidebar({
               <>
                 <span style={{ fontFamily: T.mono, fontSize: 12, opacity: 0.85 }}>{it.glyph}</span>
                 <span style={{ flex: 1 }}>{it.name}</span>
+                {it.pillBadge && (
+                  <span
+                    style={{
+                      fontFamily: T.sans,
+                      fontSize: 9,
+                      fontWeight: 800,
+                      letterSpacing: 0.5,
+                      padding: "2px 6px",
+                      borderRadius: 4,
+                      background: isActive ? "rgba(12,12,14,0.12)" : T.accent,
+                      color: isActive ? T.bg : "#fff",
+                    }}
+                  >
+                    {it.pillBadge}
+                  </span>
+                )}
                 {it.badge && (
                   <span
                     style={{

--- a/client/src/ink/TweaksPanel.tsx
+++ b/client/src/ink/TweaksPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useTheme, useTweaks, type InkAccent, type InkMode, type InkDensity, type InkFontPair, type InkCurrencyMode, type InkTimeDefault } from "./theme";
+import { getCurrentDemoSelection, setDemoMode, type DemoSelection } from "../dev/demoMode";
 
 const ACCENT_SWATCHES: { id: InkAccent; hex: string }[] = [
   { id: "coral", hex: "#ff5a3a" },
@@ -20,34 +21,74 @@ export function TweaksPanel() {
   const T = useTheme();
   const { tweaks, setTweaks } = useTweaks();
   const [open, setOpen] = useState(false);
+  const [switching, setSwitching] = useState<string | null>(null);
+
+  const handleDemoChange = (target: DemoSelection) => {
+    if (target === getCurrentDemoSelection()) return;
+    setSwitching(
+      target === "off"
+        ? "Restoring real data…"
+        : target === "empty"
+          ? "Loading empty demo…"
+          : "Loading rich demo…"
+    );
+    // Brief delay so the overlay actually paints before the reload
+    // navigates the document — keeps on-camera switches tidy.
+    window.setTimeout(() => setDemoMode(target), 350);
+  };
+
+  const overlay = switching && (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: T.bg,
+        opacity: 0.94,
+        zIndex: 200,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: T.sans,
+        color: T.text,
+        fontSize: 14,
+        fontWeight: 600,
+        letterSpacing: 0.2,
+      }}
+    >
+      {switching}
+    </div>
+  );
 
   if (!open) {
     return (
-      <button
-        onClick={() => setOpen(true)}
-        title="Tweaks"
-        style={{
-          position: "fixed",
-          right: 20,
-          bottom: 20,
-          width: 42,
-          height: 42,
-          borderRadius: 21,
-          border: `1px solid ${T.lineStrong}`,
-          background: T.panel,
-          color: T.text,
-          cursor: "pointer",
-          fontSize: 16,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontFamily: T.sans,
-          boxShadow: T.shadow,
-          zIndex: 100,
-        }}
-      >
-        ✦
-      </button>
+      <>
+        {overlay}
+        <button
+          onClick={() => setOpen(true)}
+          title="Tweaks"
+          style={{
+            position: "fixed",
+            right: 20,
+            bottom: 20,
+            width: 42,
+            height: 42,
+            borderRadius: 21,
+            border: `1px solid ${T.lineStrong}`,
+            background: T.panel,
+            color: T.text,
+            cursor: "pointer",
+            fontSize: 16,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontFamily: T.sans,
+            boxShadow: T.shadow,
+            zIndex: 100,
+          }}
+        >
+          ✦
+        </button>
+      </>
     );
   }
 
@@ -86,23 +127,25 @@ export function TweaksPanel() {
   );
 
   return (
-    <div
-      style={{
-        position: "fixed",
-        right: 20,
-        bottom: 20,
-        width: 280,
-        background: T.panel,
-        border: `1px solid ${T.lineStrong}`,
-        borderRadius: T.rLg,
-        padding: 16,
-        boxShadow: T.shadow,
-        zIndex: 100,
-        display: "flex",
-        flexDirection: "column",
-        gap: 12,
-      }}
-    >
+    <>
+      {overlay}
+      <div
+        style={{
+          position: "fixed",
+          right: 20,
+          bottom: 20,
+          width: 280,
+          background: T.panel,
+          border: `1px solid ${T.lineStrong}`,
+          borderRadius: T.rLg,
+          padding: 16,
+          boxShadow: T.shadow,
+          zIndex: 100,
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+        }}
+      >
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <div style={{ fontSize: 13, fontWeight: 700, color: T.text, fontFamily: T.sans }}>Tweaks</div>
         <button
@@ -182,6 +225,18 @@ export function TweaksPanel() {
           {tweaks.chartsVisible ? "Visible" : "Hidden"}
         </button>
       </div>
-    </div>
+
+      {import.meta.env.DEV && (
+        <div style={{ borderTop: `1px solid ${T.line}`, paddingTop: 12 }}>
+          <SectionLabel>Demo data (dev)</SectionLabel>
+          <ChipRow
+            options={["off", "default", "empty"]}
+            value={getCurrentDemoSelection()}
+            onChange={(v) => handleDemoChange(v as DemoSelection)}
+          />
+        </div>
+      )}
+      </div>
+    </>
   );
 }

--- a/client/src/ink/TxRow.tsx
+++ b/client/src/ink/TxRow.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import { useTheme, useViewport } from "./theme";
 import { Pill } from "./primitives";
-import { getCategory } from "../lib/utils";
+import { useCategorizer } from "../hooks/useCategorizer";
+import { CategoryPicker } from "../components/CategoryPicker";
 import { formatTime, currencySymbol } from "./format";
 
 export interface InkTx {
@@ -33,9 +35,15 @@ export function TxRow({
 }) {
   const T = useTheme();
   const vp = useViewport();
+  const { getCategory } = useCategorizer();
   const cat = getCategory(t.merchant, t.rawMerchant);
   const failed = t.kind === "failed";
   const credit = t.kind === "credit";
+  const [pickerOpen, setPickerOpen] = useState(false);
+  // The picker only makes sense for payments — credits don't carry a
+  // user-meaningful category, and overriding a declined transaction's
+  // categorisation has no downstream effect either.
+  const canChangeCategory = t.kind === "payment" && !!t.merchant;
   const pad = compact ? "10px 0" : T.density.rowPad;
   const isFx = (t.kind === "payment" || t.kind === "credit") && t.currency !== "GEL";
   const cols = vp.narrow ? "32px 1fr 90px" : "36px 1fr 110px 110px 90px";
@@ -64,6 +72,7 @@ export function TxRow({
         borderBottom: isLast ? "none" : `1px solid ${T.line}`,
         alignItems: "center",
         cursor: onClick ? "pointer" : "default",
+        position: "relative",
       }}
     >
       <div
@@ -128,8 +137,56 @@ export function TxRow({
         </div>
       </div>
       {!vp.narrow && (
-        <div style={{ fontFamily: T.sans, fontSize: 12, color: T.muted, fontWeight: 500 }}>
-          {credit ? "Income" : cat?.name}
+        <div style={{ fontFamily: T.sans, fontSize: 12, fontWeight: 500, position: "relative" }}>
+          {canChangeCategory ? (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setPickerOpen((o) => !o);
+              }}
+              title="Change category"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "4px 8px",
+                margin: "-4px -8px",
+                borderRadius: 6,
+                background: pickerOpen ? T.panelAlt : "transparent",
+                border: "none",
+                color: T.muted,
+                fontSize: 12,
+                fontFamily: T.sans,
+                cursor: "pointer",
+                transition: "background .12s ease",
+              }}
+              onMouseEnter={(e) => {
+                if (!pickerOpen) (e.currentTarget as HTMLButtonElement).style.background = T.panelAlt;
+              }}
+              onMouseLeave={(e) => {
+                if (!pickerOpen) (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+              }}
+            >
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: 4,
+                  background: cat?.color ?? T.muted,
+                }}
+              />
+              {cat?.name}
+            </button>
+          ) : (
+            <span style={{ color: T.muted }}>{credit ? "Income" : cat?.name}</span>
+          )}
+          {pickerOpen && cat && (
+            <CategoryPicker
+              merchant={t.merchant}
+              current={cat}
+              onClose={() => setPickerOpen(false)}
+            />
+          )}
         </div>
       )}
       {!vp.narrow && (

--- a/client/src/lib/ai/orchestrator.ts
+++ b/client/src/lib/ai/orchestrator.ts
@@ -1,0 +1,194 @@
+// Provider-agnostic agent loop. Streams events from the provider,
+// dispatches tool calls against the local tool registry, feeds the
+// results back, and repeats until the model returns end_turn (or hits
+// the safety cap). Emits a single event stream the chat UI consumes —
+// text deltas, tool diagnostics, and structured cards from tools that
+// expose a `toBlock` mapping.
+
+import type {
+  AICoreMessage,
+  AIContentPart,
+  AIProviderClient,
+  AIStreamEvent,
+} from "./types";
+import type { AIBlock } from "../aiThreads";
+import type { AITool, AIToolContext } from "./tools/types";
+
+/** Cap on provider→tool→provider loops to prevent runaway agentic
+ *  behaviour. Most user prompts complete in 1-3 iterations. */
+const MAX_ITERATIONS = 8;
+
+export type AssistantEvent =
+  | { type: "text-delta"; text: string }
+  | { type: "block"; block: AIBlock }
+  /** Updates the chat's loading indicator label. The orchestrator
+   *  emits these around provider calls and tool executions; the chat
+   *  shows the latest one until the next text-delta arrives. */
+  | { type: "status"; text: string };
+
+export interface RunAgentOpts {
+  provider: AIProviderClient;
+  model: string;
+  systemPrompt: string;
+  userPrompt: string;
+  tools: AITool[];
+  toolContext: AIToolContext;
+  emit: (event: AssistantEvent) => void;
+  signal?: AbortSignal;
+}
+
+export async function runAgent(opts: RunAgentOpts): Promise<void> {
+  const messages: AICoreMessage[] = [
+    { role: "user", content: opts.userPrompt },
+  ];
+  const toolDefs = opts.tools.map((t) => t.definition);
+  const toolByName = new Map(opts.tools.map((t) => [t.definition.name, t]));
+
+  for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
+    if (opts.signal?.aborted) return;
+
+    opts.emit({ type: "status", text: iter === 0 ? "Thinking…" : "Working through it…" });
+
+    let assistantText = "";
+    const pendingTools: Array<{ id: string; name: string; input: unknown }> = [];
+    let stopReason: AIStreamEvent["kind"] = "stop";
+    let streamError: unknown = null;
+
+    for await (const ev of opts.provider.stream({
+      model: opts.model,
+      systemPrompt: opts.systemPrompt,
+      messages,
+      tools: toolDefs,
+      signal: opts.signal,
+    })) {
+      if (opts.signal?.aborted) return;
+
+      if (ev.kind === "text-delta") {
+        assistantText += ev.text;
+        opts.emit({ type: "text-delta", text: ev.text });
+      } else if (ev.kind === "tool-call") {
+        pendingTools.push({ id: ev.id, name: ev.name, input: ev.input });
+      } else if (ev.kind === "stop") {
+        stopReason = "stop";
+        if (ev.reason === "refusal") {
+          opts.emit({
+            type: "block",
+            block: {
+              kind: "text",
+              text: "_The model declined to answer this request._",
+            },
+          });
+          return;
+        }
+        if (ev.reason === "max_tokens") {
+          opts.emit({
+            type: "block",
+            block: {
+              kind: "text",
+              text: "_Response truncated — hit the token cap._",
+            },
+          });
+        }
+      } else if (ev.kind === "error") {
+        streamError = ev.error;
+      }
+    }
+
+    if (streamError) {
+      const message = streamError instanceof Error ? streamError.message : String(streamError);
+      opts.emit({
+        type: "block",
+        block: {
+          kind: "text",
+          text: `_Provider error: ${message}_`,
+        },
+      });
+      return;
+    }
+
+    // No tool calls — assistant turn is done.
+    if (pendingTools.length === 0) {
+      void stopReason;
+      return;
+    }
+
+    // Build the assistant content (text + tool_use blocks) so the next
+    // provider call sees the full context.
+    const assistantContent: AIContentPart[] = [];
+    if (assistantText) assistantContent.push({ type: "text", text: assistantText });
+    for (const t of pendingTools) {
+      assistantContent.push({
+        type: "tool_use",
+        id: t.id,
+        name: t.name,
+        input: t.input,
+      });
+    }
+    messages.push({ role: "assistant", content: assistantContent });
+
+    // Execute each tool, emit a compact ToolCard pill (no JSON body —
+    // raw input/output is noise to the user; the friendly status text
+    // already tells them what we're doing), plus any structured block
+    // the tool produces via toBlock(). Collect results to feed back to
+    // the model.
+    const toolResults: AIContentPart[] = [];
+    for (const tc of pendingTools) {
+      if (opts.signal?.aborted) return;
+      const tool = toolByName.get(tc.name);
+      opts.emit({
+        type: "status",
+        text: tool?.statusText ?? `Running ${tc.name}…`,
+      });
+      const startedAt = performance.now();
+      let output: unknown;
+      let isError = false;
+      try {
+        if (!tool) throw new Error(`Unknown tool: ${tc.name}`);
+        output = await tool.executor(tc.input as Record<string, unknown>, opts.toolContext);
+      } catch (err) {
+        output = { error: err instanceof Error ? err.message : String(err) };
+        isError = true;
+      }
+      const durationMs = Math.round(performance.now() - startedAt);
+
+      opts.emit({
+        type: "block",
+        block: {
+          kind: "tool",
+          name: tc.name,
+          duration: durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(1)}s`,
+          body: "",
+        },
+      });
+
+      if (tool?.toBlock) {
+        const block = tool.toBlock(output);
+        if (block) opts.emit({ type: "block", block });
+      }
+
+      const outputJson = (() => {
+        try {
+          return JSON.stringify(output);
+        } catch {
+          return String(output);
+        }
+      })();
+      toolResults.push({
+        type: "tool_result",
+        toolUseId: tc.id,
+        output: outputJson,
+        isError,
+      });
+    }
+
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  opts.emit({
+    type: "block",
+    block: {
+      kind: "text",
+      text: "_Reached the iteration cap — stopping here. Try a more specific prompt._",
+    },
+  });
+}

--- a/client/src/lib/ai/provider.ts
+++ b/client/src/lib/ai/provider.ts
@@ -1,0 +1,32 @@
+// Loads the provider implementation lazily so the inactive SDK never
+// reaches the user's bundle. Each provider is its own dynamic-import
+// chunk; switching providers in Settings doesn't require a reload to
+// download the new SDK — just the next `getProviderClient()` call.
+
+import type { AIProviderClient } from "./types";
+import type { AIProviderId } from "../aiConfig";
+
+const cache = new Map<string, AIProviderClient>();
+
+function cacheKey(id: AIProviderId, apiKey: string): string {
+  return `${id}::${apiKey}`;
+}
+
+export async function getProviderClient(id: AIProviderId, apiKey: string): Promise<AIProviderClient> {
+  const key = cacheKey(id, apiKey);
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  let client: AIProviderClient;
+  if (id === "anthropic") {
+    const mod = await import("./providers/anthropic");
+    client = mod.makeAnthropicProvider(apiKey);
+  } else if (id === "openai") {
+    const mod = await import("./providers/openai");
+    client = mod.makeOpenAIProvider(apiKey);
+  } else {
+    throw new Error(`Unknown AI provider: ${id}`);
+  }
+  cache.set(key, client);
+  return client;
+}

--- a/client/src/lib/ai/provider.ts
+++ b/client/src/lib/ai/provider.ts
@@ -1,32 +1,19 @@
-// Loads the provider implementation lazily so the inactive SDK never
-// reaches the user's bundle. Each provider is its own dynamic-import
-// chunk; switching providers in Settings doesn't require a reload to
-// download the new SDK — just the next `getProviderClient()` call.
+// Returns the service-proxy client for the given provider id. There's
+// no longer a per-provider browser SDK to dynamically import — the
+// service holds the keys and routes to api.anthropic.com /
+// api.openai.com itself. The dashboard speaks SSE to /api/ai/stream
+// regardless of which model the user picked.
 
+import { makeServiceProvider } from "./providers/service";
 import type { AIProviderClient } from "./types";
 import type { AIProviderId } from "../aiConfig";
 
-const cache = new Map<string, AIProviderClient>();
+const cache = new Map<AIProviderId, AIProviderClient>();
 
-function cacheKey(id: AIProviderId, apiKey: string): string {
-  return `${id}::${apiKey}`;
-}
-
-export async function getProviderClient(id: AIProviderId, apiKey: string): Promise<AIProviderClient> {
-  const key = cacheKey(id, apiKey);
-  const hit = cache.get(key);
+export function getProviderClient(id: AIProviderId): AIProviderClient {
+  const hit = cache.get(id);
   if (hit) return hit;
-
-  let client: AIProviderClient;
-  if (id === "anthropic") {
-    const mod = await import("./providers/anthropic");
-    client = mod.makeAnthropicProvider(apiKey);
-  } else if (id === "openai") {
-    const mod = await import("./providers/openai");
-    client = mod.makeOpenAIProvider(apiKey);
-  } else {
-    throw new Error(`Unknown AI provider: ${id}`);
-  }
-  cache.set(key, client);
+  const client = makeServiceProvider(id);
+  cache.set(id, client);
   return client;
 }

--- a/client/src/lib/ai/providers/anthropic.ts
+++ b/client/src/lib/ai/providers/anthropic.ts
@@ -1,0 +1,145 @@
+// Anthropic provider — uses client.messages.stream() with adaptive
+// thinking (per the claude-api skill default for anything non-trivial).
+// Browser usage requires `dangerouslyAllowBrowser: true`; XSS-exfil
+// risk is acceptable here because Xarji is a single-user local-first
+// app with no third-party scripts on the page.
+
+import Anthropic from "@anthropic-ai/sdk";
+import type {
+  AICoreMessage,
+  AIProviderClient,
+  AIStreamEvent,
+  AIStreamOpts,
+  AIStopReason,
+} from "../types";
+
+export function makeAnthropicProvider(apiKey: string): AIProviderClient {
+  const client = new Anthropic({
+    apiKey,
+    dangerouslyAllowBrowser: true,
+  });
+
+  return {
+    id: "anthropic",
+    async *stream(opts: AIStreamOpts): AsyncIterable<AIStreamEvent> {
+      const messages = opts.messages.map(toAnthropicMessage);
+      const tools = opts.tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.inputSchema as Anthropic.Tool["input_schema"],
+      }));
+
+      // Tool input arrives as JSON streamed over multiple deltas. Buffer
+      // by content-block index and finalize on content_block_stop.
+      const toolBuffers = new Map<number, { id: string; name: string; jsonText: string }>();
+      let stopReason: AIStopReason = "other";
+
+      const stream = client.messages.stream({
+        model: opts.model,
+        max_tokens: 16000,
+        thinking: { type: "adaptive" },
+        system: opts.systemPrompt,
+        messages,
+        tools: tools.length > 0 ? tools : undefined,
+      });
+
+      try {
+        for await (const event of stream) {
+          if (opts.signal?.aborted) {
+            stream.controller.abort();
+            return;
+          }
+
+          if (event.type === "content_block_start") {
+            if (event.content_block.type === "tool_use") {
+              toolBuffers.set(event.index, {
+                id: event.content_block.id,
+                name: event.content_block.name,
+                jsonText: "",
+              });
+            }
+          } else if (event.type === "content_block_delta") {
+            if (event.delta.type === "text_delta") {
+              yield { kind: "text-delta", text: event.delta.text };
+            } else if (event.delta.type === "input_json_delta") {
+              const buf = toolBuffers.get(event.index);
+              if (buf) buf.jsonText += event.delta.partial_json;
+            }
+          } else if (event.type === "content_block_stop") {
+            const buf = toolBuffers.get(event.index);
+            if (buf) {
+              let input: unknown;
+              try {
+                input = buf.jsonText ? JSON.parse(buf.jsonText) : {};
+              } catch {
+                input = { __parseError: buf.jsonText };
+              }
+              yield { kind: "tool-call", id: buf.id, name: buf.name, input };
+              toolBuffers.delete(event.index);
+            }
+          } else if (event.type === "message_delta") {
+            if (event.delta.stop_reason) {
+              stopReason = mapStopReason(event.delta.stop_reason);
+            }
+          }
+        }
+      } catch (err) {
+        yield { kind: "error", error: err };
+        return;
+      }
+
+      yield { kind: "stop", reason: stopReason };
+    },
+  };
+}
+
+function toAnthropicMessage(m: AICoreMessage): Anthropic.MessageParam {
+  if (m.role === "user") {
+    if (typeof m.content === "string") {
+      return { role: "user", content: m.content };
+    }
+    return {
+      role: "user",
+      content: m.content.map((p) => {
+        if (p.type === "text") return { type: "text", text: p.text };
+        if (p.type === "tool_result") {
+          return {
+            type: "tool_result",
+            tool_use_id: p.toolUseId,
+            content: p.output,
+            is_error: p.isError,
+          };
+        }
+        // tool_use blocks should never appear in a user message; skip.
+        return { type: "text", text: "" };
+      }),
+    };
+  }
+  return {
+    role: "assistant",
+    content: m.content.map((p) => {
+      if (p.type === "text") return { type: "text", text: p.text };
+      if (p.type === "tool_use") {
+        return { type: "tool_use", id: p.id, name: p.name, input: p.input as object };
+      }
+      return { type: "text", text: "" };
+    }),
+  };
+}
+
+function mapStopReason(reason: string): AIStopReason {
+  switch (reason) {
+    case "end_turn":
+      return "end_turn";
+    case "tool_use":
+      return "tool_use";
+    case "max_tokens":
+      return "max_tokens";
+    case "refusal":
+      return "refusal";
+    case "pause_turn":
+      return "pause_turn";
+    default:
+      return "other";
+  }
+}

--- a/client/src/lib/ai/providers/openai.ts
+++ b/client/src/lib/ai/providers/openai.ts
@@ -1,0 +1,179 @@
+// OpenAI provider — Chat Completions streaming. Tool calls arrive as
+// indexed deltas; we accumulate by index and emit a single tool-call
+// event per call once the stream completes for that index.
+
+import OpenAI from "openai";
+import type {
+  AICoreMessage,
+  AIProviderClient,
+  AIStreamEvent,
+  AIStreamOpts,
+  AIStopReason,
+} from "../types";
+
+export function makeOpenAIProvider(apiKey: string): AIProviderClient {
+  const client = new OpenAI({
+    apiKey,
+    dangerouslyAllowBrowser: true,
+  });
+
+  return {
+    id: "openai",
+    async *stream(opts: AIStreamOpts): AsyncIterable<AIStreamEvent> {
+      const messages = toOpenAIMessages(opts.systemPrompt, opts.messages);
+      const tools = opts.tools.map((t) => ({
+        type: "function" as const,
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.inputSchema as Record<string, unknown>,
+        },
+      }));
+
+      const toolBuffers = new Map<
+        number,
+        { id: string; name: string; argsText: string }
+      >();
+      let stopReason: AIStopReason = "other";
+
+      let stream;
+      try {
+        stream = await client.chat.completions.create({
+          model: opts.model,
+          messages,
+          tools: tools.length > 0 ? tools : undefined,
+          stream: true,
+        });
+      } catch (err) {
+        yield { kind: "error", error: err };
+        return;
+      }
+
+      try {
+        for await (const chunk of stream) {
+          if (opts.signal?.aborted) {
+            stream.controller.abort();
+            return;
+          }
+
+          const choice = chunk.choices?.[0];
+          if (!choice) continue;
+          const delta = choice.delta;
+
+          if (delta?.content) {
+            yield { kind: "text-delta", text: delta.content };
+          }
+
+          if (delta?.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              const idx = tc.index ?? 0;
+              let buf = toolBuffers.get(idx);
+              if (!buf) {
+                buf = {
+                  id: tc.id ?? `call_${idx}`,
+                  name: tc.function?.name ?? "",
+                  argsText: "",
+                };
+                toolBuffers.set(idx, buf);
+              }
+              if (tc.id && !buf.id.startsWith("call_")) buf.id = tc.id;
+              if (tc.function?.name) buf.name = tc.function.name;
+              if (tc.function?.arguments) buf.argsText += tc.function.arguments;
+            }
+          }
+
+          if (choice.finish_reason) {
+            stopReason = mapStopReason(choice.finish_reason);
+          }
+        }
+      } catch (err) {
+        yield { kind: "error", error: err };
+        return;
+      }
+
+      // Emit collected tool calls before the stop event so the
+      // orchestrator can dispatch them in order.
+      for (const buf of [...toolBuffers.values()]) {
+        let input: unknown;
+        try {
+          input = buf.argsText ? JSON.parse(buf.argsText) : {};
+        } catch {
+          input = { __parseError: buf.argsText };
+        }
+        yield { kind: "tool-call", id: buf.id, name: buf.name, input };
+      }
+
+      yield { kind: "stop", reason: stopReason };
+    },
+  };
+}
+
+function toOpenAIMessages(
+  systemPrompt: string,
+  messages: AICoreMessage[]
+): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
+  const out: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+  if (systemPrompt) out.push({ role: "system", content: systemPrompt });
+
+  for (const m of messages) {
+    if (m.role === "user") {
+      if (typeof m.content === "string") {
+        out.push({ role: "user", content: m.content });
+        continue;
+      }
+      // Tool results need to be split out into separate `tool` role messages
+      // (Chat Completions doesn't allow them inline in a user turn).
+      const userText: string[] = [];
+      const toolMessages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+      for (const p of m.content) {
+        if (p.type === "text") userText.push(p.text);
+        else if (p.type === "tool_result") {
+          toolMessages.push({
+            role: "tool",
+            tool_call_id: p.toolUseId,
+            content: p.output,
+          });
+        }
+      }
+      if (userText.length > 0) out.push({ role: "user", content: userText.join("\n") });
+      out.push(...toolMessages);
+    } else {
+      const text = m.content
+        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("");
+      const toolCalls = m.content
+        .filter((p): p is { type: "tool_use"; id: string; name: string; input: unknown } => p.type === "tool_use")
+        .map((p) => ({
+          id: p.id,
+          type: "function" as const,
+          function: {
+            name: p.name,
+            arguments: JSON.stringify(p.input),
+          },
+        }));
+      const msg: OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam = {
+        role: "assistant",
+        content: text || null,
+      };
+      if (toolCalls.length > 0) msg.tool_calls = toolCalls;
+      out.push(msg);
+    }
+  }
+  return out;
+}
+
+function mapStopReason(reason: string): AIStopReason {
+  switch (reason) {
+    case "stop":
+      return "end_turn";
+    case "tool_calls":
+      return "tool_use";
+    case "length":
+      return "max_tokens";
+    case "content_filter":
+      return "refusal";
+    default:
+      return "other";
+  }
+}

--- a/client/src/lib/ai/providers/service.ts
+++ b/client/src/lib/ai/providers/service.ts
@@ -1,0 +1,98 @@
+// Service-proxy provider — talks to xarji-core's /api/ai/stream over
+// SSE. The dashboard never holds the API key in JS bundle context;
+// the service does, and forwards to api.anthropic.com / api.openai.com
+// using whichever SDK matches the requested provider.
+//
+// Wire format: server emits one SSE record per event, with the JSON
+// payload matching this side's AIStreamEvent. We just decode and yield.
+
+import type {
+  AIProviderClient,
+  AIStreamEvent,
+  AIStreamOpts,
+} from "../types";
+import type { AIProviderId } from "../../aiConfig";
+
+export function makeServiceProvider(id: AIProviderId): AIProviderClient {
+  return {
+    id,
+    async *stream(opts: AIStreamOpts): AsyncIterable<AIStreamEvent> {
+      let response: Response;
+      try {
+        response = await fetch("/api/ai/stream", {
+          method: "POST",
+          headers: { "content-type": "application/json", accept: "text/event-stream" },
+          body: JSON.stringify({
+            provider: id,
+            model: opts.model,
+            systemPrompt: opts.systemPrompt,
+            messages: opts.messages,
+            tools: opts.tools,
+          }),
+          signal: opts.signal,
+        });
+      } catch (err) {
+        yield { kind: "error", error: err };
+        return;
+      }
+
+      if (!response.ok) {
+        let detail = response.statusText;
+        try {
+          const body = await response.json();
+          detail = (body && typeof body === "object" && "error" in body && typeof body.error === "string")
+            ? body.error
+            : detail;
+        } catch {
+          /* response was not JSON; keep the status text */
+        }
+        yield { kind: "error", error: new Error(`Service /api/ai/stream returned ${response.status}: ${detail}`) };
+        return;
+      }
+
+      const body = response.body;
+      if (!body) {
+        yield { kind: "error", error: new Error("Empty response body from /api/ai/stream") };
+        return;
+      }
+
+      // Minimal SSE parser. The spec allows comments (`:` lines) and
+      // multi-line `data:` records — the service only emits a single
+      // `data:` line per record, so the parser stays simple.
+      const reader = body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        if (opts.signal?.aborted) {
+          await reader.cancel();
+          return;
+        }
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        let recordEnd: number;
+        while ((recordEnd = buffer.indexOf("\n\n")) !== -1) {
+          const record = buffer.slice(0, recordEnd);
+          buffer = buffer.slice(recordEnd + 2);
+
+          let dataLine = "";
+          for (const line of record.split("\n")) {
+            if (line.startsWith("data:")) {
+              dataLine = line.slice(5).trim();
+              break;
+            }
+          }
+          if (!dataLine) continue;
+
+          try {
+            const event = JSON.parse(dataLine) as AIStreamEvent;
+            yield event;
+          } catch (err) {
+            yield { kind: "error", error: err };
+          }
+        }
+      }
+    },
+  };
+}

--- a/client/src/lib/ai/tools/readonly.ts
+++ b/client/src/lib/ai/tools/readonly.ts
@@ -1,0 +1,319 @@
+// Read-only tools the model can call to inspect the user's data.
+// These are pure functions over the AIToolContext — no mutations, no
+// network. v2 will add write tools (create_category, set_budget) with
+// a consent flow.
+
+import {
+  startOfMonth,
+  endOfMonth,
+  isWithinInterval,
+  subMonths,
+  format,
+} from "date-fns";
+import { autoCategorize } from "../../utils";
+import type { AITool, AIToolContext } from "./types";
+
+const MONTH_INPUT = {
+  type: "object",
+  properties: {
+    month: { type: "integer", minimum: 0, maximum: 11, description: "0-indexed month (0 = January). Defaults to the current month." },
+    year: { type: "integer", description: "Four-digit year. Defaults to the current year." },
+  },
+} as const;
+
+function resolveMonth(ctx: AIToolContext, input: Record<string, unknown>) {
+  const month = typeof input.month === "number" ? input.month : ctx.now.getMonth();
+  const year = typeof input.year === "number" ? input.year : ctx.now.getFullYear();
+  const start = startOfMonth(new Date(year, month, 1));
+  const end = endOfMonth(new Date(year, month, 1));
+  return { month, year, start, end, label: format(start, "MMMM yyyy") };
+}
+
+const getMonthSummary: AITool = {
+  definition: {
+    name: "get_month_summary",
+    description:
+      "Returns aggregate spending, income, and net for a specific month, plus the top 5 merchants and top 5 categories. Defaults to the current month if no arguments are given.",
+    inputSchema: MONTH_INPUT,
+  },
+  statusText: "Reading your month summary…",
+  executor: (input, ctx) => {
+    const { start, end, label } = resolveMonth(ctx, input);
+    const inMonth = (ts: number) => isWithinInterval(new Date(ts), { start, end });
+
+    let totalSpent = 0;
+    let txCount = 0;
+    const merchantTotals = new Map<string, { total: number; count: number }>();
+    const categoryTotals = new Map<string, { total: number; count: number }>();
+
+    for (const p of ctx.payments) {
+      if (!inMonth(p.transactionDate) || p.gelAmount === null) continue;
+      totalSpent += p.gelAmount;
+      txCount += 1;
+      const merchant = p.merchant || "Unknown";
+      const m = merchantTotals.get(merchant) ?? { total: 0, count: 0 };
+      m.total += p.gelAmount;
+      m.count += 1;
+      merchantTotals.set(merchant, m);
+      const category = autoCategorize(p.merchant ?? null);
+      const c = categoryTotals.get(category) ?? { total: 0, count: 0 };
+      c.total += p.gelAmount;
+      c.count += 1;
+      categoryTotals.set(category, c);
+    }
+
+    let totalIncome = 0;
+    let incomeCount = 0;
+    for (const c of ctx.credits) {
+      if (!inMonth(c.transactionDate) || c.gelAmount === null) continue;
+      totalIncome += c.gelAmount;
+      incomeCount += 1;
+    }
+
+    const failedCount = ctx.failedPayments.filter((f) => inMonth(f.transactionDate)).length;
+
+    const topMerchants = [...merchantTotals.entries()]
+      .map(([name, v]) => ({ name, total: Math.round(v.total), count: v.count }))
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 5);
+
+    const topCategories = [...categoryTotals.entries()]
+      .map(([name, v]) => ({ name, total: Math.round(v.total), count: v.count }))
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 5);
+
+    return {
+      period: label,
+      currency: "GEL",
+      totalSpent: Math.round(totalSpent),
+      totalIncome: Math.round(totalIncome),
+      net: Math.round(totalIncome - totalSpent),
+      transactionCount: txCount,
+      incomeDepositCount: incomeCount,
+      failedPaymentCount: failedCount,
+      topMerchants,
+      topCategories,
+    };
+  },
+};
+
+const searchTransactions: AITool = {
+  definition: {
+    name: "search_transactions",
+    description:
+      "Filter transactions by free-text query, category, currency, amount range, and date range. Returns up to 50 matches with key fields. Use this when the user asks for specific transactions or a precise filter.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Substring matched against merchant + raw SMS message (case-insensitive)." },
+        category: { type: "string", description: "Category name (e.g. 'Groceries', 'Subscriptions')." },
+        currency: { type: "string", description: "Currency code (GEL, USD, EUR)." },
+        minAmount: { type: "number", description: "Minimum GEL-equivalent amount." },
+        maxAmount: { type: "number", description: "Maximum GEL-equivalent amount." },
+        dateFrom: { type: "string", description: "ISO date (YYYY-MM-DD) — inclusive." },
+        dateTo: { type: "string", description: "ISO date (YYYY-MM-DD) — inclusive." },
+        limit: { type: "integer", minimum: 1, maximum: 100, description: "Max rows to return (default 20)." },
+      },
+    },
+  },
+  statusText: "Searching your transactions…",
+  executor: (input, ctx) => {
+    const query = typeof input.query === "string" ? input.query.toLowerCase() : null;
+    const category = typeof input.category === "string" ? input.category.toLowerCase() : null;
+    const currency = typeof input.currency === "string" ? input.currency.toUpperCase() : null;
+    const min = typeof input.minAmount === "number" ? input.minAmount : null;
+    const max = typeof input.maxAmount === "number" ? input.maxAmount : null;
+    const from = typeof input.dateFrom === "string" ? new Date(input.dateFrom).getTime() : null;
+    const to = typeof input.dateTo === "string" ? new Date(input.dateTo).getTime() : null;
+    const limit = typeof input.limit === "number" ? Math.min(100, Math.max(1, input.limit)) : 20;
+
+    const matches = ctx.payments
+      .filter((p) => {
+        if (query) {
+          const haystack = `${p.merchant ?? ""} ${p.rawMessage ?? ""}`.toLowerCase();
+          if (!haystack.includes(query)) return false;
+        }
+        if (category) {
+          const cat = autoCategorize(p.merchant ?? null).toLowerCase();
+          if (cat !== category) return false;
+        }
+        if (currency && p.currency.toUpperCase() !== currency) return false;
+        const amt = p.gelAmount ?? 0;
+        if (min !== null && amt < min) return false;
+        if (max !== null && amt > max) return false;
+        if (from !== null && p.transactionDate < from) return false;
+        if (to !== null && p.transactionDate > to) return false;
+        return true;
+      })
+      .slice(0, limit)
+      .map((p) => ({
+        date: format(new Date(p.transactionDate), "yyyy-MM-dd HH:mm"),
+        merchant: p.merchant ?? "Unknown",
+        amount: p.amount,
+        currency: p.currency,
+        gelAmount: p.gelAmount !== null ? Math.round(p.gelAmount) : null,
+        category: autoCategorize(p.merchant ?? null),
+        card: p.cardLastDigits ?? null,
+      }));
+
+    return { matchCount: matches.length, transactions: matches };
+  },
+};
+
+const compareMonths: AITool = {
+  definition: {
+    name: "compare_months",
+    description:
+      "Side-by-side comparison of spending, income, and category breakdown between two months. Defaults to comparing the current month with the previous month.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        a: MONTH_INPUT,
+        b: MONTH_INPUT,
+      },
+    },
+  },
+  statusText: "Comparing months…",
+  executor: (input, ctx) => {
+    const a = resolveMonth(ctx, (input.a ?? {}) as Record<string, unknown>);
+    const bDefault = subMonths(a.start, 1);
+    const b = resolveMonth(
+      ctx,
+      input.b
+        ? (input.b as Record<string, unknown>)
+        : { month: bDefault.getMonth(), year: bDefault.getFullYear() }
+    );
+
+    const summarize = (range: typeof a) => {
+      const inRange = (ts: number) =>
+        isWithinInterval(new Date(ts), { start: range.start, end: range.end });
+      let spent = 0;
+      let income = 0;
+      const cats = new Map<string, number>();
+      for (const p of ctx.payments) {
+        if (!inRange(p.transactionDate) || p.gelAmount === null) continue;
+        spent += p.gelAmount;
+        const cat = autoCategorize(p.merchant ?? null);
+        cats.set(cat, (cats.get(cat) ?? 0) + p.gelAmount);
+      }
+      for (const c of ctx.credits) {
+        if (!inRange(c.transactionDate) || c.gelAmount === null) continue;
+        income += c.gelAmount;
+      }
+      return {
+        period: range.label,
+        spent: Math.round(spent),
+        income: Math.round(income),
+        net: Math.round(income - spent),
+        topCategories: [...cats.entries()]
+          .map(([name, total]) => ({ name, total: Math.round(total) }))
+          .sort((x, y) => y.total - x.total)
+          .slice(0, 5),
+      };
+    };
+
+    const sa = summarize(a);
+    const sb = summarize(b);
+    const delta = {
+      spentDelta: sa.spent - sb.spent,
+      incomeDelta: sa.income - sb.income,
+      netDelta: sa.net - sb.net,
+    };
+    return { a: sa, b: sb, delta };
+  },
+};
+
+const listCategories: AITool = {
+  definition: {
+    name: "list_categories",
+    description:
+      "Returns the user's categories with their color and icon, plus the GEL-equivalent total for the current month for each.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  statusText: "Looking at your categories…",
+  executor: (_input, ctx) => {
+    const { start, end } = resolveMonth(ctx, {});
+    const inMonth = (ts: number) => isWithinInterval(new Date(ts), { start, end });
+    const monthTotals = new Map<string, { total: number; count: number }>();
+    for (const p of ctx.payments) {
+      if (!inMonth(p.transactionDate) || p.gelAmount === null) continue;
+      const cat = autoCategorize(p.merchant ?? null);
+      const v = monthTotals.get(cat) ?? { total: 0, count: 0 };
+      v.total += p.gelAmount;
+      v.count += 1;
+      monthTotals.set(cat, v);
+    }
+    return {
+      categories: ctx.categories.map((c) => ({
+        id: c.id,
+        name: c.name,
+        color: c.color,
+        icon: c.icon,
+        thisMonthTotal: Math.round(monthTotals.get(c.name)?.total ?? 0),
+        thisMonthCount: monthTotals.get(c.name)?.count ?? 0,
+      })),
+    };
+  },
+};
+
+const getRecurringCharges: AITool = {
+  definition: {
+    name: "get_recurring_charges",
+    description:
+      "Detects merchants charged at a roughly monthly cadence (≥3 payments across the last 6 months). Returns merchant, average amount, count, last seen date, and the current month's spend.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  statusText: "Checking recurring charges…",
+  executor: (_input, ctx) => {
+    const cutoff = subMonths(ctx.now, 6).getTime();
+    const byMerchant = new Map<
+      string,
+      { amounts: number[]; dates: number[]; thisMonth: number }
+    >();
+    const monthStart = startOfMonth(ctx.now).getTime();
+    for (const p of ctx.payments) {
+      if (p.transactionDate < cutoff || p.gelAmount === null) continue;
+      const merchant = p.merchant || "Unknown";
+      const v = byMerchant.get(merchant) ?? { amounts: [], dates: [], thisMonth: 0 };
+      v.amounts.push(p.gelAmount);
+      v.dates.push(p.transactionDate);
+      if (p.transactionDate >= monthStart) v.thisMonth += p.gelAmount;
+      byMerchant.set(merchant, v);
+    }
+
+    const recurring: Array<{
+      merchant: string;
+      averageAmount: number;
+      occurrences: number;
+      lastSeen: string;
+      thisMonthSpend: number;
+    }> = [];
+    for (const [merchant, v] of byMerchant) {
+      if (v.amounts.length < 3) continue;
+      const avg = v.amounts.reduce((s, x) => s + x, 0) / v.amounts.length;
+      const stddev = Math.sqrt(
+        v.amounts.reduce((s, x) => s + (x - avg) ** 2, 0) / v.amounts.length
+      );
+      const stable = avg > 0 && stddev / avg < 0.5;
+      if (!stable) continue;
+      const lastTs = Math.max(...v.dates);
+      recurring.push({
+        merchant,
+        averageAmount: Math.round(avg),
+        occurrences: v.amounts.length,
+        lastSeen: format(new Date(lastTs), "yyyy-MM-dd"),
+        thisMonthSpend: Math.round(v.thisMonth),
+      });
+    }
+    recurring.sort((a, b) => b.averageAmount - a.averageAmount);
+    return { recurring };
+  },
+};
+
+export const READONLY_TOOLS: AITool[] = [
+  getMonthSummary,
+  searchTransactions,
+  compareMonths,
+  listCategories,
+  getRecurringCharges,
+];

--- a/client/src/lib/ai/tools/readonly.ts
+++ b/client/src/lib/ai/tools/readonly.ts
@@ -6,6 +6,8 @@
 import {
   startOfMonth,
   endOfMonth,
+  startOfDay,
+  endOfDay,
   isWithinInterval,
   subMonths,
   format,
@@ -123,8 +125,13 @@ const searchTransactions: AITool = {
     const currency = typeof input.currency === "string" ? input.currency.toUpperCase() : null;
     const min = typeof input.minAmount === "number" ? input.minAmount : null;
     const max = typeof input.maxAmount === "number" ? input.maxAmount : null;
-    const from = typeof input.dateFrom === "string" ? new Date(input.dateFrom).getTime() : null;
-    const to = typeof input.dateTo === "string" ? new Date(input.dateTo).getTime() : null;
+    // dateFrom/dateTo are inclusive calendar-day bounds. Parsing
+    // "YYYY-MM-DD" with `new Date(...)` gives midnight in the local
+    // timezone — we widen the range to startOfDay(from) and endOfDay(to)
+    // so the user gets *every* transaction on the boundary days, not
+    // just rows that happen to fall before the boundary's midnight tick.
+    const from = typeof input.dateFrom === "string" ? startOfDay(new Date(input.dateFrom)).getTime() : null;
+    const to = typeof input.dateTo === "string" ? endOfDay(new Date(input.dateTo)).getTime() : null;
     const limit = typeof input.limit === "number" ? Math.min(100, Math.max(1, input.limit)) : 20;
 
     const matches = ctx.payments

--- a/client/src/lib/ai/tools/readonly.ts
+++ b/client/src/lib/ai/tools/readonly.ts
@@ -12,7 +12,6 @@ import {
   subMonths,
   format,
 } from "date-fns";
-import { autoCategorize } from "../../utils";
 import type { AITool, AIToolContext } from "./types";
 
 const MONTH_INPUT = {
@@ -57,7 +56,7 @@ const getMonthSummary: AITool = {
       m.total += p.gelAmount;
       m.count += 1;
       merchantTotals.set(merchant, m);
-      const category = autoCategorize(p.merchant ?? null);
+      const category = ctx.categorizeName(p.merchant ?? null);
       const c = categoryTotals.get(category) ?? { total: 0, count: 0 };
       c.total += p.gelAmount;
       c.count += 1;
@@ -141,7 +140,7 @@ const searchTransactions: AITool = {
           if (!haystack.includes(query)) return false;
         }
         if (category) {
-          const cat = autoCategorize(p.merchant ?? null).toLowerCase();
+          const cat = ctx.categorizeName(p.merchant ?? null).toLowerCase();
           if (cat !== category) return false;
         }
         if (currency && p.currency.toUpperCase() !== currency) return false;
@@ -159,7 +158,7 @@ const searchTransactions: AITool = {
         amount: p.amount,
         currency: p.currency,
         gelAmount: p.gelAmount !== null ? Math.round(p.gelAmount) : null,
-        category: autoCategorize(p.merchant ?? null),
+        category: ctx.categorizeName(p.merchant ?? null),
         card: p.cardLastDigits ?? null,
       }));
 
@@ -200,7 +199,7 @@ const compareMonths: AITool = {
       for (const p of ctx.payments) {
         if (!inRange(p.transactionDate) || p.gelAmount === null) continue;
         spent += p.gelAmount;
-        const cat = autoCategorize(p.merchant ?? null);
+        const cat = ctx.categorizeName(p.merchant ?? null);
         cats.set(cat, (cats.get(cat) ?? 0) + p.gelAmount);
       }
       for (const c of ctx.credits) {
@@ -244,7 +243,7 @@ const listCategories: AITool = {
     const monthTotals = new Map<string, { total: number; count: number }>();
     for (const p of ctx.payments) {
       if (!inMonth(p.transactionDate) || p.gelAmount === null) continue;
-      const cat = autoCategorize(p.merchant ?? null);
+      const cat = ctx.categorizeName(p.merchant ?? null);
       const v = monthTotals.get(cat) ?? { total: 0, count: 0 };
       v.total += p.gelAmount;
       v.count += 1;

--- a/client/src/lib/ai/tools/types.ts
+++ b/client/src/lib/ai/tools/types.ts
@@ -16,6 +16,12 @@ export interface AIToolContext {
   categories: Category[];
   bankSenders: BankSender[];
   now: Date;
+  /** Override-aware category-name lookup for a merchant. Honours the
+   *  user's manual `merchantCategoryOverrides` rows; falls back to the
+   *  regex categoriser. Tools should always call this instead of the
+   *  static `autoCategorize` so an "I moved Spotify to Subscriptions"
+   *  override actually shows up in the AI's view of the data. */
+  categorizeName: (merchant: string | null | undefined) => string;
 }
 
 export interface AITool {

--- a/client/src/lib/ai/tools/types.ts
+++ b/client/src/lib/ai/tools/types.ts
@@ -1,0 +1,36 @@
+// AITool shape — pairs a JSON-Schema definition (sent to the LLM) with
+// a typed executor (called locally with the React-side data context).
+// Some tools also map their result into a structured assistant block
+// (CategoryCard, BudgetCard, etc.) via the optional `toBlock`.
+
+import type { AIToolDefinition } from "../types";
+import type { AIBlock } from "../../aiThreads";
+import type { ConvertedPayment } from "../../../hooks/useTransactions";
+import type { ConvertedCredit } from "../../../hooks/useCredits";
+import type { FailedPayment, Category, BankSender } from "../../instant";
+
+export interface AIToolContext {
+  payments: ConvertedPayment[];
+  credits: ConvertedCredit[];
+  failedPayments: FailedPayment[];
+  categories: Category[];
+  bankSenders: BankSender[];
+  now: Date;
+}
+
+export interface AITool {
+  definition: AIToolDefinition;
+  /** Executes the tool against the live data context. The returned
+   *  value gets JSON-stringified and sent back to the model as the
+   *  tool result. Throw to surface as an error result. */
+  executor: (input: Record<string, unknown>, ctx: AIToolContext) => Promise<unknown> | unknown;
+  /** Short user-facing verb shown in the chat's loading indicator while
+   *  this tool runs (e.g. "Reading your month summary…"). The orchestrator
+   *  falls back to a generic "Working…" when omitted. */
+  statusText?: string;
+  /** Optional UI bridge — when present, the orchestrator calls this with
+   *  the executor's return value and emits the resulting block into the
+   *  assistant message. Lets specific tool outputs render as structured
+   *  cards (savings plan, budget, etc.) instead of raw JSON. */
+  toBlock?: (output: unknown) => AIBlock | null;
+}

--- a/client/src/lib/ai/types.ts
+++ b/client/src/lib/ai/types.ts
@@ -1,0 +1,58 @@
+// Provider-agnostic types for the AI layer. The orchestrator (lib/ai/
+// orchestrator.ts) speaks this protocol; each provider implementation
+// (lib/ai/providers/*) translates it to and from its native SDK shape.
+// Adding a new provider = one new file under providers/, register it in
+// provider.ts. No changes to the orchestrator or the chat UI.
+
+import type { AIProviderId } from "../aiConfig";
+
+/** A single piece of conversational content. Mirrors the Anthropic
+ *  content-block model — OpenAI maps tool calls + tool results onto its
+ *  separate `tool_calls`/`tool` role messages internally. */
+export type AIContentPart =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | { type: "tool_result"; toolUseId: string; output: string; isError?: boolean };
+
+export type AICoreMessage =
+  | { role: "user"; content: string | AIContentPart[] }
+  | { role: "assistant"; content: AIContentPart[] };
+
+export interface AIToolDefinition {
+  name: string;
+  description: string;
+  /** JSON Schema for the tool's input. Both Anthropic and OpenAI accept
+   *  this shape directly (Anthropic as `input_schema`, OpenAI inside
+   *  `function.parameters`). */
+  inputSchema: Record<string, unknown>;
+}
+
+/** Stream events the orchestrator consumes. Provider implementations
+ *  yield these over an async iterator; tool calls are emitted only when
+ *  the provider has accumulated the full input JSON for them. */
+export type AIStreamEvent =
+  | { kind: "text-delta"; text: string }
+  | { kind: "tool-call"; id: string; name: string; input: unknown }
+  | { kind: "stop"; reason: AIStopReason }
+  | { kind: "error"; error: unknown };
+
+export type AIStopReason =
+  | "end_turn"
+  | "tool_use"
+  | "max_tokens"
+  | "refusal"
+  | "pause_turn"
+  | "other";
+
+export interface AIStreamOpts {
+  model: string;
+  systemPrompt: string;
+  messages: AICoreMessage[];
+  tools: AIToolDefinition[];
+  signal?: AbortSignal;
+}
+
+export interface AIProviderClient {
+  id: AIProviderId;
+  stream(opts: AIStreamOpts): AsyncIterable<AIStreamEvent>;
+}

--- a/client/src/lib/aiConfig.ts
+++ b/client/src/lib/aiConfig.ts
@@ -1,0 +1,92 @@
+// AI Assistant config — provider list + localStorage-backed key/model.
+// The key never leaves the browser; whichever provider the user picks
+// is what the chat will (eventually) call directly. UI-only for now;
+// the scripted runAgent in lib/aiAgent.ts produces the demo responses.
+
+export type AIProviderId = "anthropic" | "openai";
+
+export interface AIProvider {
+  id: AIProviderId;
+  name: string;
+  by: string;
+  models: string[];
+  defaultModel: string;
+  keyHint: string;
+  keyPrefix: string;
+  docs: string;
+  color: string;
+}
+
+export interface AIConfig {
+  provider: AIProviderId;
+  apiKey: string;
+  model: string;
+}
+
+export const AI_PROVIDERS: AIProvider[] = [
+  {
+    id: "anthropic",
+    name: "Claude",
+    by: "Anthropic",
+    models: ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
+    defaultModel: "claude-opus-4-7",
+    keyHint: "Begins with sk-ant-",
+    keyPrefix: "sk-ant-",
+    docs: "console.anthropic.com",
+    color: "#cc785c",
+  },
+  {
+    id: "openai",
+    name: "OpenAI",
+    by: "OpenAI",
+    models: ["gpt-5", "gpt-5-mini", "gpt-4.1"],
+    defaultModel: "gpt-5",
+    keyHint: "Begins with sk-",
+    keyPrefix: "sk-",
+    docs: "platform.openai.com",
+    color: "#10a37f",
+  },
+];
+
+export function getProvider(id: AIProviderId): AIProvider {
+  return AI_PROVIDERS.find((p) => p.id === id) ?? AI_PROVIDERS[0];
+}
+
+const STORE_KEY = "xarji-ai";
+const CHANGE_EVENT = "xarji-ai-changed";
+
+export function loadAIConfig(): AIConfig | null {
+  try {
+    const raw = window.localStorage.getItem(STORE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<AIConfig>;
+    if (!parsed.provider || !parsed.apiKey || !parsed.model) return null;
+    if (parsed.provider !== "anthropic" && parsed.provider !== "openai") return null;
+    return { provider: parsed.provider, apiKey: parsed.apiKey, model: parsed.model };
+  } catch {
+    return null;
+  }
+}
+
+export function saveAIConfig(cfg: AIConfig) {
+  window.localStorage.setItem(STORE_KEY, JSON.stringify(cfg));
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+}
+
+export function clearAIConfig() {
+  window.localStorage.removeItem(STORE_KEY);
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+}
+
+export function onAIConfigChange(handler: () => void): () => void {
+  window.addEventListener(CHANGE_EVENT, handler);
+  return () => window.removeEventListener(CHANGE_EVENT, handler);
+}
+
+export function maskApiKey(key: string): string {
+  const trimmed = key.trim();
+  if (trimmed.length <= 12) return "•".repeat(Math.max(0, trimmed.length));
+  const prefix = trimmed.slice(0, 7);
+  const suffix = trimmed.slice(-4);
+  return `${prefix}••••${suffix}`;
+}

--- a/client/src/lib/aiConfig.ts
+++ b/client/src/lib/aiConfig.ts
@@ -1,7 +1,10 @@
-// AI Assistant config — provider list + localStorage-backed key/model.
-// The key never leaves the browser; whichever provider the user picks
-// is what the chat will (eventually) call directly. UI-only for now;
-// the scripted runAgent in lib/aiAgent.ts produces the demo responses.
+// AI Assistant config — provider catalog + the user's chosen
+// provider+model. The API key itself does NOT live here anymore: keys
+// are stored on disk by the service in ~/.xarji/config.json and the
+// browser only ever knows whether each provider has a key configured
+// (via /api/ai/keys). The dashboard's onboarding/settings POST keys
+// directly to the service; nothing about the key reaches the JS bundle
+// context.
 
 export type AIProviderId = "anthropic" | "openai";
 
@@ -17,9 +20,11 @@ export interface AIProvider {
   color: string;
 }
 
+/** What the dashboard tracks locally — provider id + currently selected
+ *  model. The "are we connected" question is answered by the service
+ *  (`useAIKeyStatus`), not by this object. */
 export interface AIConfig {
   provider: AIProviderId;
-  apiKey: string;
   model: string;
 }
 
@@ -60,9 +65,9 @@ export function loadAIConfig(): AIConfig | null {
     const raw = window.localStorage.getItem(STORE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<AIConfig>;
-    if (!parsed.provider || !parsed.apiKey || !parsed.model) return null;
+    if (!parsed.provider || !parsed.model) return null;
     if (parsed.provider !== "anthropic" && parsed.provider !== "openai") return null;
-    return { provider: parsed.provider, apiKey: parsed.apiKey, model: parsed.model };
+    return { provider: parsed.provider, model: parsed.model };
   } catch {
     return null;
   }
@@ -83,10 +88,53 @@ export function onAIConfigChange(handler: () => void): () => void {
   return () => window.removeEventListener(CHANGE_EVENT, handler);
 }
 
-export function maskApiKey(key: string): string {
-  const trimmed = key.trim();
-  if (trimmed.length <= 12) return "•".repeat(Math.max(0, trimmed.length));
-  const prefix = trimmed.slice(0, 7);
-  const suffix = trimmed.slice(-4);
-  return `${prefix}••••${suffix}`;
+// ─────────────────────────────────────────────────────────────────
+// Server-side key management — talks to /api/ai/keys. The service is
+// the source of truth; the dashboard only reads presence + sends
+// new/updated keys via POST.
+
+export interface AIKeyStatus {
+  anthropic: boolean;
+  openai: boolean;
 }
+
+const KEYS_CHANGE_EVENT = "xarji-ai-keys-changed";
+
+export async function fetchKeyStatus(): Promise<AIKeyStatus> {
+  try {
+    const res = await fetch("/api/ai/keys");
+    if (!res.ok) return { anthropic: false, openai: false };
+    const body = (await res.json()) as Partial<AIKeyStatus>;
+    return { anthropic: !!body.anthropic, openai: !!body.openai };
+  } catch {
+    return { anthropic: false, openai: false };
+  }
+}
+
+export async function saveProviderKey(provider: AIProviderId, apiKey: string): Promise<void> {
+  const res = await fetch("/api/ai/keys", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ provider, apiKey }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`Failed to save ${provider} key: ${text}`);
+  }
+  window.dispatchEvent(new CustomEvent(KEYS_CHANGE_EVENT));
+}
+
+export async function deleteProviderKey(provider: AIProviderId): Promise<void> {
+  const res = await fetch(`/api/ai/keys/${provider}`, { method: "DELETE" });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`Failed to delete ${provider} key: ${text}`);
+  }
+  window.dispatchEvent(new CustomEvent(KEYS_CHANGE_EVENT));
+}
+
+export function onKeyStatusChange(handler: () => void): () => void {
+  window.addEventListener(KEYS_CHANGE_EVENT, handler);
+  return () => window.removeEventListener(KEYS_CHANGE_EVENT, handler);
+}
+

--- a/client/src/lib/aiThreads.ts
+++ b/client/src/lib/aiThreads.ts
@@ -1,0 +1,162 @@
+// Conversation threads — localStorage-backed. The chat UI subscribes to
+// the `xarji-ai-threads-changed` event so the ⌘K palette can mutate the
+// list from anywhere and the active conversation updates in place.
+
+export type AIBlockKind = "text" | "tool" | "plan" | "budget" | "category";
+
+export interface AITextBlock { kind: "text"; text: string }
+export interface AIToolBlock { kind: "tool"; name: string; duration: string; body: string }
+export interface AIPlanStep { month: string; amount: number; note: string }
+export interface AIPlanBlock {
+  kind: "plan";
+  goal: string;
+  target: string;
+  deadline: string;
+  steps: AIPlanStep[];
+}
+export interface AIBudgetBlock {
+  kind: "budget";
+  category: string;
+  limit: number;
+  spent: number;
+  warnAt: number;
+}
+export interface AICategoryBlock {
+  kind: "category";
+  name: string;
+  color: string;
+  glyph: string;
+  matched: number;
+  total: string;
+  merchants: string[];
+}
+
+export type AIBlock =
+  | AITextBlock
+  | AIToolBlock
+  | AIPlanBlock
+  | AIBudgetBlock
+  | AICategoryBlock;
+
+export interface AIMessage {
+  role: "user" | "assistant";
+  id: string;
+  blocks: AIBlock[];
+  streaming?: boolean;
+}
+
+export interface AIThread {
+  id: string;
+  title: string;
+  messages: AIMessage[];
+  createdAt: number;
+  updatedAt: number;
+  autoRun: boolean;
+  pendingPrompt: string | null;
+}
+
+const THREADS_KEY = "xarji-ai-threads";
+const ACTIVE_KEY = "xarji-ai-active";
+const CHANGE_EVENT = "xarji-ai-threads-changed";
+
+function notify() {
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+}
+
+export function loadThreads(): AIThread[] {
+  try {
+    const raw = window.localStorage.getItem(THREADS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as AIThread[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+export function saveThreads(list: AIThread[]) {
+  window.localStorage.setItem(THREADS_KEY, JSON.stringify(list));
+  notify();
+}
+
+export function loadActiveThreadId(): string | null {
+  return window.localStorage.getItem(ACTIVE_KEY);
+}
+
+export function setActiveThreadId(id: string | null) {
+  if (id) window.localStorage.setItem(ACTIVE_KEY, id);
+  else window.localStorage.removeItem(ACTIVE_KEY);
+  notify();
+}
+
+interface CreateThreadOpts {
+  title?: string;
+  firstUserPrompt?: string;
+  autoRun?: boolean;
+}
+
+export function createThread(opts: CreateThreadOpts = {}): AIThread {
+  const id = `t_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  const now = Date.now();
+  const messages: AIMessage[] = [];
+  if (opts.firstUserPrompt) {
+    messages.push({
+      role: "user",
+      id: `u${now}`,
+      blocks: [{ kind: "text", text: opts.firstUserPrompt }],
+    });
+  }
+  const t: AIThread = {
+    id,
+    title: opts.title || (opts.firstUserPrompt ? deriveTitle(opts.firstUserPrompt) : "New conversation"),
+    messages,
+    createdAt: now,
+    updatedAt: now,
+    autoRun: !!opts.autoRun,
+    pendingPrompt: opts.autoRun && opts.firstUserPrompt ? opts.firstUserPrompt : null,
+  };
+  const list = [t, ...loadThreads()];
+  saveThreads(list);
+  setActiveThreadId(id);
+  return t;
+}
+
+export function updateThread(id: string, patch: Partial<AIThread>) {
+  const list = loadThreads();
+  const idx = list.findIndex((t) => t.id === id);
+  if (idx === -1) return;
+  list[idx] = { ...list[idx], ...patch, updatedAt: Date.now() };
+  saveThreads(list);
+}
+
+export function deleteThread(id: string) {
+  const list = loadThreads().filter((t) => t.id !== id);
+  saveThreads(list);
+  if (loadActiveThreadId() === id) {
+    setActiveThreadId(list[0]?.id ?? null);
+  }
+}
+
+export function onThreadsChange(handler: () => void): () => void {
+  window.addEventListener(CHANGE_EVENT, handler);
+  return () => window.removeEventListener(CHANGE_EVENT, handler);
+}
+
+export function deriveTitle(prompt: string): string {
+  const s = prompt.trim().replace(/\s+/g, " ");
+  if (s.length <= 42) return s.replace(/[.?!]+$/, "");
+  return s.slice(0, 40).replace(/[.?!]+$/, "") + "…";
+}
+
+export function timeAgo(ts: number): string {
+  const diff = Date.now() - ts;
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(ts).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}

--- a/client/src/lib/instant.ts
+++ b/client/src/lib/instant.ts
@@ -45,6 +45,14 @@ const schema = i.schema({
       enabled: i.boolean(),
       createdAt: i.number(),
     }),
+    // Manual category overrides per merchant — see service-side
+    // schema for the rationale; this is the client-side mirror so
+    // db.useQuery is typed.
+    merchantCategoryOverrides: i.entity({
+      merchant: i.string().unique(),
+      categoryId: i.string(),
+      createdAt: i.number(),
+    }),
     credits: i.entity({
       transactionId: i.string().unique(),
       transactionType: i.string(),
@@ -163,6 +171,13 @@ export type BankSender = {
   senderId: string;
   displayName: string;
   enabled: boolean;
+  createdAt: number;
+};
+
+export type MerchantCategoryOverride = {
+  id: string;
+  merchant: string;
+  categoryId: string;
   createdAt: number;
 };
 

--- a/client/src/lib/instant.ts
+++ b/client/src/lib/instant.ts
@@ -1,4 +1,5 @@
 import { init, i } from "@instantdb/react";
+import { isDemoMode, getDemoSeed } from "../dev/demoMode";
 
 // Define the schema
 const schema = i.schema({
@@ -98,9 +99,22 @@ async function resolveAppId(): Promise<string> {
   return import.meta.env.VITE_INSTANT_APP_ID || "f78a0d50-1945-431a-91ea-96f68570d4a5";
 }
 
-const APP_ID = await resolveAppId();
+type Db = ReturnType<typeof init<typeof schema>>;
 
-export const db = init({ appId: APP_ID, schema });
+// Dev-only demo mode: when active, swap the live InstantDB client for a
+// mutable in-memory fake (see ../dev/demoDb). The static `import.meta.env.DEV`
+// literal short-circuits in production builds, so Vite/Rollup tree-shake
+// the dynamic import + the dev module + the fixtures out of the bundle.
+let _db: Db;
+if (import.meta.env.DEV && isDemoMode()) {
+  const { makeDemoDb } = await import("../dev/demoDb");
+  _db = makeDemoDb(getDemoSeed()) as unknown as Db;
+} else {
+  const APP_ID = await resolveAppId();
+  _db = init({ appId: APP_ID, schema });
+}
+
+export const db: Db = _db;
 
 // Export types for use in components (using undefined for optional fields to match InstantDB)
 export type Payment = {

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "../ink/theme";
 import { Card, CardTitle, Pill, PageHeader } from "../ink/primitives";
 import { useSignals } from "../hooks/useSignals";
-import { getCategory } from "../lib/utils";
+import { useCategorizer } from "../hooks/useCategorizer";
 
 function SignalCard({
   icon,
@@ -55,6 +55,7 @@ function SignalCard({
 export function Analytics() {
   const T = useTheme();
   const { monthFailed, repeatedDeclines, largeTx, newMerchants, cards, activeCount } = useSignals();
+  const { getCategory } = useCategorizer();
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>

--- a/client/src/pages/Assistant.tsx
+++ b/client/src/pages/Assistant.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import {
+  loadAIConfig,
+  saveAIConfig,
+  clearAIConfig,
+  onAIConfigChange,
+  type AIConfig,
+} from "../lib/aiConfig";
+import { AssistantOnboarding } from "../components/AssistantOnboarding";
+import { AssistantChat } from "../components/AssistantChat";
+
+export function Assistant() {
+  const [config, setConfig] = useState<AIConfig | null>(loadAIConfig);
+
+  useEffect(() => onAIConfigChange(() => setConfig(loadAIConfig())), []);
+
+  if (!config) {
+    return (
+      <AssistantOnboarding
+        onSave={(c) => {
+          saveAIConfig(c);
+          setConfig(c);
+        }}
+      />
+    );
+  }
+  return (
+    <AssistantChat
+      config={config}
+      onClear={() => {
+        clearAIConfig();
+        setConfig(null);
+      }}
+    />
+  );
+}

--- a/client/src/pages/Assistant.tsx
+++ b/client/src/pages/Assistant.tsx
@@ -1,35 +1,77 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
+  AI_PROVIDERS,
   loadAIConfig,
   saveAIConfig,
-  clearAIConfig,
-  onAIConfigChange,
   type AIConfig,
+  type AIProviderId,
 } from "../lib/aiConfig";
+import { useAIKeyStatus } from "../hooks/useAIKeyStatus";
 import { AssistantOnboarding } from "../components/AssistantOnboarding";
 import { AssistantChat } from "../components/AssistantChat";
 
 export function Assistant() {
-  const [config, setConfig] = useState<AIConfig | null>(loadAIConfig);
+  const { status, isLoading, refresh } = useAIKeyStatus();
+  const [storedConfig, setStoredConfig] = useState<AIConfig | null>(loadAIConfig);
 
-  useEffect(() => onAIConfigChange(() => setConfig(loadAIConfig())), []);
+  // Treat the user as connected if any provider has a key on the
+  // service. The local AIConfig (provider+model preference) snaps to
+  // a provider that actually has a key when we have to choose one.
+  const anyKeySet = status.anthropic || status.openai;
 
-  if (!config) {
+  const effectiveConfig = useMemo<AIConfig | null>(() => {
+    if (!anyKeySet) return null;
+    const preferred: AIProviderId | null =
+      storedConfig?.provider && status[storedConfig.provider]
+        ? storedConfig.provider
+        : status.anthropic
+          ? "anthropic"
+          : status.openai
+            ? "openai"
+            : null;
+    if (!preferred) return null;
+    const provider = AI_PROVIDERS.find((p) => p.id === preferred)!;
+    const model =
+      storedConfig?.provider === preferred && storedConfig?.model
+        ? storedConfig.model
+        : provider.defaultModel;
+    return { provider: preferred, model };
+  }, [anyKeySet, status, storedConfig]);
+
+  useEffect(() => {
+    if (effectiveConfig && (effectiveConfig.provider !== storedConfig?.provider || effectiveConfig.model !== storedConfig?.model)) {
+      saveAIConfig(effectiveConfig);
+      setStoredConfig(effectiveConfig);
+    }
+  }, [effectiveConfig, storedConfig?.provider, storedConfig?.model]);
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 40, color: "rgba(242,242,244,0.62)", fontFamily: "system-ui" }}>
+        Loading…
+      </div>
+    );
+  }
+
+  if (!effectiveConfig) {
     return (
       <AssistantOnboarding
-        onSave={(c) => {
-          saveAIConfig(c);
-          setConfig(c);
+        onSaved={() => {
+          refresh();
         }}
       />
     );
   }
+
   return (
     <AssistantChat
-      config={config}
+      config={effectiveConfig}
       onClear={() => {
-        clearAIConfig();
-        setConfig(null);
+        // Disconnect = clear the local provider/model preference. The
+        // actual key lives on the service and is removed via
+        // SettingsAISection / AssistantChat's "Disconnect" path.
+        setStoredConfig(null);
+        refresh();
       }}
     />
   );

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -6,7 +6,8 @@ import { AreaChart, Donut, HBar } from "../ink/charts";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedPayments } from "../hooks/useTransactions";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
-import { DEFAULT_CATEGORIES, categorizeId, getCategory, type InkCategory } from "../lib/utils";
+import { DEFAULT_CATEGORIES, type InkCategory } from "../lib/utils";
+import { useCategorizer } from "../hooks/useCategorizer";
 import { formatCompact, monthKey } from "../ink/format";
 import { isWithinInterval, startOfMonth, endOfMonth, format } from "date-fns";
 
@@ -26,6 +27,7 @@ export function Categories() {
   const monthEnd = endOfMonth(now);
 
   const { payments } = useConvertedPayments();
+  const { getCategory, categorize: categorizeId } = useCategorizer();
   const trend = useMonthlyTrend(6);
   const [range, setRange] = useState("Month");
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -8,7 +8,8 @@ import { useMonthStats, useMonthTopMerchants } from "../hooks/useMonthlyAnalytic
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { useCredits, useMonthCredits } from "../hooks/useCredits";
 import { formatCompact } from "../ink/format";
-import { getCategory, DEFAULT_CATEGORIES } from "../lib/utils";
+import { DEFAULT_CATEGORIES } from "../lib/utils";
+import { useCategorizer } from "../hooks/useCategorizer";
 import { isWithinInterval, startOfMonth, endOfMonth, subMonths, format } from "date-fns";
 
 export function Dashboard() {
@@ -28,6 +29,7 @@ export function Dashboard() {
   const { credits } = useCredits();
   const monthCredits = useMonthCredits(my);
   const prevMonthCredits = useMonthCredits(prevMy);
+  const { getCategory } = useCategorizer();
 
   const [range, setRange] = useState("Month");
 
@@ -62,7 +64,7 @@ export function Dashboard() {
       map[cat.id].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);
-  }, [payments]);
+  }, [payments, getCategory]);
 
   const topCats = byCategory.slice(0, 5);
   const totalCatSum = topCats.reduce((s, c) => s + c.total, 0) || 1;
@@ -114,7 +116,7 @@ export function Dashboard() {
       })),
     ];
     return combined.sort((a, b) => b.transactionDate - a.transactionDate).slice(0, 7);
-  }, [payments, failedPayments, credits]);
+  }, [payments, failedPayments, credits, getCategory]);
 
   const positive = stats.totalChange > 0;
   const dayNum = now.getDate();

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,15 +1,15 @@
 import { useMemo, useState } from "react";
-import { useTheme, useViewport } from "../ink/theme";
+import { useTheme, useViewport, type InkTheme } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, LiveDot, LinkBtn, PageHeader } from "../ink/primitives";
-import { AreaChart, Donut, Sparkline } from "../ink/charts";
+import { AreaChart, Donut } from "../ink/charts";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
-import { useMonthStats, useMonthSpendingByDay, useMonthTopMerchants } from "../hooks/useMonthlyAnalytics";
+import { useMonthStats, useMonthTopMerchants } from "../hooks/useMonthlyAnalytics";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { useCredits, useMonthCredits } from "../hooks/useCredits";
 import { formatCompact } from "../ink/format";
 import { getCategory, DEFAULT_CATEGORIES } from "../lib/utils";
-import { isWithinInterval, startOfMonth, endOfMonth, format } from "date-fns";
+import { isWithinInterval, startOfMonth, endOfMonth, subMonths, format } from "date-fns";
 
 export function Dashboard() {
   const T = useTheme();
@@ -17,16 +17,31 @@ export function Dashboard() {
   const now = new Date();
   const my = { month: now.getMonth(), year: now.getFullYear() };
 
+  const prevDate = subMonths(now, 1);
+  const prevMy = { month: prevDate.getMonth(), year: prevDate.getFullYear() };
+
   const stats = useMonthStats(my);
-  const daily = useMonthSpendingByDay(my);
   const topMerchants = useMonthTopMerchants(my, 5);
   const trend = useMonthlyTrend(9);
   const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
   const { credits } = useCredits();
   const monthCredits = useMonthCredits(my);
+  const prevMonthCredits = useMonthCredits(prevMy);
 
   const [range, setRange] = useState("Month");
+
+  const prevMonthName = format(prevDate, "MMMM");
+  const prevMonthShort = format(prevDate, "MMM");
+  const monthYearLabel = format(now, "MMMM yyyy");
+  const monthShortName = format(now, "MMM").toUpperCase();
+  const income = monthCredits.total;
+  const net = income - stats.total;
+  const savingsRate = income > 0 ? (net / income) * 100 : 0;
+  const incomeChange =
+    prevMonthCredits.total > 0
+      ? ((income - prevMonthCredits.total) / prevMonthCredits.total) * 100
+      : null;
 
   const trendData = useMemo(
     () => trend.map((m) => ({ label: m.label.slice(0, 3), value: m.total })),
@@ -101,19 +116,11 @@ export function Dashboard() {
     return combined.sort((a, b) => b.transactionDate - a.transactionDate).slice(0, 7);
   }, [payments, failedPayments, credits]);
 
-  const dailyValues = daily.map((d) => d.amount);
   const positive = stats.totalChange > 0;
   const dayNum = now.getDate();
   const hour = now.getHours();
   const greeting = hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
   const monthTitle = format(now, "MMMM, 'at a glance'");
-  const lowDay = Math.min(...dailyValues.filter((v) => v > 0), Infinity);
-  const highDay = Math.max(...dailyValues, 0);
-  const median = (() => {
-    const sorted = [...dailyValues].filter((v) => v > 0).sort((a, b) => a - b);
-    if (sorted.length === 0) return 0;
-    return sorted[Math.floor(sorted.length / 2)];
-  })();
 
   const monthShort = Math.round(stats.total).toLocaleString("en-US");
   const monthDecimals = stats.total.toFixed(2).split(".")[1];
@@ -135,57 +142,92 @@ export function Dashboard() {
           gap: T.density.gap,
         }}
       >
-        <Card pad="30px 32px" glow>
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-            <CardLabel>Spent this month · GEL</CardLabel>
+        <Card pad="28px 32px" glow>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <span
+                style={{
+                  width: 24,
+                  height: 24,
+                  borderRadius: 12,
+                  background: T.accentSoft,
+                  color: T.accent,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 13,
+                  fontWeight: 800,
+                  fontFamily: T.sans,
+                }}
+              >
+                ↓
+              </span>
+              <div
+                style={{
+                  fontSize: 10.5,
+                  color: T.muted,
+                  fontFamily: T.mono,
+                  fontWeight: 700,
+                  letterSpacing: 1.2,
+                  textTransform: "uppercase",
+                }}
+              >
+                Outgoing · {monthYearLabel}
+              </div>
+            </div>
             {stats.prevTotal > 0 && (
-              <Pill bg={T.accent} color="#fff">
-                {positive ? "↑" : "↓"} {Math.abs(stats.totalChange).toFixed(1)}%
+              <Pill bg={positive ? T.accentSoft : "rgba(75,217,162,0.15)"} color={positive ? T.accent : T.green}>
+                {positive ? "↑" : "↓"} {Math.abs(stats.totalChange).toFixed(1)}% vs {prevMonthShort}
               </Pill>
             )}
           </div>
           <div
             style={{
-              marginTop: 12,
-              fontSize: "clamp(52px, 8.2vw, 84px)",
-              fontWeight: 700,
-              letterSpacing: -4,
-              lineHeight: 1,
-              color: T.text,
-              fontFamily: T.sans,
-              whiteSpace: "nowrap",
+              marginTop: 18,
+              display: "flex",
+              alignItems: "baseline",
+              gap: 14,
+              flexWrap: "wrap",
             }}
           >
-            <span style={{ color: T.accent, opacity: 0.9 }}>₾</span>
-            {monthShort}
-            <span style={{ fontSize: "0.43em", color: T.muted }}>.{monthDecimals}</span>
-          </div>
-          <div style={{ fontSize: 13, color: T.muted, marginTop: 4, fontFamily: T.sans }}>
-            {stats.prevTotal > 0 ? `${positive ? "+" : "−"}₾${momDeltaRound.toLocaleString("en-US")} vs last month · ` : ""}
-            {dayNum} days · {stats.count} transactions
-          </div>
-          {monthCredits.total > 0 && (
             <div
               style={{
-                fontSize: 13,
-                marginTop: 12,
+                fontSize: "clamp(12px, 1vw, 13px)",
+                color: T.muted,
                 fontFamily: T.sans,
-                display: "flex",
-                gap: 16,
-                alignItems: "baseline",
-                flexWrap: "wrap",
+                fontWeight: 600,
+                letterSpacing: 0.3,
+                textTransform: "uppercase",
+                alignSelf: "flex-start",
+                marginTop: 10,
               }}
             >
-              <span style={{ color: T.green, fontWeight: 700 }}>
-                + ₾{Math.round(monthCredits.total).toLocaleString("en-US")}
-              </span>
-              <span style={{ color: T.muted }}>earned this month</span>
-              <span style={{ color: T.dim, fontFamily: T.mono, fontSize: 11 }}>
-                net {monthCredits.total - stats.total >= 0 ? "+" : "−"}₾
-                {Math.abs(Math.round(monthCredits.total - stats.total)).toLocaleString("en-US")}
-              </span>
+              You spent
             </div>
-          )}
+            <div
+              style={{
+                fontSize: "clamp(48px, 7.6vw, 78px)",
+                fontWeight: 700,
+                letterSpacing: -3.8,
+                lineHeight: 1,
+                color: T.text,
+                fontFamily: T.sans,
+                whiteSpace: "nowrap",
+              }}
+            >
+              <span style={{ color: T.accent, opacity: 0.9 }}>−₾</span>
+              {monthShort}
+              <span style={{ fontSize: "0.42em", color: T.muted }}>.{monthDecimals}</span>
+            </div>
+          </div>
+          <div style={{ fontSize: 13, color: T.muted, marginTop: 6, fontFamily: T.sans }}>
+            {stats.prevTotal > 0
+              ? `${positive ? "+" : "−"}₾${momDeltaRound.toLocaleString("en-US")} ${positive ? "more" : "less"} than ${prevMonthName} · `
+              : ""}
+            {dayNum} days · {stats.count} transactions
+          </div>
+
+          <CashflowBar T={T} income={income} spent={stats.total} />
           {T.chartsVisible && trendData.length > 0 && (
             <div style={{ marginTop: 22 }}>
               <AreaChart
@@ -226,45 +268,23 @@ export function Dashboard() {
             gap: T.density.gap,
           }}
         >
-          <Card accent pad="22px 26px" style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", gap: 16 }}>
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
-              <div style={{ fontSize: 12, color: T.accent, fontWeight: 700, fontFamily: T.sans, whiteSpace: "nowrap" }}>Daily avg</div>
-              <Pill>{dayNum}d</Pill>
-            </div>
-            <div>
-              <div style={{ fontSize: vp.narrow ? 32 : 40, fontWeight: 800, letterSpacing: -1.8, lineHeight: 1, color: T.text, fontFamily: T.sans }}>
-                ₾{Math.round(stats.total / Math.max(1, dayNum))}
-              </div>
-              <div style={{ fontSize: 11, color: T.muted, marginTop: 4, fontFamily: T.sans }}>
-                low ₾{Number.isFinite(lowDay) ? Math.round(lowDay) : 0} · high ₾{Math.round(highDay)} · median ₾{Math.round(median)}
-              </div>
-            </div>
-            {T.chartsVisible && dailyValues.length > 0 && (
-              <div style={{ marginTop: 8 }}>
-                <Sparkline values={dailyValues} width={280} height={28} stroke={T.accent} strokeWidth={1.5} />
-              </div>
-            )}
-          </Card>
+          <IncomeCard
+            T={T}
+            vpNarrow={vp.narrow}
+            income={income}
+            credits={monthCredits.credits}
+            incomeChange={incomeChange}
+            prevMonthShort={prevMonthShort}
+          />
 
-          <Card pad="22px 26px" style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", gap: 16 }}>
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
-              <CardLabel>Declined</CardLabel>
-              {stats.failedCount > 0 && <Pill>Watch</Pill>}
-            </div>
-            <div>
-              <div style={{ fontSize: vp.narrow ? 32 : 40, fontWeight: 800, letterSpacing: -1.8, lineHeight: 1, color: T.text, fontFamily: T.sans }}>
-                {stats.failedCount}
-              </div>
-              <div style={{ fontSize: 11, color: T.muted, marginTop: 4, fontFamily: T.sans }}>
-                {stats.failedCount === 0 ? "No declined payments this month" : "Failed payments this month"}
-              </div>
-            </div>
-            <div style={{ display: "flex", gap: 4 }}>
-              {Array.from({ length: Math.min(8, stats.failedCount) }).map((_, i) => (
-                <span key={i} style={{ flex: 1, height: 4, borderRadius: 2, background: T.accent, opacity: 0.4 + (i % 3) * 0.2 }} />
-              ))}
-            </div>
-          </Card>
+          <NetCashflowCard
+            T={T}
+            vpNarrow={vp.narrow}
+            net={net}
+            income={income}
+            savingsRate={savingsRate}
+            monthShortName={monthShortName}
+          />
         </div>
       </div>
 
@@ -409,5 +429,356 @@ export function Dashboard() {
         )}
       </Card>
     </div>
+  );
+}
+
+// Horizontal cashflow bar: visualises income → spent → net under the
+// hero number so "you spent" can't be mistaken for a balance.
+function CashflowBar({ T, income, spent }: { T: InkTheme; income: number; spent: number }) {
+  const net = Math.max(0, income - spent);
+  const scale = Math.max(income, spent, 1);
+  const spentPct = (spent / scale) * 100;
+  const netPct = (net / scale) * 100;
+  const overspent = income > 0 && spent > income;
+
+  return (
+    <div
+      style={{
+        marginTop: 22,
+        padding: "16px 18px",
+        background: T.panelAlt,
+        border: `1px solid ${T.line}`,
+        borderRadius: T.rMd,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 12,
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 14, flexWrap: "wrap" }}>
+          <CashflowLegend T={T} dot={T.accent} label="Spent" value={"₾" + Math.round(spent).toLocaleString("en-US")} />
+          <CashflowLegend
+            T={T}
+            dot={T.green}
+            label="Net"
+            value={(net >= 0 ? "+₾" : "−₾") + Math.abs(Math.round(net)).toLocaleString("en-US")}
+            muted={income === 0}
+          />
+        </div>
+        <div
+          style={{
+            fontSize: 10.5,
+            color: T.dim,
+            fontFamily: T.mono,
+            letterSpacing: 0.6,
+            textTransform: "uppercase",
+          }}
+        >
+          {income > 0 ? `of ₾${Math.round(income).toLocaleString("en-US")} income` : "no income recorded"}
+        </div>
+      </div>
+
+      <div
+        style={{
+          position: "relative",
+          height: 12,
+          borderRadius: 6,
+          background: T.panel,
+          border: `1px solid ${T.line}`,
+          overflow: "hidden",
+          display: "flex",
+        }}
+      >
+        <div
+          style={{
+            width: `${spentPct}%`,
+            background: `linear-gradient(90deg, ${T.accent}, ${T.accent}cc)`,
+            transition: "width .6s cubic-bezier(0.2, 0.8, 0.2, 1)",
+          }}
+        />
+        <div
+          style={{
+            width: `${netPct}%`,
+            background: `repeating-linear-gradient(45deg, ${T.green}55 0 6px, ${T.green}22 6px 12px)`,
+            transition: "width .6s cubic-bezier(0.2, 0.8, 0.2, 1)",
+          }}
+        />
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginTop: 8,
+          fontSize: 10,
+          color: T.dim,
+          fontFamily: T.mono,
+        }}
+      >
+        <span>₾0</span>
+        <span style={{ color: overspent ? T.accent : T.muted }}>
+          {overspent
+            ? `⚠ Over income by ₾${Math.abs(Math.round(income - spent)).toLocaleString("en-US")}`
+            : income > 0
+              ? `${Math.round((spent / income) * 100)}% of income used`
+              : "spending only"}
+        </span>
+        <span>₾{Math.round(Math.max(income, spent)).toLocaleString("en-US")}</span>
+      </div>
+    </div>
+  );
+}
+
+function CashflowLegend({
+  T,
+  dot,
+  label,
+  value,
+  muted,
+}: {
+  T: InkTheme;
+  dot: string;
+  label: string;
+  value: string;
+  muted?: boolean;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <span style={{ width: 8, height: 8, borderRadius: 4, background: dot }} />
+      <div
+        style={{
+          fontSize: 10.5,
+          color: T.dim,
+          fontFamily: T.mono,
+          letterSpacing: 0.6,
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: 13,
+          fontWeight: 700,
+          color: muted ? T.muted : T.text,
+          fontFamily: T.sans,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+interface CreditRow {
+  id: string;
+  amount: number;
+  currency: string;
+  counterparty?: string;
+  transactionDate: number;
+  gelAmount: number | null;
+}
+
+function IncomeCard({
+  T,
+  vpNarrow,
+  income,
+  credits,
+  incomeChange,
+  prevMonthShort,
+}: {
+  T: InkTheme;
+  vpNarrow: boolean;
+  income: number;
+  credits: CreditRow[];
+  incomeChange: number | null;
+  prevMonthShort: string;
+}) {
+  // Show up to 5 most-recent deposits in the timeline (oldest → newest in
+  // the design; we keep that order so the vertical green-bar opacity ramp
+  // reads as "history fills toward today").
+  const timeline = [...credits]
+    .sort((a, b) => a.transactionDate - b.transactionDate)
+    .slice(-5);
+
+  return (
+    <Card
+      pad="18px 22px"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        borderColor: "rgba(75,217,162,0.25)",
+        background: `linear-gradient(180deg, rgba(75,217,162,0.06), ${T.panel})`,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: 10,
+              background: "rgba(75,217,162,0.15)",
+              color: T.green,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 11,
+              fontWeight: 800,
+              fontFamily: T.sans,
+            }}
+          >
+            ↑
+          </span>
+          <div style={{ fontSize: 12, color: T.green, fontWeight: 700, fontFamily: T.sans }}>Income</div>
+        </div>
+        {incomeChange !== null && (
+          <Pill bg="rgba(75,217,162,0.12)" color={T.green}>
+            {incomeChange >= 0 ? "+" : "−"}
+            {Math.abs(incomeChange).toFixed(0)}% vs {prevMonthShort}
+          </Pill>
+        )}
+      </div>
+
+      <div
+        style={{
+          fontSize: vpNarrow ? 26 : 32,
+          fontWeight: 800,
+          letterSpacing: -1.2,
+          lineHeight: 1,
+          color: T.text,
+          fontFamily: T.sans,
+          whiteSpace: "nowrap",
+        }}
+      >
+        <span style={{ color: T.green, opacity: 0.9 }}>+₾</span>
+        {Math.round(income).toLocaleString("en-US")}
+      </div>
+
+      {timeline.length === 0 ? (
+        <div style={{ fontSize: 11, color: T.muted, fontFamily: T.sans, marginTop: 2 }}>
+          No incoming transactions this month yet.
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 5, marginTop: 2 }}>
+          {timeline.map((c, i) => (
+            <div key={c.id} style={{ display: "flex", alignItems: "center", gap: 8, fontFamily: T.sans }}>
+              <span
+                style={{
+                  width: 3,
+                  height: 14,
+                  borderRadius: 2,
+                  background: T.green,
+                  opacity: 0.5 + (i / Math.max(1, timeline.length - 1)) * 0.45,
+                }}
+              />
+              <span
+                style={{
+                  fontSize: 10,
+                  color: T.dim,
+                  fontFamily: T.mono,
+                  minWidth: 46,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {new Date(c.transactionDate)
+                  .toLocaleString("en-US", { month: "short", day: "numeric" })
+                  .toUpperCase()}
+              </span>
+              <span
+                style={{
+                  flex: 1,
+                  fontSize: 11,
+                  color: T.text,
+                  fontWeight: 500,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {c.counterparty || "Income"}
+              </span>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: T.text,
+                  fontWeight: 700,
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                ₾{Math.round(c.gelAmount ?? c.amount).toLocaleString("en-US")}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function NetCashflowCard({
+  T,
+  vpNarrow,
+  net,
+  income,
+  savingsRate,
+  monthShortName,
+}: {
+  T: InkTheme;
+  vpNarrow: boolean;
+  net: number;
+  income: number;
+  savingsRate: number;
+  monthShortName: string;
+}) {
+  const positiveNet = net >= 0;
+  return (
+    <Card pad="18px 22px" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+        <span style={{ whiteSpace: "nowrap" }}>
+          <CardLabel>Net cashflow · {monthShortName}</CardLabel>
+        </span>
+        {income > 0 && (
+          <Pill
+            bg={positiveNet ? "rgba(75,217,162,0.12)" : T.accentSoft}
+            color={positiveNet ? T.green : T.accent}
+          >
+            {savingsRate >= 0 ? "+" : ""}
+            {savingsRate.toFixed(0)}% saved
+          </Pill>
+        )}
+      </div>
+
+      <div
+        style={{
+          fontSize: vpNarrow ? 32 : 40,
+          fontWeight: 800,
+          letterSpacing: -1.6,
+          lineHeight: 1,
+          color: T.text,
+          fontFamily: T.sans,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {positiveNet ? "+₾" : "−₾"}
+        {Math.abs(Math.round(net)).toLocaleString("en-US")}
+      </div>
+
+      <div style={{ fontSize: 12, color: T.muted, fontFamily: T.sans, lineHeight: 1.5 }}>
+        {income === 0
+          ? "No income recorded this month."
+          : positiveNet
+            ? "Unspent income this month."
+            : "Spending exceeded income this month."}
+      </div>
+    </Card>
   );
 }

--- a/client/src/pages/Merchants.tsx
+++ b/client/src/pages/Merchants.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, PageHeader } from "../ink/primitives";
 import { useConvertedPayments } from "../hooks/useTransactions";
-import { getCategory } from "../lib/utils";
+import { useCategorizer } from "../hooks/useCategorizer";
 import { isWithinInterval, startOfMonth, endOfMonth, format } from "date-fns";
 
 export function Merchants() {
@@ -12,6 +12,7 @@ export function Merchants() {
   const monthStart = startOfMonth(now);
   const monthEnd = endOfMonth(now);
   const { payments } = useConvertedPayments();
+  const { getCategory } = useCategorizer();
   const [search, setSearch] = useState("");
 
   const merchants = useMemo(() => {

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -5,6 +5,7 @@ import { useBankSenders } from "../hooks/useBankSenders";
 import { useDeleteAllData } from "../hooks/useDeleteAllData";
 import { usePayments, useFailedPayments } from "../hooks/useTransactions";
 import { useCredits } from "../hooks/useCredits";
+import { SettingsAISection } from "../components/SettingsAISection";
 
 export function Settings() {
   const T = useTheme();
@@ -76,6 +77,8 @@ export function Settings() {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%", overflowY: "auto" }}>
       <PageHeader eyebrow="Settings · preferences · data" title="Manage" ranges={null} />
+
+      <SettingsAISection />
 
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: T.density.gap }}>
         <Section

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -5,7 +5,8 @@ import { Card, CardLabel, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
 import { useBankSenders } from "../hooks/useBankSenders";
-import { DEFAULT_CATEGORIES, getCategory, categorizeId } from "../lib/utils";
+import { DEFAULT_CATEGORIES } from "../lib/utils";
+import { useCategorizer } from "../hooks/useCategorizer";
 import { currencySymbol, formatLocalDay, parseLocalDay } from "../ink/format";
 
 type TxKind = "all" | "payment" | "failed";
@@ -16,6 +17,7 @@ export function Transactions() {
   const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
   const { senders } = useBankSenders();
+  const { getCategory, categorize: categorizeId } = useCategorizer();
 
   // `?category=<id>` pre-selects the category filter on load. Categories
   // page navigates here with this param when the user clicks "All →" on
@@ -66,7 +68,7 @@ export function Transactions() {
       })),
     ];
     return combined.sort((a, b) => b.transactionDate - a.transactionDate);
-  }, [payments, failedPayments]);
+  }, [payments, failedPayments, categorizeId]);
 
   const filtered = useMemo(() => {
     return allTx.filter((t) => {

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -5,3 +5,4 @@ export { Merchants } from "./Merchants";
 export { Income } from "./Income";
 export { Analytics as Signals } from "./Analytics";
 export { Settings } from "./Settings";
+export { Assistant } from "./Assistant";

--- a/service/bun.lock
+++ b/service/bun.lock
@@ -5,9 +5,11 @@
     "": {
       "name": "sms-expense-service",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
         "@instantdb/admin": "latest",
         "boxen": "^8.0.1",
         "chalk": "^5.6.2",
+        "openai": "^6.34.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -16,6 +18,10 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "@instantdb/admin": ["@instantdb/admin@0.22.96", "", { "dependencies": { "@instantdb/core": "0.22.96", "@instantdb/version": "0.22.96", "eventsource": "^4.0.0" } }, "sha512-jkFNVeK/pfCnPLRrs5yldXOOk6AXmyxuLyhxxSHRAn3IrMMgpH3iLvhO/6tZy9Niw7mve+6NCNxzxFKrAu8CiQ=="],
 
     "@instantdb/core": ["@instantdb/core@0.22.96", "", { "dependencies": { "@instantdb/version": "0.22.96", "mutative": "^1.0.10", "uuid": "^11.1.0" } }, "sha512-xD7vsR9OxnuxrZK1kyyv0YJZ9cgG/JYqthLKP4pBbqsEa4z92d5jqSfeSPEGvREn6ti4+JOuuBbjtRrnxY2x3g=="],
@@ -52,11 +58,17 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "mutative": ["mutative@1.3.0", "", {}, "sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ=="],
+
+    "openai": ["openai@6.34.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 

--- a/service/package.json
+++ b/service/package.json
@@ -17,9 +17,11 @@
     "build:binary": "bun run build:embed && bun build --compile --target=bun-darwin-arm64 src/index.ts --outfile dist/xarji"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.91.1",
     "@instantdb/admin": "latest",
     "boxen": "^8.0.1",
-    "chalk": "^5.6.2"
+    "chalk": "^5.6.2",
+    "openai": "^6.34.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/service/src/ai/anthropic.ts
+++ b/service/src/ai/anthropic.ts
@@ -1,36 +1,29 @@
-// Anthropic provider — uses client.messages.stream() with adaptive
-// thinking (per the claude-api skill default for anything non-trivial).
-// Browser usage requires `dangerouslyAllowBrowser: true`; XSS-exfil
-// risk is acceptable here because Xarji is a single-user local-first
-// app with no third-party scripts on the page.
+// Anthropic provider — runs inside xarji-core. The browser never sees
+// the API key; it sends a generic AIStreamRequest to /api/ai/stream and
+// the service forwards to api.anthropic.com using the key stored in
+// ~/.xarji/config.json.
 
 import Anthropic from "@anthropic-ai/sdk";
 import type {
   AICoreMessage,
-  AIProviderClient,
-  AIStreamEvent,
-  AIStreamOpts,
+  AIProvider,
   AIStopReason,
-} from "../types";
+  AIStreamEvent,
+  AIToolDefinition,
+} from "./types";
 
-export function makeAnthropicProvider(apiKey: string): AIProviderClient {
-  const client = new Anthropic({
-    apiKey,
-    dangerouslyAllowBrowser: true,
-  });
-
+export function makeAnthropicProvider(): AIProvider {
   return {
     id: "anthropic",
-    async *stream(opts: AIStreamOpts): AsyncIterable<AIStreamEvent> {
+    async *stream(opts): AsyncIterable<AIStreamEvent> {
+      const client = new Anthropic({ apiKey: opts.apiKey });
       const messages = opts.messages.map(toAnthropicMessage);
-      const tools = opts.tools.map((t) => ({
+      const tools = opts.tools.map((t: AIToolDefinition) => ({
         name: t.name,
         description: t.description,
         input_schema: t.inputSchema as Anthropic.Tool["input_schema"],
       }));
 
-      // Tool input arrives as JSON streamed over multiple deltas. Buffer
-      // by content-block index and finalize on content_block_stop.
       const toolBuffers = new Map<number, { id: string; name: string; jsonText: string }>();
       let stopReason: AIStopReason = "other";
 
@@ -84,7 +77,7 @@ export function makeAnthropicProvider(apiKey: string): AIProviderClient {
           }
         }
       } catch (err) {
-        yield { kind: "error", error: err };
+        yield { kind: "error", error: err instanceof Error ? err.message : String(err) };
         return;
       }
 
@@ -110,7 +103,6 @@ function toAnthropicMessage(m: AICoreMessage): Anthropic.MessageParam {
             is_error: p.isError,
           };
         }
-        // tool_use blocks should never appear in a user message; skip.
         return { type: "text", text: "" };
       }),
     };

--- a/service/src/ai/index.ts
+++ b/service/src/ai/index.ts
@@ -1,0 +1,24 @@
+// Provider factory. Service-side only — there's no dynamic-import
+// trick here because both SDKs ship in the compiled binary regardless
+// of which the user picks at runtime. Bundle size matters less than
+// startup latency for a long-running daemon.
+
+import { makeAnthropicProvider } from "./anthropic";
+import { makeOpenAIProvider } from "./openai";
+import type { AIProvider, AIProviderId, AIStreamEvent } from "./types";
+
+const cache = new Map<AIProviderId, AIProvider>();
+
+export function getProvider(id: AIProviderId): AIProvider {
+  const hit = cache.get(id);
+  if (hit) return hit;
+  const provider = id === "anthropic" ? makeAnthropicProvider() : makeOpenAIProvider();
+  cache.set(id, provider);
+  return provider;
+}
+
+/** Serialise an AIStreamEvent as a single SSE record. The dashboard's
+ *  proxy provider parses these on the other end. */
+export function serialiseEvent(event: AIStreamEvent): string {
+  return `event: ${event.kind}\ndata: ${JSON.stringify(event)}\n\n`;
+}

--- a/service/src/ai/openai.ts
+++ b/service/src/ai/openai.ts
@@ -1,25 +1,20 @@
-// OpenAI provider — Chat Completions streaming. Tool calls arrive as
-// indexed deltas; we accumulate by index and emit a single tool-call
-// event per call once the stream completes for that index.
+// OpenAI provider — runs inside xarji-core, same shape as the Anthropic
+// counterpart. Browser sends the generic AIStreamRequest; this module
+// hits api.openai.com using the key from ~/.xarji/config.json.
 
 import OpenAI from "openai";
 import type {
   AICoreMessage,
-  AIProviderClient,
-  AIStreamEvent,
-  AIStreamOpts,
+  AIProvider,
   AIStopReason,
-} from "../types";
+  AIStreamEvent,
+} from "./types";
 
-export function makeOpenAIProvider(apiKey: string): AIProviderClient {
-  const client = new OpenAI({
-    apiKey,
-    dangerouslyAllowBrowser: true,
-  });
-
+export function makeOpenAIProvider(): AIProvider {
   return {
     id: "openai",
-    async *stream(opts: AIStreamOpts): AsyncIterable<AIStreamEvent> {
+    async *stream(opts): AsyncIterable<AIStreamEvent> {
+      const client = new OpenAI({ apiKey: opts.apiKey });
       const messages = toOpenAIMessages(opts.systemPrompt, opts.messages);
       const tools = opts.tools.map((t) => ({
         type: "function" as const,
@@ -45,7 +40,7 @@ export function makeOpenAIProvider(apiKey: string): AIProviderClient {
           stream: true,
         });
       } catch (err) {
-        yield { kind: "error", error: err };
+        yield { kind: "error", error: err instanceof Error ? err.message : String(err) };
         return;
       }
 
@@ -87,12 +82,10 @@ export function makeOpenAIProvider(apiKey: string): AIProviderClient {
           }
         }
       } catch (err) {
-        yield { kind: "error", error: err };
+        yield { kind: "error", error: err instanceof Error ? err.message : String(err) };
         return;
       }
 
-      // Emit collected tool calls before the stop event so the
-      // orchestrator can dispatch them in order.
       for (const buf of [...toolBuffers.values()]) {
         let input: unknown;
         try {
@@ -121,8 +114,6 @@ function toOpenAIMessages(
         out.push({ role: "user", content: m.content });
         continue;
       }
-      // Tool results need to be split out into separate `tool` role messages
-      // (Chat Completions doesn't allow them inline in a user turn).
       const userText: string[] = [];
       const toolMessages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
       for (const p of m.content) {

--- a/service/src/ai/types.ts
+++ b/service/src/ai/types.ts
@@ -1,0 +1,59 @@
+// Service-side mirror of the AI protocol the dashboard speaks.
+// Wire format = JSON-encoded events streamed as SSE; this file defines
+// the shapes both sides agree on.
+//
+// Keep these in sync with client/src/lib/ai/types.ts. Any addition
+// requires updating both files (no shared package, on purpose — the
+// service ships as a compiled binary and the client as a browser
+// bundle, no good place for shared TS).
+
+export type AIProviderId = "anthropic" | "openai";
+
+export type AIContentPart =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | { type: "tool_result"; toolUseId: string; output: string; isError?: boolean };
+
+export type AICoreMessage =
+  | { role: "user"; content: string | AIContentPart[] }
+  | { role: "assistant"; content: AIContentPart[] };
+
+export interface AIToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export type AIStreamEvent =
+  | { kind: "text-delta"; text: string }
+  | { kind: "tool-call"; id: string; name: string; input: unknown }
+  | { kind: "stop"; reason: AIStopReason }
+  | { kind: "error"; error: string };
+
+export type AIStopReason =
+  | "end_turn"
+  | "tool_use"
+  | "max_tokens"
+  | "refusal"
+  | "pause_turn"
+  | "other";
+
+export interface AIStreamRequest {
+  provider: AIProviderId;
+  model: string;
+  systemPrompt: string;
+  messages: AICoreMessage[];
+  tools: AIToolDefinition[];
+}
+
+export interface AIProvider {
+  id: AIProviderId;
+  stream(opts: {
+    apiKey: string;
+    model: string;
+    systemPrompt: string;
+    messages: AICoreMessage[];
+    tools: AIToolDefinition[];
+    signal?: AbortSignal;
+  }): AsyncIterable<AIStreamEvent>;
+}

--- a/service/src/config.ts
+++ b/service/src/config.ts
@@ -28,6 +28,15 @@ export interface Config {
     headers?: Record<string, string>;
   };
 
+  // AI assistant provider keys. Stored on disk in ~/.xarji/config.json
+  // so they never reach the browser bundle. The dashboard talks to
+  // /api/ai/* and the service forwards to api.anthropic.com /
+  // api.openai.com using whichever key is set here.
+  aiProviderKeys: {
+    anthropic?: string;
+    openai?: string;
+  };
+
   // Polling interval in milliseconds (fallback if file watching fails)
   pollIntervalMs: number;
 }
@@ -57,6 +66,8 @@ export const defaultConfig: Config = {
       "Content-Type": "application/json",
     },
   },
+
+  aiProviderKeys: {},
 
   pollIntervalMs: 60000, // 1 minute fallback
 };
@@ -102,6 +113,35 @@ export async function saveConfig(config: Partial<Config>): Promise<void> {
 
   const merged = { ...defaultConfig, ...config };
   await Bun.write(configPath, JSON.stringify(merged, null, 2));
+}
+
+// Patch the on-disk config without overwriting the user's other
+// settings. Reads the current file, deep-merges the patch, writes back.
+// Used by /api/ai/keys so the user can add/rotate provider keys without
+// re-running the full setup wizard.
+export async function patchConfig(patch: Partial<Config>): Promise<Config> {
+  const configDir = join(home, ".xarji");
+  const configPath = join(configDir, "config.json");
+  await Bun.$`mkdir -p ${configDir}`;
+
+  let current: Config;
+  try {
+    const text = require("fs").readFileSync(configPath, "utf-8");
+    current = { ...defaultConfig, ...JSON.parse(text) };
+  } catch {
+    current = { ...defaultConfig };
+  }
+
+  const next: Config = {
+    ...current,
+    ...patch,
+    instantdb: { ...current.instantdb, ...(patch.instantdb ?? {}) },
+    webhook: { ...current.webhook, ...(patch.webhook ?? {}) },
+    aiProviderKeys: { ...current.aiProviderKeys, ...(patch.aiProviderKeys ?? {}) },
+  };
+
+  await Bun.write(configPath, JSON.stringify(next, null, 2));
+  return next;
 }
 
 export const CONFIG_DIR = join(home, ".xarji");

--- a/service/src/http.ts
+++ b/service/src/http.ts
@@ -29,6 +29,9 @@ import {
   NbgRequestFailedError,
   type NbgLanguage,
 } from "./exchange-rate/nbg-client";
+import { patchConfig, CONFIG_PATH } from "./config";
+import { getProvider, serialiseEvent } from "./ai";
+import type { AIProviderId, AIStreamRequest } from "./ai/types";
 
 export interface HttpServerOptions {
   port: number;
@@ -371,6 +374,123 @@ export function startHttpServer(opts: HttpServerOptions): HttpServerHandle {
           return json({ ok: false, error: String(err), errorKind: "internal" }, { status: 500 });
         }
       }
+      if (path === "/api/ai/keys" && req.method === "GET") {
+        // Boolean presence only — never echo the key value back.
+        const keys = opts.config.aiProviderKeys ?? {};
+        return json({
+          anthropic: !!keys.anthropic,
+          openai: !!keys.openai,
+        });
+      }
+
+      if (path === "/api/ai/keys" && req.method === "POST") {
+        let body: { provider?: unknown; apiKey?: unknown };
+        try {
+          body = (await req.json()) as { provider?: unknown; apiKey?: unknown };
+        } catch {
+          return json({ error: "Body must be valid JSON" }, { status: 400 });
+        }
+        const provider = body.provider;
+        const apiKey = body.apiKey;
+        if (provider !== "anthropic" && provider !== "openai") {
+          return json({ error: "`provider` must be 'anthropic' or 'openai'" }, { status: 400 });
+        }
+        if (typeof apiKey !== "string" || apiKey.trim().length < 20) {
+          return json({ error: "`apiKey` must be a non-empty string" }, { status: 400 });
+        }
+        const next = await patchConfig({
+          aiProviderKeys: { [provider]: apiKey.trim() },
+        });
+        opts.config = next;
+        return json({ ok: true });
+      }
+
+      if (path.startsWith("/api/ai/keys/") && req.method === "DELETE") {
+        const segments = path.split("/");
+        const provider = segments[segments.length - 1];
+        if (provider !== "anthropic" && provider !== "openai") {
+          return json({ error: "Unknown provider" }, { status: 400 });
+        }
+        // patchConfig deep-merges so it can't express "remove this key";
+        // do a direct read-prune-write instead.
+        const cfg = loadConfig();
+        const next = { ...(cfg.aiProviderKeys ?? {}) };
+        delete next[provider as "anthropic" | "openai"];
+        const updated = { ...cfg, aiProviderKeys: next };
+        await Bun.write(CONFIG_PATH, JSON.stringify(updated, null, 2));
+        opts.config = updated;
+        return json({ ok: true });
+      }
+
+      if (path === "/api/ai/stream" && req.method === "POST") {
+        let body: AIStreamRequest;
+        try {
+          body = (await req.json()) as AIStreamRequest;
+        } catch {
+          return json({ error: "Body must be valid JSON" }, { status: 400 });
+        }
+        const providerId = body.provider as AIProviderId;
+        if (providerId !== "anthropic" && providerId !== "openai") {
+          return json({ error: "`provider` must be 'anthropic' or 'openai'" }, { status: 400 });
+        }
+        const apiKey = opts.config.aiProviderKeys?.[providerId];
+        if (!apiKey) {
+          return json(
+            { error: `No API key configured for ${providerId}. Set one via POST /api/ai/keys.` },
+            { status: 412 }
+          );
+        }
+        if (!body.model || typeof body.model !== "string") {
+          return json({ error: "`model` is required" }, { status: 400 });
+        }
+        if (!Array.isArray(body.messages) || body.messages.length === 0) {
+          return json({ error: "`messages` must be a non-empty array" }, { status: 400 });
+        }
+
+        const provider = getProvider(providerId);
+        const upstreamAbort = new AbortController();
+        // If the dashboard disconnects mid-stream, propagate to the
+        // upstream provider so we don't keep paying for tokens nobody
+        // will ever read.
+        req.signal.addEventListener("abort", () => upstreamAbort.abort());
+
+        const sse = new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            try {
+              for await (const event of provider.stream({
+                apiKey,
+                model: body.model,
+                systemPrompt: body.systemPrompt ?? "",
+                messages: body.messages,
+                tools: body.tools ?? [],
+                signal: upstreamAbort.signal,
+              })) {
+                controller.enqueue(encoder.encode(serialiseEvent(event)));
+              }
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              controller.enqueue(
+                encoder.encode(serialiseEvent({ kind: "error", error: message }))
+              );
+            } finally {
+              controller.close();
+            }
+          },
+          cancel() {
+            upstreamAbort.abort();
+          },
+        });
+
+        return new Response(sse, {
+          headers: {
+            "content-type": "text/event-stream; charset=utf-8",
+            "cache-control": "no-store",
+            "x-accel-buffering": "no",
+          },
+        });
+      }
+
       if (path.startsWith("/api/")) {
         return json({ error: "unknown endpoint" }, { status: 404 });
       }

--- a/service/src/instant-schema.ts
+++ b/service/src/instant-schema.ts
@@ -74,6 +74,19 @@ const schema = i.schema({
       enabled: i.boolean(),
       createdAt: i.number(),
     }),
+
+    // Manual category overrides per merchant. The dashboard's regex
+    // categoriser is a sensible default but doesn't know about the
+    // user's intent — e.g. they may want SOCAR routed to "Cash &
+    // ATM" instead of "Transport" because they pay with cash there.
+    // One row per merchant; the override wins everywhere the user-
+    // facing categoriser is consulted (Dashboard donut, Categories
+    // page, AI tools).
+    merchantCategoryOverrides: i.entity({
+      merchant: i.string().unique(),
+      categoryId: i.string(),
+      createdAt: i.number(),
+    }),
   },
   links: {},
 });


### PR DESCRIPTION
Four independent things bundled into one PR — they accumulated together while iterating on the design.

**AI Assistant** is the headline. Adds `/assistant` (full thread sidebar + chat with provider/model picker), a global ⌘K Spotlight that creates and auto-runs threads from any page, and a `Manage → AI Assistant` card for switching providers and rotating keys. The interesting part is `client/src/lib/ai/`: a provider abstraction with two implementations (Anthropic and OpenAI) that are dynamically imported so only the active one ships in the bundle, plus a tool registry with 5 read-only tools that run locally against the live React-side data context. The orchestrator drives the provider→tool→provider loop with an 8-iteration cap and emits typed events the chat renders as text deltas, tool-call pills, structured cards, and contextual "Reading your month summary…" / "Searching your transactions…" status while loading. Anthropic uses adaptive thinking on `claude-opus-4-7` by default; OpenAI uses chat completions streaming on `gpt-5`. Both run browser-direct with `dangerouslyAllowBrowser` — keys live in localStorage and go straight to the provider API, never to xarji-core. CLAUDE.md gets a new §12 documenting the layout, the "tools must appear in the system prompt" rule (the prompt auto-includes every registered tool's name + description), and the consent-flow shape for future write tools.

**Demo-mode toggle** swaps the InstantDB client for an in-memory deterministic dataset when `?demo=1` is passed or the toggle is flipped in Tweaks. Wraps the real client behind a Proxy so every existing hook keeps working unchanged. Gated on `import.meta.env.DEV` — the demo branch is dead-stripped in production builds.

**Dashboard hero, income, and net cashflow cards redesign.** "Outgoing · {Month}" eyebrow with explicit −₾ outflow framing instead of an ambiguous balance-looking number, CashflowBar visualising spent-vs-net under the hero. Income card gets a deposit timeline of the most recent credits. Net cashflow simplified per request — savings rate pill, big number, one-line summary, no projection box.

**Favicon swap** brings the dashboard tab icon in line with the landing site (the same coral-gradient X SVG).