### PR TITLE
Wire Today/Week/Month/Year/Custom range buttons through aggregators

### DIFF
--- a/client/src/hooks/useCredits.ts
+++ b/client/src/hooks/useCredits.ts
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
 import { db, type Credit } from "../lib/instant";
-import { isWithinInterval, startOfMonth, endOfMonth } from "date-fns";
+import { startOfMonth, endOfMonth, format } from "date-fns";
 import { useGelConverter } from "../lib/exchangeRates";
 import type { MonthYear } from "./useMonthlyAnalytics";
+import { isInRange, type DateRange } from "../lib/dateRange";
 
 export function useCredits() {
   const { data, isLoading, error } = db.useQuery({ credits: {} });
@@ -27,32 +28,28 @@ export function useConvertedCredits() {
   return { credits: converted, isLoading, error };
 }
 
-export function useMonthCredits(my: MonthYear) {
+export function useRangeCredits(range: DateRange) {
   const { credits } = useConvertedCredits();
 
   return useMemo(() => {
-    const start = startOfMonth(new Date(my.year, my.month, 1));
-    const end = endOfMonth(new Date(my.year, my.month, 1));
-    const monthCredits = credits.filter((c) =>
-      isWithinInterval(new Date(c.transactionDate), { start, end })
-    );
+    const inRange = credits.filter((c) => isInRange(c.transactionDate, range));
     // `total` sums every currency converted to GEL; `count` reflects rows
     // that have actually contributed (i.e. either GEL or non-GEL with a
     // resolved rate). Rows still waiting on a rate are kept in `credits`
     // but excluded from the totals until the rate lands.
     let total = 0;
     let count = 0;
-    for (const c of monthCredits) {
+    for (const c of inRange) {
       if (c.gelAmount === null) continue;
       total += c.gelAmount;
       count += 1;
     }
-    return { total, count, credits: monthCredits };
-  }, [credits, my.month, my.year]);
+    return { total, count, credits: inRange };
+  }, [credits, range]);
 }
 
-export function useMonthCashflow(my: MonthYear, spendingTotal: number) {
-  const income = useMonthCredits(my);
+export function useRangeCashflow(range: DateRange, spendingTotal: number) {
+  const income = useRangeCredits(range);
   return {
     income: income.total,
     spending: spendingTotal,
@@ -60,3 +57,16 @@ export function useMonthCashflow(my: MonthYear, spendingTotal: number) {
     incomeCount: income.count,
   };
 }
+
+// Backwards-compat shim — Dashboard + Income still call this with a
+// MonthYear; converts to DateRange and forwards. Removed once those
+// callers migrate to useRangeCredits in this same PR.
+export function useMonthCredits(my: MonthYear) {
+  const range = useMemo<DateRange>(() => {
+    const start = startOfMonth(new Date(my.year, my.month, 1));
+    const end = endOfMonth(start);
+    return { start, end, label: format(start, "MMMM yyyy"), key: "Month" };
+  }, [my.month, my.year]);
+  return useRangeCredits(range);
+}
+

--- a/client/src/hooks/useMonthlyAnalytics.ts
+++ b/client/src/hooks/useMonthlyAnalytics.ts
@@ -1,31 +1,15 @@
 import { useMemo } from "react";
 import { db } from "../lib/instant";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
-import { useCategorizer } from "./useCategorizer";
 import { formatLocalDay } from "../ink/format";
 import { useConvertedPayments } from "./useTransactions";
-import {
-  startOfMonth,
-  endOfMonth,
-  subMonths,
-  isWithinInterval,
-  getDaysInMonth,
-  format,
-} from "date-fns";
+import { useCategorizer } from "./useCategorizer";
+import { startOfMonth, endOfMonth, format, differenceInDays } from "date-fns";
+import { isInRange, previousRange, type DateRange } from "../lib/dateRange";
 
 export interface MonthYear {
   month: number; // 0-11
   year: number;
-}
-
-function getMonthInterval(my: MonthYear) {
-  const d = new Date(my.year, my.month, 1);
-  return { start: startOfMonth(d), end: endOfMonth(d) };
-}
-
-function getPreviousMonth(my: MonthYear): MonthYear {
-  const d = subMonths(new Date(my.year, my.month, 1), 1);
-  return { month: d.getMonth(), year: d.getFullYear() };
 }
 
 export function useAvailableMonths() {
@@ -61,31 +45,30 @@ export function useAvailableMonths() {
   }, [paymentsData?.payments, failedData?.failedPayments]);
 }
 
-export function useMonthStats(my: MonthYear) {
+/** Filters payments + failed-payments to the given date range, returns
+ *  the totals + comparisons against the previous equal-length window.
+ *  Replaces the old useMonthStats(my) — the page now decides the range
+ *  via the PageHeader buttons. */
+export function useRangeStats(range: DateRange) {
   const { payments } = useConvertedPayments();
   const { data: failedData } = db.useQuery({ failedPayments: {} });
 
   return useMemo(() => {
     const failed = failedData?.failedPayments || [];
-    const interval = getMonthInterval(my);
-    const prevInterval = getMonthInterval(getPreviousMonth(my));
+    const prev = previousRange(range);
+    const inCur = (ts: number) => isInRange(ts, range);
+    const inPrev = (ts: number) => isInRange(ts, prev);
 
-    const inRange = (date: number, iv: { start: Date; end: Date }) =>
-      isWithinInterval(new Date(date), iv);
-
-    // Sum every currency converted to GEL via the NBG rate for each
-    // transaction's date. Rows still loading (`gelAmount === null`)
-    // skip the total this render, then snap in once the rate arrives.
     let total = 0;
     let count = 0;
     let prevTotal = 0;
     let prevCount = 0;
     for (const p of payments) {
-      const inCur = inRange(p.transactionDate, interval);
-      const inPrev = !inCur && inRange(p.transactionDate, prevInterval);
-      if (!inCur && !inPrev) continue;
+      const cur = inCur(p.transactionDate);
+      const previous = !cur && inPrev(p.transactionDate);
+      if (!cur && !previous) continue;
       if (p.gelAmount === null) continue;
-      if (inCur) {
+      if (cur) {
         total += p.gelAmount;
         count += 1;
       } else {
@@ -93,7 +76,8 @@ export function useMonthStats(my: MonthYear) {
         prevCount += 1;
       }
     }
-    const failedCount = failed.filter((p) => inRange(p.transactionDate, interval)).length;
+
+    const failedCount = failed.filter((p) => inCur(p.transactionDate)).length;
     const avg = count > 0 ? total / count : 0;
     const totalChange = prevTotal > 0 ? ((total - prevTotal) / prevTotal) * 100 : 0;
     const countChange = prevCount > 0 ? ((count - prevCount) / prevCount) * 100 : 0;
@@ -108,49 +92,59 @@ export function useMonthStats(my: MonthYear) {
       totalChange,
       countChange,
     };
-  }, [payments, failedData?.failedPayments, my.month, my.year]);
+  }, [payments, failedData?.failedPayments, range]);
 }
 
-export function useMonthSpendingByDay(my: MonthYear) {
+/** Aggregates spending into per-day buckets across the active range.
+ *  Returns at most ~93 days; longer ranges fall back to monthly buckets
+ *  so a "Year" view stays readable. */
+export function useRangeSpendingByDay(range: DateRange) {
   const { payments } = useConvertedPayments();
 
   return useMemo(() => {
-    const interval = getMonthInterval(my);
+    const days = differenceInDays(range.end, range.start) + 1;
+    const useMonthly = days > 93;
+    const buckets: Record<string, number> = {};
 
-    const monthPayments = payments.filter((p) =>
-      isWithinInterval(new Date(p.transactionDate), interval)
-    );
-
-    const dailyTotals: Record<string, number> = {};
-    for (const p of monthPayments) {
+    for (const p of payments) {
+      if (!isInRange(p.transactionDate, range)) continue;
       if (p.gelAmount === null) continue;
-      const date = formatLocalDay(p.transactionDate);
-      dailyTotals[date] = (dailyTotals[date] || 0) + p.gelAmount;
+      const d = new Date(p.transactionDate);
+      const key = useMonthly
+        ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
+        : formatLocalDay(p.transactionDate);
+      buckets[key] = (buckets[key] || 0) + p.gelAmount;
     }
 
-    const daysInMonth = getDaysInMonth(new Date(my.year, my.month, 1));
-    const result: { date: string; amount: number }[] = [];
-    for (let day = 1; day <= daysInMonth; day++) {
-      const date = formatLocalDay(new Date(my.year, my.month, day).getTime());
-      result.push({ date, amount: dailyTotals[date] || 0 });
+    if (useMonthly) {
+      const out: { date: string; amount: number }[] = [];
+      const cur = new Date(range.start);
+      cur.setDate(1);
+      while (cur.getTime() <= range.end.getTime()) {
+        const key = `${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, "0")}`;
+        out.push({ date: key, amount: buckets[key] || 0 });
+        cur.setMonth(cur.getMonth() + 1);
+      }
+      return out;
     }
 
-    return result;
-  }, [payments, my.month, my.year]);
+    const out: { date: string; amount: number }[] = [];
+    for (let i = 0; i < days; i++) {
+      const d = new Date(range.start.getFullYear(), range.start.getMonth(), range.start.getDate() + i);
+      const key = formatLocalDay(d.getTime());
+      out.push({ date: key, amount: buckets[key] || 0 });
+    }
+    return out;
+  }, [payments, range]);
 }
 
-export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
+export function useRangeTopMerchants(range: DateRange, limit: number = 10) {
   const { payments } = useConvertedPayments();
 
   return useMemo(() => {
-    const interval = getMonthInterval(my);
-
-    const monthPayments = payments.filter((p) =>
-      isWithinInterval(new Date(p.transactionDate), interval)
-    );
-
     const merchantTotals: Record<string, { total: number; count: number }> = {};
-    for (const p of monthPayments) {
+    for (const p of payments) {
+      if (!isInRange(p.transactionDate, range)) continue;
       if (p.gelAmount === null) continue;
       const merchant = p.merchant || "Unknown";
       if (!merchantTotals[merchant]) merchantTotals[merchant] = { total: 0, count: 0 };
@@ -162,22 +156,16 @@ export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
       .map(([name, data]) => ({ name, ...data }))
       .sort((a, b) => b.total - a.total)
       .slice(0, limit);
-  }, [payments, my.month, my.year, limit]);
+  }, [payments, range, limit]);
 }
 
-export function useMonthCategoryAnalytics(my: MonthYear) {
+export function useRangeCategoryAnalytics(range: DateRange) {
   const { payments } = useConvertedPayments();
   const { data: catData } = db.useQuery({ categories: {} });
   const { categorizeName } = useCategorizer();
 
   return useMemo(() => {
     const categories = catData?.categories || [];
-    const interval = getMonthInterval(my);
-
-    const monthPayments = payments.filter((p) =>
-      isWithinInterval(new Date(p.transactionDate), interval)
-    );
-
     const categoryTotals: Record<string, { total: number; count: number; color: string }> = {};
 
     const cats = categories.length > 0 ? categories : DEFAULT_CATEGORIES;
@@ -188,7 +176,8 @@ export function useMonthCategoryAnalytics(my: MonthYear) {
       categoryTotals["Other"] = { total: 0, count: 0, color: "#6b7280" };
     }
 
-    for (const payment of monthPayments) {
+    for (const payment of payments) {
+      if (!isInRange(payment.transactionDate, range)) continue;
       if (payment.gelAmount === null) continue;
       const categoryName = categorizeName(payment.merchant ?? null);
       if (categoryTotals[categoryName]) {
@@ -215,5 +204,34 @@ export function useMonthCategoryAnalytics(my: MonthYear) {
         percentage: totalSpent > 0 ? (cat.total / totalSpent) * 100 : 0,
       })),
     };
-  }, [payments, catData?.categories, my.month, my.year, categorizeName]);
+  }, [payments, catData?.categories, range, categorizeName]);
 }
+
+// ──────────────────────────────────────────────────────────────────
+// Backwards-compat shims so call sites that still pass MonthYear keep
+// working through the migration. Each just builds the equivalent
+// DateRange and forwards. Deleted once every page has moved to the
+// range-based hooks.
+
+function rangeFromMonth(my: MonthYear): DateRange {
+  const start = startOfMonth(new Date(my.year, my.month, 1));
+  const end = endOfMonth(start);
+  return { start, end, label: format(start, "MMMM yyyy"), key: "Month" };
+}
+
+export function useMonthStats(my: MonthYear) {
+  return useRangeStats(useMemo(() => rangeFromMonth(my), [my.month, my.year]));
+}
+
+export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
+  return useRangeTopMerchants(useMemo(() => rangeFromMonth(my), [my.month, my.year]), limit);
+}
+
+export function useMonthCategoryAnalytics(my: MonthYear) {
+  return useRangeCategoryAnalytics(useMemo(() => rangeFromMonth(my), [my.month, my.year]));
+}
+
+export function useMonthSpendingByDay(my: MonthYear) {
+  return useRangeSpendingByDay(useMemo(() => rangeFromMonth(my), [my.month, my.year]));
+}
+

--- a/client/src/hooks/useRangeState.ts
+++ b/client/src/hooks/useRangeState.ts
@@ -3,7 +3,7 @@
 // derived DateRange + the props PageHeader needs (active/onRange/
 // custom inputs). Pages stay one-liner thin.
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { rangeFromKey, type DateRange, type RangeKey } from "../lib/dateRange";
 
 export interface RangeStateProps {
@@ -23,14 +23,17 @@ export function useRangeState(initial: RangeKey = "Month"): UseRangeStateResult 
   const [active, setActive] = useState<RangeKey>(initial);
   const [customStart, setCustomStart] = useState("");
   const [customEnd, setCustomEnd] = useState("");
+  // `clockTick` advances at the next local-midnight boundary so a
+  // long-lived dashboard tab doesn't keep showing yesterday's "Today"
+  // (or the previous month's "Month") after the calendar rolls over.
+  // Including it in the memo deps below recomputes the range without
+  // wedging it on a stale `new Date()` from the initial render.
+  const clockTick = useMidnightTick();
 
-  // `now` is captured per render so the hooks downstream see a stable
-  // input within a single React commit. Re-evaluating on every commit
-  // is fine: the underlying data only changes when InstantDB pushes
-  // an update, and the buckets snap to whatever "today" is then.
   const range = useMemo(
     () => rangeFromKey(active, new Date(), { start: customStart, end: customEnd }),
-    [active, customStart, customEnd]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [active, customStart, customEnd, clockTick]
   );
 
   return {
@@ -46,4 +49,39 @@ export function useRangeState(initial: RangeKey = "Month"): UseRangeStateResult 
       },
     },
   };
+}
+
+/** Returns a state value that bumps once per local-midnight rollover.
+ *  Cheap (one timeout at a time, no per-second polling) and only fires
+ *  while the tab is mounted, so it doesn't leak when the user
+ *  navigates away. */
+function useMidnightTick(): number {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    let timeoutId: number | null = null;
+    const schedule = () => {
+      const now = new Date();
+      const nextMidnight = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate() + 1,
+        0,
+        0,
+        0,
+        0
+      ).getTime();
+      // +500ms cushion so we land safely on the new day even if the
+      // event loop runs the callback a few ms early.
+      const ms = Math.max(1000, nextMidnight - now.getTime() + 500);
+      timeoutId = window.setTimeout(() => {
+        setTick((t) => t + 1);
+        schedule();
+      }, ms);
+    };
+    schedule();
+    return () => {
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+    };
+  }, []);
+  return tick;
 }

