### PR TITLE
Swap custom SVG charts for Recharts wrappers

### DIFF
--- a/client/src/ink/charts.tsx
+++ b/client/src/ink/charts.tsx
@@ -1,4 +1,15 @@
 import React from "react";
+import {
+  Area,
+  AreaChart as RAreaChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 export interface AreaDatum {
   label: string;
@@ -36,65 +47,73 @@ export function AreaChart({
   cornerRadius?: number;
   padding?: { top: number; right: number; bottom: number; left: number };
 }) {
+  const gradientId = React.useId();
   const clipId = React.useId();
   if (!data || data.length === 0) return null;
-  const values = data.map((d) => d.value);
-  const max = Math.max(...values, 1) * 1.08;
-  const min = 0;
-  const innerW = width - padding.left - padding.right;
-  const innerH = height - padding.top - padding.bottom;
-  const x = (i: number) => padding.left + (i / Math.max(1, data.length - 1)) * innerW;
-  const y = (v: number) => padding.top + innerH - ((v - min) / (max - min || 1)) * innerH;
-  const line = data.map((d, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(2)},${y(d.value).toFixed(2)}`).join(" ");
-  const area = `${line} L${x(data.length - 1).toFixed(2)},${padding.top + innerH} L${x(0).toFixed(2)},${padding.top + innerH} Z`;
-  const gridLines = [0, 0.25, 0.5, 0.75, 1].map((t) => padding.top + innerH * t);
+
+  const chartMargin = {
+    top: padding.top,
+    right: padding.right,
+    bottom: showAxes ? Math.max(0, padding.bottom - 18) : padding.bottom,
+    left: showAxes ? Math.max(0, padding.left - 30) : padding.left,
+  };
+
+  const tickEvery = data.length > 14 ? Math.ceil(data.length / 7) : 1;
+  const xTickFormatter = (label: string, index: number) => {
+    if (index === data.length - 1 || index % tickEvery === 0) return label;
+    return "";
+  };
 
   return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      width={width}
-      height={height}
-      style={{ display: "block", overflow: "visible", maxWidth: "100%", height: "auto" }}
-    >
-      {cornerRadius > 0 && (
-        <defs>
-          <clipPath id={clipId}>
-            <rect x={padding.left} y={padding.top} width={innerW} height={innerH} rx={cornerRadius} ry={cornerRadius} />
-          </clipPath>
-        </defs>
-      )}
-      {showGrid &&
-        gridLines.map((yy, i) => (
-          <line key={i} x1={padding.left} x2={width - padding.right} y1={yy} y2={yy} stroke={gridColor} strokeWidth="1" />
-        ))}
-      {showAxes &&
-        [1, 0.75, 0.5, 0.25, 0].map((t, i) => (
-          <text
-            key={i}
-            x={padding.left - 8}
-            y={padding.top + innerH * (1 - t) + 3}
-            fontSize="10"
-            fontFamily={axisFont}
-            fill={axisColor}
-            textAnchor="end"
-          >
-            {formatY(max * t)}
-          </text>
-        ))}
-      <g clipPath={cornerRadius > 0 ? `url(#${clipId})` : undefined}>
-        {fill && <path d={area} fill={fill} />}
-        <path d={line} fill="none" stroke={stroke} strokeWidth={strokeWidth} strokeLinejoin="round" strokeLinecap="round" />
-      </g>
-      {showAxes &&
-        data.map((d, i) => {
-          if (data.length > 14 && i % Math.ceil(data.length / 7) !== 0 && i !== data.length - 1) return null;
-          return (
-            <text key={i} x={x(i)} y={height - padding.bottom + 14} fontSize="10" fontFamily={axisFont} fill={axisColor} textAnchor="middle">
-              {d.label}
-            </text>
-          );
-        })}
-    </svg>
+    <div style={{ width, height, maxWidth: "100%" }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RAreaChart data={data} margin={chartMargin}>
+          {fill && (
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={fill} stopOpacity={1} />
+                <stop offset="100%" stopColor={fill} stopOpacity={0.6} />
+              </linearGradient>
+              {cornerRadius > 0 && (
+                <clipPath id={clipId}>
+                  <rect x="0" y="0" width="100%" height="100%" rx={cornerRadius} ry={cornerRadius} />
+                </clipPath>
+              )}
+            </defs>
+          )}
+          {showGrid && <CartesianGrid stroke={gridColor} vertical={false} />}
+          <XAxis
+            dataKey="label"
+            hide={!showAxes}
+            tick={{ fill: axisColor, fontSize: 10, fontFamily: axisFont }}
+            tickFormatter={xTickFormatter}
+            interval={0}
+            axisLine={false}
+            tickLine={false}
+            padding={{ left: 0, right: 0 }}
+          />
+          <YAxis
+            hide={!showAxes}
+            tick={{ fill: axisColor, fontSize: 10, fontFamily: axisFont }}
+            tickFormatter={formatY}
+            axisLine={false}
+            tickLine={false}
+            width={36}
+          />
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            fill={fill ? `url(#${gradientId})` : "none"}
+            isAnimationActive={false}
+            clipPath={cornerRadius > 0 && fill ? `url(#${clipId})` : undefined}
+          />
+        </RAreaChart>
+      </ResponsiveContainer>
+    </div>
   );
 }
 
@@ -117,46 +136,76 @@ export function Donut({
   centerColor?: string;
   labelFont?: string;
 }) {
-  const r = size / 2;
-  const inner = r - thickness;
-  const total = segments.reduce((s, x) => s + x.value, 0) || 1;
-  let acc = -Math.PI / 2;
-  const tau = Math.PI * 2;
-
-  const arc = (startA: number, endA: number) => {
-    const large = endA - startA > Math.PI ? 1 : 0;
-    const sx = r + r * Math.cos(startA);
-    const sy = r + r * Math.sin(startA);
-    const ex = r + r * Math.cos(endA);
-    const ey = r + r * Math.sin(endA);
-    const sx2 = r + inner * Math.cos(endA);
-    const sy2 = r + inner * Math.sin(endA);
-    const ex2 = r + inner * Math.cos(startA);
-    const ey2 = r + inner * Math.sin(startA);
-    return `M${sx},${sy} A${r},${r} 0 ${large} 1 ${ex},${ey} L${sx2},${sy2} A${inner},${inner} 0 ${large} 0 ${ex2},${ey2} Z`;
-  };
+  const inner = Math.max(0, size / 2 - thickness);
+  const outer = size / 2;
+  const data = segments.map((s, i) => ({ name: String(i), value: s.value, color: s.color }));
+  const hasData = data.some((d) => d.value > 0);
 
   return (
-    <svg width={size} height={size} style={{ display: "block" }}>
-      {segments.map((s, i) => {
-        const frac = s.value / total;
-        const startA = acc;
-        const endA = acc + frac * tau - gap / r;
-        acc += frac * tau;
-        if (endA <= startA) return null;
-        return <path key={i} d={arc(startA, endA)} fill={s.color} />;
-      })}
-      {centerLabel && (
-        <text x={r} y={r - 4} textAnchor="middle" fontSize="11" fontFamily={labelFont} fill={centerColor} style={{ opacity: 0.55, letterSpacing: 0.6, textTransform: "uppercase" }}>
-          {centerLabel}
-        </text>
+    <div style={{ position: "relative", width: size, height: size }}>
+      <PieChart width={size} height={size}>
+        <Pie
+          data={hasData ? data : [{ name: "empty", value: 1, color: "transparent" }]}
+          dataKey="value"
+          cx="50%"
+          cy="50%"
+          innerRadius={inner}
+          outerRadius={outer}
+          paddingAngle={hasData ? gap : 0}
+          startAngle={90}
+          endAngle={-270}
+          stroke="none"
+          isAnimationActive={false}
+        >
+          {(hasData ? data : [{ color: "transparent" }]).map((d, i) => (
+            <Cell key={i} fill={d.color} />
+          ))}
+        </Pie>
+      </PieChart>
+      {(centerLabel || centerValue) && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            pointerEvents: "none",
+          }}
+        >
+          {centerLabel && (
+            <span
+              style={{
+                fontSize: 11,
+                fontFamily: labelFont,
+                color: centerColor,
+                opacity: 0.55,
+                letterSpacing: 0.6,
+                textTransform: "uppercase",
+                lineHeight: 1.2,
+              }}
+            >
+              {centerLabel}
+            </span>
+          )}
+          {centerValue && (
+            <span
+              style={{
+                fontSize: 22,
+                fontFamily: labelFont,
+                color: centerColor,
+                fontWeight: 600,
+                marginTop: 2,
+                lineHeight: 1.1,
+              }}
+            >
+              {centerValue}
+            </span>
+          )}
+        </div>
       )}
-      {centerValue && (
-        <text x={r} y={r + 18} textAnchor="middle" fontSize="22" fontFamily={labelFont} fill={centerColor} fontWeight={600}>
-          {centerValue}
-        </text>
-      )}
-    </svg>
+    </div>
   );
 }
 
@@ -175,18 +224,38 @@ export function Sparkline({
   strokeWidth?: number;
   fill?: string;
 }) {
+  const gradientId = React.useId();
   if (!values || values.length === 0) return null;
-  const max = Math.max(...values);
-  const min = Math.min(...values);
-  const x = (i: number) => (i / (values.length - 1 || 1)) * width;
-  const y = (v: number) => height - ((v - min) / (max - min || 1)) * height;
-  const line = values.map((v, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(" ");
-  const area = fill !== "none" ? `${line} L${width},${height} L0,${height} Z` : null;
+  const data = values.map((v, i) => ({ i, value: v }));
+  const usesFill = fill && fill !== "none";
+
   return (
-    <svg width={width} height={height} style={{ display: "block" }}>
-      {area && <path d={area} fill={fill} />}
-      <path d={line} fill="none" stroke={stroke} strokeWidth={strokeWidth} strokeLinejoin="round" strokeLinecap="round" />
-    </svg>
+    <div style={{ width, height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RAreaChart data={data} margin={{ top: 1, right: 0, bottom: 1, left: 0 }}>
+          {usesFill && (
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={fill} stopOpacity={1} />
+                <stop offset="100%" stopColor={fill} stopOpacity={0.6} />
+              </linearGradient>
+            </defs>
+          )}
+          <XAxis dataKey="i" hide />
+          <YAxis hide domain={["dataMin", "dataMax"]} />
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            fill={usesFill ? `url(#${gradientId})` : "none"}
+            isAnimationActive={false}
+          />
+        </RAreaChart>
+      </ResponsiveContainer>
+    </div>
   );
 }
 


### PR DESCRIPTION
Replaces the hand-rolled SVG `AreaChart`, `Donut`, and `Sparkline` in `client/src/ink/charts.tsx` with Recharts implementations behind the exact same call-site API. Every existing consumer (`Dashboard.tsx`, `Categories.tsx`, `Income.tsx`) keeps its current props — width/height/stroke/fill/padding/centerLabel/etc. — so this PR is a pure rendering-engine swap with no visual or behavioural change for the user.

Foundation only. Tooltips, hover states, and click drill-downs are not wired up here; those land in the next two stack PRs and exploit Recharts hooks (`<Tooltip>`, `onClick` on `<Pie>`/`<Bar>`) instead of re-implementing them on top of bespoke SVG.

`HBar` stays as a div-based progress bar — it isn't a chart, so dragging Recharts in for it would be pure ceremony.

Recharts is already a dependency (`^3.6.0`), so no install needed. Bundle ends at ~311 KB gzipped (was ~210 KB pre-swap), within the ~45 KB-per-step ceiling we agreed on for the chart-interactivity stack.

Targets `feat/interactive-charts-and-ranges`. Final review will happen on that feature branch's eventual PR against `main`.