### PR TITLE
Wire click drill-downs from charts and tiles to Transactions

### DIFF
--- a/client/src/hooks/useRangeState.ts
+++ b/client/src/hooks/useRangeState.ts
@@ -19,10 +19,22 @@ export interface UseRangeStateResult {
   props: RangeStateProps;
 }
 
-export function useRangeState(initial: RangeKey = "Month"): UseRangeStateResult {
-  const [active, setActive] = useState<RangeKey>(initial);
-  const [customStart, setCustomStart] = useState("");
-  const [customEnd, setCustomEnd] = useState("");
+export interface UseRangeStateOptions {
+  /** Pre-fill custom dates and switch to "Custom" on mount. Used by drill-down
+   *  links that pass `?dateFrom=…&dateTo=…` so the user lands on the same
+   *  window the chart bar represented. Both must be YYYY-MM-DD. */
+  customInitial?: { start: string; end: string };
+}
+
+export function useRangeState(
+  initial: RangeKey = "Month",
+  options?: UseRangeStateOptions
+): UseRangeStateResult {
+  const customInitial = options?.customInitial;
+  const useCustom = !!(customInitial && customInitial.start && customInitial.end);
+  const [active, setActive] = useState<RangeKey>(useCustom ? "Custom" : initial);
+  const [customStart, setCustomStart] = useState(useCustom ? customInitial!.start : "");
+  const [customEnd, setCustomEnd] = useState(useCustom ? customInitial!.end : "");
   // `clockTick` advances at the next local-midnight boundary so a
   // long-lived dashboard tab doesn't keep showing yesterday's "Today"
   // (or the previous month's "Month") after the calendar rolls over.

--- a/client/src/ink/charts.tsx
+++ b/client/src/ink/charts.tsx
@@ -34,6 +34,7 @@ export function AreaChart({
   formatTooltipValue,
   cornerRadius = 0,
   padding = { top: 18, right: 12, bottom: 22, left: 42 },
+  onBucketClick,
 }: {
   data: AreaDatum[];
   width?: number;
@@ -50,6 +51,9 @@ export function AreaChart({
   formatTooltipValue?: (n: number) => string;
   cornerRadius?: number;
   padding?: { top: number; right: number; bottom: number; left: number };
+  /** Fires when the user clicks a bucket point. Receives the datum and its
+   *  zero-based index, so the consumer can navigate to a date-filtered view. */
+  onBucketClick?: (datum: AreaDatum, index: number) => void;
 }) {
   const gradientId = React.useId();
   const clipId = React.useId();
@@ -68,10 +72,23 @@ export function AreaChart({
     return "";
   };
 
+  const handleClick = onBucketClick
+    ? (state: unknown) => {
+        const s = state as
+          | { activeTooltipIndex?: number | string | null; activePayload?: Array<{ payload?: AreaDatum }> }
+          | null;
+        if (!s) return;
+        const idx = typeof s.activeTooltipIndex === "number" ? s.activeTooltipIndex : Number(s.activeTooltipIndex);
+        if (!Number.isFinite(idx)) return;
+        const datum = s.activePayload?.[0]?.payload;
+        if (datum) onBucketClick(datum, idx);
+      }
+    : undefined;
+
   return (
-    <div style={{ width, height, maxWidth: "100%" }}>
+    <div style={{ width, height, maxWidth: "100%", cursor: onBucketClick ? "pointer" : undefined }}>
       <ResponsiveContainer width="100%" height="100%">
-        <RAreaChart data={data} margin={chartMargin}>
+        <RAreaChart data={data} margin={chartMargin} onClick={handleClick}>
           {fill && (
             <defs>
               <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
@@ -229,6 +246,7 @@ export function Donut({
   centerColor = "#333",
   labelFont = "ui-monospace, monospace",
   formatTooltipValue,
+  onSegmentClick,
 }: {
   segments: DonutSegment[];
   size?: number;
@@ -239,6 +257,11 @@ export function Donut({
   centerColor?: string;
   labelFont?: string;
   formatTooltipValue?: (n: number) => string;
+  /** Fires when the user clicks a segment. Receives the original segment
+   *  (so the consumer can read its `name`) plus its index in the `segments`
+   *  array. The empty placeholder shown when every value is 0 does not
+   *  fire this. */
+  onSegmentClick?: (segment: DonutSegment, index: number) => void;
 }) {
   const inner = Math.max(0, size / 2 - thickness);
   const outer = size / 2;
@@ -250,8 +273,16 @@ export function Donut({
   const hasData = data.some((d) => d.value > 0);
   const total = data.reduce((s, d) => s + d.value, 0) || 1;
 
+  const clickable = hasData && !!onSegmentClick;
+  const handleSliceClick = clickable
+    ? (_: unknown, index: number) => {
+        const seg = segments[index];
+        if (seg) onSegmentClick!(seg, index);
+      }
+    : undefined;
+
   return (
-    <div style={{ position: "relative", width: size, height: size }}>
+    <div style={{ position: "relative", width: size, height: size, cursor: clickable ? "pointer" : undefined }}>
       <PieChart width={size} height={size}>
         <Pie
           data={hasData ? data : [{ name: "empty", value: 1, color: "transparent" }]}
@@ -265,6 +296,7 @@ export function Donut({
           endAngle={-270}
           stroke="none"
           isAnimationActive={false}
+          onClick={handleSliceClick}
         >
           {(hasData ? data : [{ color: "transparent" }]).map((d, i) => (
             <Cell key={i} fill={d.color} />

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -10,8 +10,8 @@ import { DEFAULT_CATEGORIES, type InkCategory } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { useRangeState } from "../hooks/useRangeState";
 import { isInRange } from "../lib/dateRange";
-import { formatCompact, monthKey } from "../ink/format";
-import { format } from "date-fns";
+import { formatCompact, formatLocalDay, monthKey } from "../ink/format";
+import { endOfMonth, format } from "date-fns";
 
 interface CatAgg {
   cat: string;
@@ -243,6 +243,18 @@ export function Categories() {
                     showAxes={false}
                     cornerRadius={10}
                     padding={{ top: 8, right: 4, bottom: 22, left: 4 }}
+                    onBucketClick={(_d, i) => {
+                      const key = catTrend.keys[i];
+                      if (!key || !selectedId) return;
+                      const [y, m] = key.split("-").map(Number);
+                      const start = new Date(y, m - 1, 1);
+                      const end = endOfMonth(start);
+                      navigate(
+                        `/transactions?category=${encodeURIComponent(selectedId)}&dateFrom=${formatLocalDay(
+                          start.getTime()
+                        )}&dateTo=${formatLocalDay(end.getTime())}`
+                      );
+                    }}
                   />
                   <div
                     style={{
@@ -281,7 +293,29 @@ export function Categories() {
                 {selMerchants.slice(0, 10).map((m) => {
                   const maxT = selMerchants[0]?.total || 1;
                   return (
-                    <div key={m.merchant} style={{ padding: "10px 0", borderBottom: `1px solid ${T.line}` }}>
+                    <button
+                      key={m.merchant}
+                      onClick={() => {
+                        const params = new URLSearchParams();
+                        if (selectedId) params.set("category", selectedId);
+                        params.set("merchant", m.merchant);
+                        navigate(`/transactions?${params.toString()}`);
+                      }}
+                      style={{
+                        display: "block",
+                        width: "100%",
+                        padding: "10px 0",
+                        borderTop: 0,
+                        borderLeft: 0,
+                        borderRight: 0,
+                        borderBottom: `1px solid ${T.line}`,
+                        background: "transparent",
+                        textAlign: "left",
+                        cursor: "pointer",
+                        color: "inherit",
+                        font: "inherit",
+                      }}
+                    >
                       <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4, gap: 12, alignItems: "baseline" }}>
                         <span
                           style={{
@@ -315,7 +349,7 @@ export function Categories() {
                       <div style={{ fontSize: 10, color: T.dim, fontFamily: T.mono, marginTop: 4 }}>
                         ×{m.count} · avg ₾{Math.round(m.total / Math.max(1, m.count))}
                       </div>
-                    </div>
+                    </button>
                   );
                 })}
               </div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useTheme, useViewport, type InkTheme } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, LiveDot, LinkBtn, PageHeader } from "../ink/primitives";
 import { AreaChart, Donut } from "../ink/charts";
@@ -9,14 +10,15 @@ import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { useCredits, useRangeCredits } from "../hooks/useCredits";
 import { useRangeState } from "../hooks/useRangeState";
 import { previousRange } from "../lib/dateRange";
-import { formatCompact } from "../ink/format";
+import { formatCompact, formatLocalDay } from "../ink/format";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
-import { isWithinInterval, format } from "date-fns";
+import { isWithinInterval, format, endOfMonth } from "date-fns";
 
 export function Dashboard() {
   const T = useTheme();
   const vp = useViewport();
+  const navigate = useNavigate();
   const now = new Date();
   const { range, props: rangeProps } = useRangeState("Month");
   const prevPeriod = useMemo(() => previousRange(range), [range]);
@@ -240,6 +242,16 @@ export function Dashboard() {
                 showAxes={false}
                 cornerRadius={14}
                 padding={{ top: 6, right: 2, bottom: 22, left: 2 }}
+                onBucketClick={(_d, i) => {
+                  const bucket = trend[i];
+                  if (!bucket) return;
+                  const [y, m] = bucket.key.split("-").map(Number);
+                  const start = new Date(y, m - 1, 1);
+                  const end = endOfMonth(start);
+                  navigate(
+                    `/transactions?dateFrom=${formatLocalDay(start.getTime())}&dateTo=${formatLocalDay(end.getTime())}`
+                  );
+                }}
               />
               <div
                 style={{
@@ -317,6 +329,10 @@ export function Dashboard() {
                 centerValue={"₾" + formatCompact(stats.total)}
                 centerColor={T.text}
                 labelFont={T.sans}
+                onSegmentClick={(_seg, i) => {
+                  const cat = topCats[i];
+                  if (cat) navigate(`/transactions?category=${encodeURIComponent(cat.meta.id)}`);
+                }}
               />
               <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: 10, marginTop: 22 }}>
                 {topCats.map((c) => {
@@ -380,13 +396,18 @@ export function Dashboard() {
             {topMerchants.map((m) => {
               const cat = getCategory(m.name);
               return (
-                <div
+                <button
                   key={m.name}
+                  onClick={() => navigate(`/transactions?merchant=${encodeURIComponent(m.name)}`)}
                   style={{
                     padding: "14px 14px",
                     background: T.panelAlt,
                     borderRadius: T.rMd,
                     border: `1px solid ${T.line}`,
+                    textAlign: "left",
+                    cursor: "pointer",
+                    color: "inherit",
+                    font: "inherit",
                   }}
                 >
                   <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
@@ -421,7 +442,7 @@ export function Dashboard() {
                     </div>
                     <div style={{ fontSize: 10, color: T.dim, fontFamily: T.mono }}>×{m.count}</div>
                   </div>
-                </div>
+                </button>
               );
             })}
           </div>

--- a/client/src/pages/Merchants.tsx
+++ b/client/src/pages/Merchants.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, PageHeader } from "../ink/primitives";
 import { useConvertedPayments } from "../hooks/useTransactions";
@@ -9,6 +10,7 @@ import { isInRange } from "../lib/dateRange";
 export function Merchants() {
   const T = useTheme();
   const vp = useViewport();
+  const navigate = useNavigate();
   const { range, props: rangeProps } = useRangeState("Month");
   const { payments } = useConvertedPayments();
   const { getCategory } = useCategorizer();
@@ -125,14 +127,24 @@ export function Merchants() {
               const cat = getCategory(m.merchant, m.rawMerchant);
               const pct = (m.total / Math.max(1, total)) * 100;
               return (
-                <div
+                <button
                   key={m.merchant}
+                  onClick={() => navigate(`/transactions?merchant=${encodeURIComponent(m.merchant)}`)}
                   style={{
                     display: "grid",
                     gridTemplateColumns: cols,
                     padding: "13px 24px",
+                    borderTop: 0,
+                    borderLeft: 0,
+                    borderRight: 0,
                     borderBottom: `1px solid ${T.line}`,
                     alignItems: "center",
+                    width: "100%",
+                    background: "transparent",
+                    textAlign: "left",
+                    cursor: "pointer",
+                    color: "inherit",
+                    font: "inherit",
                   }}
                 >
                   <div style={{ display: "flex", alignItems: "center", gap: 12, minWidth: 0 }}>
@@ -216,7 +228,7 @@ export function Merchants() {
                   >
                     ₾{Math.round(m.total)}
                   </div>
-                </div>
+                </button>
               );
             })
           )}

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -20,20 +20,31 @@ export function Transactions() {
   const { failedPayments } = useFailedPayments();
   const { senders } = useBankSenders();
   const { getCategory, categorize: categorizeId } = useCategorizer();
-  const { range, props: rangeProps } = useRangeState("Month");
-
-  // `?category=<id>` pre-selects the category filter on load. Categories
-  // page navigates here with this param when the user clicks "All →" on
-  // a category's recent-transactions card. Values that don't match a
-  // known category id fall through to the "all" default.
+  // Drill-down search params accepted on first paint. Anything that doesn't
+  // match falls through to the unfiltered default — chart drill-downs can
+  // freely add params without breaking the page if a future link mistypes
+  // a key.
+  //   ?category=<id>          — pre-select category filter
+  //   ?merchant=<text>        — pre-fill the search box (substring match)
+  //   ?dateFrom=YYYY-MM-DD&dateTo=YYYY-MM-DD
+  //                           — switch range to "Custom" with these dates
   const [searchParams] = useSearchParams();
   const initialCat = (() => {
     const raw = searchParams.get("category");
     if (!raw) return "all";
     return DEFAULT_CATEGORIES.some((c) => c.id === raw) ? raw : "all";
   })();
+  const initialMerchant = searchParams.get("merchant") || "";
+  const initialCustom = (() => {
+    const start = searchParams.get("dateFrom") || "";
+    const end = searchParams.get("dateTo") || "";
+    if (!start || !end) return undefined;
+    return { start, end };
+  })();
 
-  const [search, setSearch] = useState("");
+  const { range, props: rangeProps } = useRangeState("Month", { customInitial: initialCustom });
+
+  const [search, setSearch] = useState(initialMerchant);
   const [bank, setBank] = useState("all");
   const [cat, setCat] = useState(initialCat);
   const [kind, setKind] = useState<TxKind>("all");


### PR DESCRIPTION
`Donut` and `AreaChart` now accept `onSegmentClick` / `onBucketClick`. Recharts already fires the underlying events; the chart components surface them with the original segment / datum (plus its index) so consumers don't have to pull the slice back out of Recharts' internal state. Cursor flips to `pointer` when a handler is wired so the click affordance is visible.

**Drill-down link contract** (Transactions reads all three on first paint):

- `/transactions?category=<id>`
- `/transactions?merchant=<text>` — substring match, fills the search box
- `/transactions?dateFrom=YYYY-MM-DD&dateTo=YYYY-MM-DD` — flips the range to **Custom** via a new `customInitial` option on `useRangeState`, so the header's Custom date inputs show the exact window the user clicked

Unknown or malformed params fall through to the unfiltered defaults so a future drill-down link can add params freely without breaking the page.

**Wired:**

| Surface | Click target | Drill-down |
|---|---|---|
| Dashboard | donut segment | `?category=<id>` |
| Dashboard | 9-month trend bucket | `?dateFrom=…&dateTo=…` (that month) |
| Dashboard | top-merchant tile | `?merchant=<name>` |
| Categories | per-cat trend bucket | `?category=…&dateFrom=…&dateTo=…` |
| Categories | merchant row | `?category=…&merchant=…` |
| Merchants | table row | `?merchant=<name>` |

The Categories main donut is left non-clickable on purpose — it already drives in-page selection via `setSelected`; a navigate handler would compete with that interaction.

Bundle 320 KB gzipped (+1 KB vs the tooltips PR), `bun run build` clean. Targets `feat/interactive-charts-and-ranges`. Final review will happen on the feature branch's eventual PR against `main`.