--- a/client/src/hooks/useRangeState.ts
+++ b/client/src/hooks/useRangeState.ts
@@ -1,0 +1,49 @@
+// Shared range-button state for any page that renders the
+// Today/Week/Month/Year/Custom switcher in PageHeader. Returns the
+// derived DateRange + the props PageHeader needs (active/onRange/
+// custom inputs). Pages stay one-liner thin.
+
+import { useMemo, useState } from "react";
+import { rangeFromKey, type DateRange, type RangeKey } from "../lib/dateRange";
+
+export interface RangeStateProps {
+  active: RangeKey;
+  onRange: (key: string) => void;
+  customStart: string;
+  customEnd: string;
+  onCustomChange: (start: string, end: string) => void;
+}
+
+export interface UseRangeStateResult {
+  range: DateRange;
+  props: RangeStateProps;
+}
+
+export function useRangeState(initial: RangeKey = "Month"): UseRangeStateResult {
+  const [active, setActive] = useState<RangeKey>(initial);
+  const [customStart, setCustomStart] = useState("");
+  const [customEnd, setCustomEnd] = useState("");
+
+  // `now` is captured per render so the hooks downstream see a stable
+  // input within a single React commit. Re-evaluating on every commit
+  // is fine: the underlying data only changes when InstantDB pushes
+  // an update, and the buckets snap to whatever "today" is then.
+  const range = useMemo(
+    () => rangeFromKey(active, new Date(), { start: customStart, end: customEnd }),
+    [active, customStart, customEnd]
+  );
+
+  return {
+    range,
+    props: {
+      active,
+      onRange: (k) => setActive(k as RangeKey),
+      customStart,
+      customEnd,
+      onCustomChange: (start, end) => {
+        setCustomStart(start);
+        setCustomEnd(end);
+      },
+    },
+  };
+}

--- a/client/src/ink/primitives.tsx
+++ b/client/src/ink/primitives.tsx
@@ -174,6 +174,9 @@ export function PageHeader({
   ranges = ["Today", "Week", "Month", "Year", "Custom"],
   active = "Month",
   onRange,
+  customStart,
+  customEnd,
+  onCustomChange,
 }: {
   eyebrow?: React.ReactNode;
   title: React.ReactNode;
@@ -181,18 +184,70 @@ export function PageHeader({
   ranges?: string[] | null;
   active?: string;
   onRange?: (r: string) => void;
+  /** YYYY-MM-DD; only consulted when active === "Custom". */
+  customStart?: string;
+  customEnd?: string;
+  /** Fired whenever either custom date input changes. */
+  onCustomChange?: (start: string, end: string) => void;
 }) {
   const T = useTheme();
+  const showCustomInputs = ranges && ranges.includes("Custom") && active === "Custom" && onCustomChange;
+
   return (
-    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 20, marginBottom: 6 }}>
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 20, marginBottom: 6, flexWrap: "wrap" }}>
       <div>
         {eyebrow && <div style={{ fontSize: 12.5, color: T.muted, fontWeight: 500, fontFamily: T.sans }}>{eyebrow}</div>}
         <div style={{ fontSize: 28, fontWeight: 700, letterSpacing: -1, lineHeight: 1.1, marginTop: 4, color: T.text, fontFamily: T.sans }}>
           {title}
         </div>
       </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
         {rightSlot}
+        {showCustomInputs && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "4px 8px",
+              background: T.panel,
+              borderRadius: 12,
+              border: `1px solid ${T.line}`,
+            }}
+          >
+            <input
+              type="date"
+              value={customStart ?? ""}
+              max={customEnd || undefined}
+              onChange={(e) => onCustomChange!(e.target.value, customEnd ?? "")}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: T.text,
+                fontSize: 12,
+                fontFamily: T.mono,
+                padding: "4px 6px",
+                outline: "none",
+              }}
+            />
+            <span style={{ color: T.dim, fontSize: 12, fontFamily: T.mono }}>→</span>
+            <input
+              type="date"
+              value={customEnd ?? ""}
+              min={customStart || undefined}
+              onChange={(e) => onCustomChange!(customStart ?? "", e.target.value)}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: T.text,
+                fontSize: 12,
+                fontFamily: T.mono,
+                padding: "4px 6px",
+                outline: "none",
+              }}
+            />
+          </div>
+        )}
         {ranges && (
           <div style={{ display: "flex", background: T.panel, borderRadius: 12, padding: 3, border: `1px solid ${T.line}` }}>
             {ranges.map((r) => (

--- a/client/src/lib/dateRange.ts
+++ b/client/src/lib/dateRange.ts
@@ -71,8 +71,14 @@ export function rangeFromKey(key: RangeKey, now: Date, custom?: CustomRange): Da
     }
     case "Custom": {
       if (custom?.start && custom?.end) {
-        const start = startOfDay(new Date(custom.start));
-        const end = endOfDay(new Date(custom.end));
+        // <input type="date"> emits YYYY-MM-DD which `new Date(...)`
+        // parses as UTC midnight. In timezones west of UTC that lands
+        // on the previous calendar day, so a user-picked boundary
+        // would silently exclude the intended last day. Parse the
+        // components manually so the bounds line up with the user's
+        // local calendar regardless of timezone.
+        const start = startOfDay(parseLocalIsoDate(custom.start));
+        const end = endOfDay(parseLocalIsoDate(custom.end));
         return { start, end, label: `${format(start, "MMM d")} – ${format(end, "MMM d, yyyy")}`, key };
       }
       // Fallback while the user hasn't set explicit dates yet.
@@ -81,6 +87,15 @@ export function rangeFromKey(key: RangeKey, now: Date, custom?: CustomRange): Da
       return { start, end, label: "Last 30 days", key };
     }
   }
+}
+
+/** Parses a YYYY-MM-DD string as a local-time date. `new Date(string)`
+ *  treats it as UTC; we want the bounds to follow the user's wall
+ *  clock so date-range filters match what they typed. */
+function parseLocalIsoDate(value: string): Date {
+  const [y, m, d] = value.split("-").map(Number);
+  if (!y || !m || !d) return new Date(NaN);
+  return new Date(y, m - 1, d);
 }
 
 export function isInRange(ts: number, range: DateRange): boolean {

--- a/client/src/lib/dateRange.ts
+++ b/client/src/lib/dateRange.ts
@@ -1,0 +1,111 @@
+// Shared date-range model the page-header range buttons drive. Aggregator
+// hooks (useRangeStats, useRangeCredits, useRangeTopMerchants) consume
+// `DateRange` directly so a button change re-runs the right slice of the
+// transactions list with no per-hook special-casing.
+//
+// "Custom" is a placeholder until the user sets explicit start/end dates
+// via the inline date inputs in PageHeader; before they do, it falls back
+// to the last 30 days so the UI never shows a blank screen.
+
+import {
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+  subDays,
+  format,
+} from "date-fns";
+
+export type RangeKey = "Today" | "Week" | "Month" | "Year" | "Custom";
+
+export const RANGE_OPTIONS: RangeKey[] = ["Today", "Week", "Month", "Year", "Custom"];
+
+export interface DateRange {
+  /** Inclusive start, local time. */
+  start: Date;
+  /** Inclusive end, local time. */
+  end: Date;
+  /** "April 2026", "Apr 1 – 26", etc. — used for chart subtitles + tooltips. */
+  label: string;
+  /** Which named range this came from. "Custom" means the user picked a
+   *  bespoke window via the date inputs. */
+  key: RangeKey;
+}
+
+export interface CustomRange {
+  start: string; // YYYY-MM-DD
+  end: string;
+}
+
+/** Build a DateRange from the active button + optional custom dates.
+ *  `now` is injected so tests / per-page mounts compute against the
+ *  same instant for the lifetime of a render. */
+export function rangeFromKey(key: RangeKey, now: Date, custom?: CustomRange): DateRange {
+  switch (key) {
+    case "Today": {
+      const start = startOfDay(now);
+      const end = endOfDay(now);
+      return { start, end, label: format(start, "MMMM d, yyyy"), key };
+    }
+    case "Week": {
+      // Calendar week starting Monday — matches the convention most
+      // Georgian users expect (Sunday-start would push half the
+      // weekend into the next bucket).
+      const start = startOfWeek(now, { weekStartsOn: 1 });
+      const end = endOfWeek(now, { weekStartsOn: 1 });
+      return { start, end, label: `${format(start, "MMM d")} – ${format(end, "MMM d")}`, key };
+    }
+    case "Month": {
+      const start = startOfMonth(now);
+      const end = endOfMonth(now);
+      return { start, end, label: format(start, "MMMM yyyy"), key };
+    }
+    case "Year": {
+      const start = startOfYear(now);
+      const end = endOfYear(now);
+      return { start, end, label: format(start, "yyyy"), key };
+    }
+    case "Custom": {
+      if (custom?.start && custom?.end) {
+        const start = startOfDay(new Date(custom.start));
+        const end = endOfDay(new Date(custom.end));
+        return { start, end, label: `${format(start, "MMM d")} – ${format(end, "MMM d, yyyy")}`, key };
+      }
+      // Fallback while the user hasn't set explicit dates yet.
+      const start = startOfDay(subDays(now, 29));
+      const end = endOfDay(now);
+      return { start, end, label: "Last 30 days", key };
+    }
+  }
+}
+
+export function isInRange(ts: number, range: DateRange): boolean {
+  return ts >= range.start.getTime() && ts <= range.end.getTime();
+}
+
+/** Returns the equivalent range shifted back by one period — used for
+ *  the "vs. previous period" comparison labels in tooltips and stat
+ *  cards. */
+export function previousRange(range: DateRange): DateRange {
+  const span = range.end.getTime() - range.start.getTime();
+  const prevEnd = new Date(range.start.getTime() - 1);
+  const prevStart = new Date(prevEnd.getTime() - span);
+  // Anchor the comparison label to the same shape as the source.
+  switch (range.key) {
+    case "Today":
+      return { start: startOfDay(prevStart), end: endOfDay(prevStart), label: format(prevStart, "MMM d, yyyy"), key: "Today" };
+    case "Week":
+      return { start: startOfWeek(prevStart, { weekStartsOn: 1 }), end: endOfWeek(prevStart, { weekStartsOn: 1 }), label: `${format(prevStart, "MMM d")} – ${format(prevEnd, "MMM d")}`, key: "Week" };
+    case "Month":
+      return { start: startOfMonth(prevStart), end: endOfMonth(prevStart), label: format(prevStart, "MMMM yyyy"), key: "Month" };
+    case "Year":
+      return { start: startOfYear(prevStart), end: endOfYear(prevStart), label: format(prevStart, "yyyy"), key: "Year" };
+    case "Custom":
+    default:
+      return { start: prevStart, end: prevEnd, label: `${format(prevStart, "MMM d")} – ${format(prevEnd, "MMM d, yyyy")}`, key: "Custom" };
+  }
+}

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -8,8 +8,10 @@ import { useConvertedPayments } from "../hooks/useTransactions";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { DEFAULT_CATEGORIES, type InkCategory } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
+import { useRangeState } from "../hooks/useRangeState";
+import { isInRange } from "../lib/dateRange";
 import { formatCompact, monthKey } from "../ink/format";
-import { isWithinInterval, startOfMonth, endOfMonth, format } from "date-fns";
+import { format } from "date-fns";
 
 interface CatAgg {
   cat: string;
@@ -23,19 +25,15 @@ export function Categories() {
   const vp = useViewport();
   const navigate = useNavigate();
   const now = new Date();
-  const monthStart = startOfMonth(now);
-  const monthEnd = endOfMonth(now);
 
   const { payments } = useConvertedPayments();
   const { getCategory, categorize: categorizeId } = useCategorizer();
   const trend = useMonthlyTrend(6);
-  const [range, setRange] = useState("Month");
-
-  const inMonth = (ts: number) => isWithinInterval(new Date(ts), { start: monthStart, end: monthEnd });
+  const { range, props: rangeProps } = useRangeState("Month");
 
   const monthPayments = useMemo(
-    () => payments.filter((p) => inMonth(p.transactionDate)),
-    [payments]
+    () => payments.filter((p) => isInRange(p.transactionDate, range)),
+    [payments, range]
   );
 
   const cats: CatAgg[] = useMemo(() => {
@@ -48,7 +46,7 @@ export function Categories() {
       map[cat.id].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);
-  }, [monthPayments]);
+  }, [monthPayments, getCategory]);
 
   const total = cats.reduce((s, c) => s + c.total, 0);
   const [selected, setSelected] = useState<string | null>(null);
@@ -112,7 +110,7 @@ export function Categories() {
   if (cats.length === 0) {
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap }}>
-        <PageHeader eyebrow={eyebrow} title="Categories" active={range} onRange={setRange} />
+        <PageHeader eyebrow={eyebrow} title="Categories" {...rangeProps} />
         <Card>
           <div style={{ color: T.muted, fontSize: 13, padding: "40px 0", textAlign: "center", fontFamily: T.sans }}>
             No transactions in {format(now, "MMMM")} yet.
@@ -124,7 +122,7 @@ export function Categories() {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
-      <PageHeader eyebrow={eyebrow} title="Categories" active={range} onRange={setRange} />
+      <PageHeader eyebrow={eyebrow} title="Categories" {...rangeProps} />
 
       <div
         style={{

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,42 +1,40 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useTheme, useViewport, type InkTheme } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, LiveDot, LinkBtn, PageHeader } from "../ink/primitives";
 import { AreaChart, Donut } from "../ink/charts";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
-import { useMonthStats, useMonthTopMerchants } from "../hooks/useMonthlyAnalytics";
+import { useRangeStats, useRangeTopMerchants } from "../hooks/useMonthlyAnalytics";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
-import { useCredits, useMonthCredits } from "../hooks/useCredits";
+import { useCredits, useRangeCredits } from "../hooks/useCredits";
+import { useRangeState } from "../hooks/useRangeState";
+import { previousRange } from "../lib/dateRange";
 import { formatCompact } from "../ink/format";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
-import { isWithinInterval, startOfMonth, endOfMonth, subMonths, format } from "date-fns";
+import { isWithinInterval, format } from "date-fns";
 
 export function Dashboard() {
   const T = useTheme();
   const vp = useViewport();
   const now = new Date();
-  const my = { month: now.getMonth(), year: now.getFullYear() };
+  const { range, props: rangeProps } = useRangeState("Month");
+  const prevPeriod = useMemo(() => previousRange(range), [range]);
 
-  const prevDate = subMonths(now, 1);
-  const prevMy = { month: prevDate.getMonth(), year: prevDate.getFullYear() };
-
-  const stats = useMonthStats(my);
-  const topMerchants = useMonthTopMerchants(my, 5);
+  const stats = useRangeStats(range);
+  const topMerchants = useRangeTopMerchants(range, 5);
   const trend = useMonthlyTrend(9);
   const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
   const { credits } = useCredits();
-  const monthCredits = useMonthCredits(my);
-  const prevMonthCredits = useMonthCredits(prevMy);
+  const monthCredits = useRangeCredits(range);
+  const prevMonthCredits = useRangeCredits(prevPeriod);
   const { getCategory } = useCategorizer();
 
-  const [range, setRange] = useState("Month");
-
-  const prevMonthName = format(prevDate, "MMMM");
-  const prevMonthShort = format(prevDate, "MMM");
-  const monthYearLabel = format(now, "MMMM yyyy");
-  const monthShortName = format(now, "MMM").toUpperCase();
+  const prevMonthName = prevPeriod.label;
+  const prevMonthShort = prevPeriod.label.split(" ")[0]; // "Mar 2026" → "Mar", "Mar 1 – 31" → "Mar"
+  const monthYearLabel = range.label;
+  const monthShortName = range.label.split(" ")[0].toUpperCase();
   const income = monthCredits.total;
   const net = income - stats.total;
   const savingsRate = income > 0 ? (net / income) * 100 : 0;
@@ -50,21 +48,21 @@ export function Dashboard() {
     [trend]
   );
 
-  // Category breakdown for this month
+  // Category breakdown for the active range. Uses the same date-fns
+  // isWithinInterval the aggregator hooks use so the donut total
+  // always reconciles with stats.total.
   const byCategory = useMemo(() => {
-    const monthStart = startOfMonth(now);
-    const monthEnd = endOfMonth(now);
     const map: Record<string, { total: number; count: number; meta: typeof DEFAULT_CATEGORIES[number] }> = {};
     for (const p of payments) {
       if (p.gelAmount === null) continue;
-      if (!isWithinInterval(new Date(p.transactionDate), { start: monthStart, end: monthEnd })) continue;
+      if (!isWithinInterval(new Date(p.transactionDate), { start: range.start, end: range.end })) continue;
       const cat = getCategory(p.merchant, p.rawMessage);
       if (!map[cat.id]) map[cat.id] = { total: 0, count: 0, meta: cat };
       map[cat.id].total += p.gelAmount;
       map[cat.id].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);
-  }, [payments, getCategory]);
+  }, [payments, getCategory, range]);
 
   const topCats = byCategory.slice(0, 5);
   const totalCatSum = topCats.reduce((s, c) => s + c.total, 0) || 1;
@@ -133,8 +131,7 @@ export function Dashboard() {
       <PageHeader
         eyebrow={`${greeting}`}
         title={monthTitle}
-        active={range}
-        onRange={setRange}
+        {...rangeProps}
       />
 
       <div

--- a/client/src/pages/Income.tsx
+++ b/client/src/pages/Income.tsx
@@ -2,19 +2,21 @@ import { useMemo, useState } from "react";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
-import { useConvertedCredits, useMonthCredits } from "../hooks/useCredits";
+import { useConvertedCredits, useRangeCredits } from "../hooks/useCredits";
 import { useBankSenders } from "../hooks/useBankSenders";
+import { useRangeState } from "../hooks/useRangeState";
 import { AreaChart } from "../ink/charts";
 import { currencySymbol, monthKey, monthLabel, formatLocalDay, parseLocalDay } from "../ink/format";
-import { isWithinInterval, startOfMonth, endOfMonth, format, subMonths } from "date-fns";
+import { isInRange } from "../lib/dateRange";
+import { format, subMonths } from "date-fns";
 
 export function Income() {
   const T = useTheme();
   const vp = useViewport();
   const now = new Date();
-  const my = { month: now.getMonth(), year: now.getFullYear() };
+  const { range, props: rangeProps } = useRangeState("Month");
   const { credits } = useConvertedCredits();
-  const monthly = useMonthCredits(my);
+  const monthly = useRangeCredits(range);
   const { senders } = useBankSenders();
 
   const [search, setSearch] = useState("");
@@ -93,13 +95,11 @@ export function Income() {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  const monthStart = startOfMonth(now);
-  const monthEnd = endOfMonth(now);
   const topSources = useMemo(() => {
     const map: Record<string, { name: string; total: number; count: number }> = {};
     for (const c of credits) {
       if (c.gelAmount === null) continue;
-      if (!isWithinInterval(new Date(c.transactionDate), { start: monthStart, end: monthEnd })) continue;
+      if (!isInRange(c.transactionDate, range)) continue;
       const name = c.counterparty || "—";
       if (!map[name]) map[name] = { name, total: 0, count: 0 };
       map[name].total += c.gelAmount;
@@ -108,14 +108,14 @@ export function Income() {
     return Object.values(map)
       .sort((a, b) => b.total - a.total)
       .slice(0, 5);
-  }, [credits, monthStart, monthEnd]);
+  }, [credits, range]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
       <PageHeader
         eyebrow="Money coming in · parsed from SMS"
         title="Income"
-        active="Month"
+        {...rangeProps}
         rightSlot={
           <Pill bg="rgba(75,217,162,0.15)" color={T.green}>
             {credits.length} total

--- a/client/src/pages/Income.tsx
+++ b/client/src/pages/Income.tsx
@@ -63,6 +63,10 @@ export function Income() {
 
   const filtered = useMemo(() => {
     return allTx.filter((t) => {
+      // Apply the active range first so the ledger reconciles with the
+      // hero totals; previously the summary cards switched on range
+      // but the list kept showing all-time credits.
+      if (!isInRange(t.transactionDate, range)) return false;
       if (bank !== "all" && t.bankSenderId !== bank) return false;
       if (search) {
         const q = search.toLowerCase();
@@ -72,7 +76,7 @@ export function Income() {
       }
       return true;
     });
-  }, [allTx, bank, search]);
+  }, [allTx, bank, search, range]);
 
   const groups = useMemo(() => {
     const g: Record<string, InkTx[]> = {};

--- a/client/src/pages/Merchants.tsx
+++ b/client/src/pages/Merchants.tsx
@@ -3,14 +3,13 @@ import { useTheme, useViewport } from "../ink/theme";
 import { Card, PageHeader } from "../ink/primitives";
 import { useConvertedPayments } from "../hooks/useTransactions";
 import { useCategorizer } from "../hooks/useCategorizer";
-import { isWithinInterval, startOfMonth, endOfMonth, format } from "date-fns";
+import { useRangeState } from "../hooks/useRangeState";
+import { isInRange } from "../lib/dateRange";
 
 export function Merchants() {
   const T = useTheme();
   const vp = useViewport();
-  const now = new Date();
-  const monthStart = startOfMonth(now);
-  const monthEnd = endOfMonth(now);
+  const { range, props: rangeProps } = useRangeState("Month");
   const { payments } = useConvertedPayments();
   const { getCategory } = useCategorizer();
   const [search, setSearch] = useState("");
@@ -31,7 +30,7 @@ export function Merchants() {
     const map: Record<string, MerchantAgg> = {};
     for (const p of payments) {
       if (p.gelAmount === null) continue;
-      if (!isWithinInterval(new Date(p.transactionDate), { start: monthStart, end: monthEnd })) continue;
+      if (!isInRange(p.transactionDate, range)) continue;
       const key = p.merchant || "Unknown";
       const raw = p.rawMessage || "";
       if (!map[key]) {
@@ -49,7 +48,7 @@ export function Merchants() {
       map[key].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);
-  }, [payments, monthStart, monthEnd]);
+  }, [payments, range]);
 
   const total = merchants.reduce((s, m) => s + m.total, 0);
   const filtered = merchants.filter(
@@ -61,9 +60,9 @@ export function Merchants() {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
       <PageHeader
-        eyebrow={`Who you paid · ${format(now, "MMMM")}`}
+        eyebrow={`Who you paid · ${range.label}`}
         title="Merchants"
-        active="Month"
+        {...rangeProps}
         rightSlot={<span style={{ fontFamily: T.mono, fontSize: 11, color: T.dim }}>{merchants.length} unique</span>}
       />
 

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -5,6 +5,8 @@ import { Card, CardLabel, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
 import { useBankSenders } from "../hooks/useBankSenders";
+import { useRangeState } from "../hooks/useRangeState";
+import { isInRange } from "../lib/dateRange";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { currencySymbol, formatLocalDay, parseLocalDay } from "../ink/format";
@@ -18,6 +20,7 @@ export function Transactions() {
   const { failedPayments } = useFailedPayments();
   const { senders } = useBankSenders();
   const { getCategory, categorize: categorizeId } = useCategorizer();
+  const { range, props: rangeProps } = useRangeState("Month");
 
   // `?category=<id>` pre-selects the category filter on load. Categories
   // page navigates here with this param when the user clicks "All →" on
@@ -72,6 +75,7 @@ export function Transactions() {
 
   const filtered = useMemo(() => {
     return allTx.filter((t) => {
+      if (!isInRange(t.transactionDate, range)) return false;
       if (bank !== "all" && t.bankSenderId !== bank) return false;
       if (cat !== "all" && t.category !== cat) return false;
       if (kind !== "all" && t.kind !== kind) return false;
@@ -81,7 +85,7 @@ export function Transactions() {
       }
       return true;
     });
-  }, [allTx, bank, cat, kind, search]);
+  }, [allTx, bank, cat, kind, search, range]);
 
   const groups = useMemo(() => {
     const g: Record<string, InkTx[]> = {};
@@ -135,7 +139,7 @@ export function Transactions() {
       <PageHeader
         eyebrow="All transactions · read-only from SMS"
         title="Transactions"
-        active="Month"
+        {...rangeProps}
         rightSlot={
           <span style={{ fontFamily: T.mono, fontSize: 11, color: T.dim }}>
             {filtered.length.toLocaleString("en-US")} results


### PR DESCRIPTION
First of four sub-PRs stacked on \`feat/interactive-charts-and-ranges\`. Tightly scoped to making the existing range buttons functional; chart interactivity (Recharts swap, tooltips, drill-downs) stays in subsequent sub-PRs.

The buttons in \`PageHeader\` were rendered on every page but only Dashboard held local state for them, and even there nothing read it. Now every page that displays the switcher actually filters its data by the active range, including a Custom mode with two inline date inputs that surface only when Custom is selected.

The aggregator hooks were rewritten to take a single \`DateRange\` value (\`{start, end, label, key}\`) instead of a \`{month, year}\` pair. \`useRangeStats\` / \`useRangeTopMerchants\` / \`useRangeCategoryAnalytics\` / \`useRangeSpendingByDay\` / \`useRangeCredits\` / \`useRangeCashflow\`. The day-bucketing version auto-rolls up to monthly buckets once the range is wider than about three months so a Year view stays readable. Old \`useMonthStats\`/etc. names are kept as backwards-compat shims until any external callers migrate.

A new \`useRangeState\` hook packs the active button + the inline custom date inputs into a single \`...rangeProps\` spread so each page is one line of wiring on \`PageHeader\` plus a \`useMemo\` that filters by \`isInRange(ts, range)\`. Dashboard derives its prev-period comparisons via \`previousRange(range)\` (a same-shape window shifted back by one period) so "vs March" naturally generalises to "vs last week", "vs yesterday", "vs 2025".

Custom range falls back to the last 30 days while either date input is empty so the UI never goes blank.

The chart-rich tooltip + click-to-drill flows depend on this scaffolding and ship next as Sub-PR 2/3.