### PR TITLE
Add "Sync now" button to Manage page

### DIFF
--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -18,19 +18,55 @@ export function Settings() {
 
   const [confirm, setConfirm] = useState(false);
   const [syncing, setSyncing] = useState(false);
-  const [lastSyncCount, setLastSyncCount] = useState<number | null>(null);
+  // `null` before the first sync; otherwise the last result. Failures are
+  // an array of `{ target, error }` so the hint can show "instantdb: …"
+  // instead of just a count that overstates how much actually landed.
+  type SyncResultState =
+    | { kind: "ok"; synced: number }
+    | { kind: "partial"; synced: number; failures: Array<{ target: string; error: string }> }
+    | { kind: "error"; message: string };
+  const [lastSync, setLastSync] = useState<SyncResultState | null>(null);
 
   const handleSync = async () => {
     setSyncing(true);
-    setLastSyncCount(null);
+    setLastSync(null);
     try {
       const res = await fetch("/api/sync", { method: "POST" });
-      const body = await res.json() as { synced: number };
-      setLastSyncCount(body.synced);
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        setLastSync({ kind: "error", message: text || `HTTP ${res.status}` });
+        return;
+      }
+      const body = (await res.json()) as { synced: number; failures?: Array<{ target: string; error: string }> };
+      const failures = body.failures || [];
+      if (failures.length > 0) {
+        setLastSync({ kind: "partial", synced: body.synced, failures });
+      } else {
+        setLastSync({ kind: "ok", synced: body.synced });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setLastSync({ kind: "error", message });
     } finally {
       setSyncing(false);
     }
   };
+
+  const syncHint = (() => {
+    if (lastSync === null) return "Re-read chat.db and push any new messages";
+    if (lastSync.kind === "ok") {
+      return `Last sync: ${lastSync.synced} new transaction${lastSync.synced === 1 ? "" : "s"}`;
+    }
+    if (lastSync.kind === "error") {
+      return `Sync failed: ${lastSync.message}`;
+    }
+    // partial — show which target(s) failed so the user understands why
+    // the sync count may not reflect what's actually in their dashboard.
+    const failedTargets = lastSync.failures.map((f) => f.target).join(", ");
+    return `Synced ${lastSync.synced}, ${lastSync.failures.length} target${
+      lastSync.failures.length === 1 ? "" : "s"
+    } failed (${failedTargets}). Will retry on next sync.`;
+  })();
   const [newSenderId, setNewSenderId] = useState("");
   const [newSenderName, setNewSenderName] = useState("");
 
@@ -300,7 +336,7 @@ export function Settings() {
             ))}
           </div>
           <div style={{ marginTop: 14 }}>
-            <Row label="Sync now" hint={lastSyncCount !== null ? `Last sync: ${lastSyncCount} new transaction${lastSyncCount === 1 ? "" : "s"}` : "Re-read chat.db and push any new messages"}>
+            <Row label="Sync now" hint={syncHint}>
               <button
                 type="button"
                 onMouseDown={(e) => e.preventDefault()}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -17,6 +17,20 @@ export function Settings() {
   const { credits } = useCredits();
 
   const [confirm, setConfirm] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [lastSyncCount, setLastSyncCount] = useState<number | null>(null);
+
+  const handleSync = async () => {
+    setSyncing(true);
+    setLastSyncCount(null);
+    try {
+      const res = await fetch("/api/sync", { method: "POST" });
+      const body = await res.json() as { synced: number };
+      setLastSyncCount(body.synced);
+    } finally {
+      setSyncing(false);
+    }
+  };
   const [newSenderId, setNewSenderId] = useState("");
   const [newSenderName, setNewSenderName] = useState("");
 
@@ -284,6 +298,29 @@ export function Settings() {
                 <div style={{ fontSize: 10, color: T.dim, marginTop: 4, fontFamily: T.sans }}>{d.hint}</div>
               </div>
             ))}
+          </div>
+          <div style={{ marginTop: 14 }}>
+            <Row label="Sync now" hint={lastSyncCount !== null ? `Last sync: ${lastSyncCount} new transaction${lastSyncCount === 1 ? "" : "s"}` : "Re-read chat.db and push any new messages"}>
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={syncing ? undefined : handleSync}
+                style={{
+                  padding: "9px 16px",
+                  borderRadius: 10,
+                  border: `1px solid ${T.line}`,
+                  background: T.panelAlt,
+                  color: syncing ? T.muted : T.text,
+                  fontSize: 12.5,
+                  fontWeight: 600,
+                  fontFamily: T.sans,
+                  cursor: syncing ? "default" : "pointer",
+                  opacity: syncing ? 0.7 : 1,
+                }}
+              >
+                {syncing ? "Syncing…" : "Sync"}
+              </button>
+            </Row>
           </div>
         </Section>
 

--- a/service/src/http.ts
+++ b/service/src/http.ts
@@ -84,6 +84,52 @@ function notFound(): Response {
   return new Response("Not found", { status: 404 });
 }
 
+// Allowlist of `Origin` / `Referer` values accepted by state-changing
+// endpoints. The service binds 127.0.0.1 only, but a malicious page the
+// user is visiting can still POST to it cross-origin via a plain HTML
+// form (no preflight, response unreadable but the side effect lands).
+// Reject anything that doesn't originate from the dashboard itself.
+const SAFE_ORIGINS = new Set([
+  "http://127.0.0.1:8721",
+  "http://localhost:8721",
+  // Vite dev server proxies /api → 8721 with `changeOrigin: false` so
+  // requests still carry the dev origin in the Origin header.
+  "http://127.0.0.1:5173",
+  "http://localhost:5173",
+]);
+
+/**
+ * Reject a state-changing request that doesn't carry an Origin / Referer
+ * matching the dashboard. Returns a 403 Response on rejection, null on
+ * pass. Apply to every POST/PUT/DELETE handler that mutates state, not
+ * just the visible-to-the-user ones — a CSRF that forces a benign-looking
+ * sync still leaks transactions to the user's downstream targets.
+ */
+function assertSafeOrigin(req: Request): Response | null {
+  const origin = req.headers.get("origin");
+  if (origin) {
+    return SAFE_ORIGINS.has(origin)
+      ? null
+      : json({ error: "Forbidden: cross-origin request" }, { status: 403 });
+  }
+  // Browsers always send `Origin` on POST since 2017. Fall back to
+  // `Referer` for non-browser clients (curl, the menu-bar app) and
+  // require it match. If neither is present, reject — a missing Origin
+  // on a POST is suspicious.
+  const referer = req.headers.get("referer");
+  if (!referer) {
+    return json({ error: "Forbidden: missing Origin" }, { status: 403 });
+  }
+  try {
+    const refOrigin = new URL(referer).origin;
+    return SAFE_ORIGINS.has(refOrigin)
+      ? null
+      : json({ error: "Forbidden: cross-origin request" }, { status: 403 });
+  } catch {
+    return json({ error: "Forbidden: malformed Referer" }, { status: 403 });
+  }
+}
+
 // When the generated module is populated the server reads bytes through
 // Bun.file(path) where `path` is the string returned by the file-type
 // import — that string resolves correctly inside a compiled binary.
@@ -317,9 +363,11 @@ export function startHttpServer(opts: HttpServerOptions): HttpServerHandle {
         return json(result);
       }
       if (path === "/api/sync" && req.method === "POST") {
+        const csrf = assertSafeOrigin(req);
+        if (csrf) return csrf;
         if (!opts.service) return json({ error: "Service not running" }, { status: 503 });
-        const count = await opts.service.processNewMessages();
-        return json({ synced: count });
+        const outcome = await opts.service.processNewMessages();
+        return json(outcome);
       }
       if (path === "/api/exchange-rate" && req.method === "GET") {
         const dateParam = url.searchParams.get("date");

--- a/service/src/http.ts
+++ b/service/src/http.ts
@@ -316,6 +316,11 @@ export function startHttpServer(opts: HttpServerOptions): HttpServerHandle {
         }
         return json(result);
       }
+      if (path === "/api/sync" && req.method === "POST") {
+        if (!opts.service) return json({ error: "Service not running" }, { status: 503 });
+        const count = await opts.service.processNewMessages();
+        return json({ synced: count });
+      }
       if (path === "/api/exchange-rate" && req.method === "GET") {
         const dateParam = url.searchParams.get("date");
         const langParam = url.searchParams.get("lang");

--- a/service/src/service.ts
+++ b/service/src/service.ts
@@ -6,6 +6,23 @@ import { syncAllTargets, initSyncTargets } from "./sync";
 import { defaultConfig, type Config } from "./config";
 import { closeInstantDB, isConnected as isInstantDBConnected } from "./instant-sync";
 
+export type SyncTargetName = "local" | "webhook" | "instantdb";
+
+export interface SyncFailure {
+  sender: string;
+  target: SyncTargetName;
+  error: string;
+}
+
+/** Result of `processNewMessages`. `synced` counts only the transactions
+ *  that landed in every enabled target — partial successes are
+ *  intentionally excluded from the count so the UI never reports a
+ *  number that overstates how many made it to the user's destination. */
+export interface SyncOutcome {
+  synced: number;
+  failures: SyncFailure[];
+}
+
 export class ExpenseTrackerService {
   private config: Config;
   private stateDb: StateDb | null = null;
@@ -37,23 +54,31 @@ export class ExpenseTrackerService {
   }
 
   /**
-   * Process new messages from all configured senders
+   * Process new messages from all configured senders.
+   *
+   * Returns the count of transactions that landed in every enabled
+   * target plus any per-target failures. The cursor (`last_message_id`)
+   * only advances when ALL enabled targets succeeded for a batch — a
+   * transient InstantDB or webhook failure now causes a retry on the
+   * next run instead of silently leaving those messages out of the
+   * destination forever.
    */
-  async processNewMessages(): Promise<number> {
+  async processNewMessages(): Promise<SyncOutcome> {
     if (this.isProcessing) {
       console.log("[Service] Already processing, skipping...");
-      return 0;
+      return { synced: 0, failures: [] };
     }
 
     // Debounce rapid file changes
     const now = Date.now();
     if (now - this.lastProcessTime < this.debounceMs) {
-      return 0;
+      return { synced: 0, failures: [] };
     }
 
     this.isProcessing = true;
     this.lastProcessTime = now;
     let totalNewTransactions = 0;
+    const failures: SyncFailure[] = [];
 
     try {
       const reader = new MessagesDbReader(this.config.messagesDbPath);
@@ -110,13 +135,48 @@ export class ExpenseTrackerService {
           // Sync to all targets (local, webhook, InstantDB)
           const syncResults = await syncAllTargets(newTransactions, this.config, senderId);
 
-          // Save to state database
-          const synced = syncResults.instantdb.success || syncResults.webhook.success;
-          for (const tx of newTransactions) {
-            this.stateDb!.saveTransaction(tx, synced);
+          // Determine which targets are enabled, then collect failures.
+          // Local file is always enabled (it's the failsafe backup).
+          // Webhook and InstantDB are config-gated.
+          const targetChecks: Array<{ target: SyncTargetName; enabled: boolean; success: boolean; error?: string }> = [
+            { target: "local", enabled: true, success: syncResults.local.success, error: syncResults.local.error },
+            {
+              target: "webhook",
+              enabled: this.config.webhook.enabled && !!this.config.webhook.url,
+              success: syncResults.webhook.success,
+              error: syncResults.webhook.error,
+            },
+            {
+              target: "instantdb",
+              enabled: this.config.instantdb.enabled,
+              success: syncResults.instantdb.success,
+              error: syncResults.instantdb.error,
+            },
+          ];
+
+          const enabledFailures = targetChecks
+            .filter((t) => t.enabled && !t.success)
+            .map((t) => ({ sender: senderId, target: t.target, error: t.error || "unknown error" }));
+
+          if (enabledFailures.length > 0) {
+            // Don't advance the cursor and don't mark transactions as
+            // processed-for-state-db — next sync will retry the same
+            // batch. Surface the failure so the manual-sync UI can show
+            // it instead of falsely reporting success.
+            failures.push(...enabledFailures);
+            console.error(
+              `[Service] ${senderId}: holding cursor at ${lastMessageId} — ${enabledFailures
+                .map((f) => `${f.target}: ${f.error}`)
+                .join("; ")}`
+            );
+            continue;
           }
 
-          // Log sync results
+          // Every enabled target succeeded — record locally and advance.
+          for (const tx of newTransactions) {
+            this.stateDb!.saveTransaction(tx, true);
+          }
+
           if (syncResults.instantdb.success && syncResults.instantdb.syncedCount) {
             console.log(`[Service] Synced ${syncResults.instantdb.syncedCount} to InstantDB`);
           }
@@ -135,18 +195,22 @@ export class ExpenseTrackerService {
             `[Service] Processed ${newTransactions.length} new transactions from ${senderId}`
           );
         } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
           console.error(`[Service] Error processing ${senderId}:`, error);
+          failures.push({ sender: senderId, target: "local", error: `processing: ${message}` });
         }
       }
 
       reader.close();
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       console.error("[Service] Error in processNewMessages:", error);
+      failures.push({ sender: "*", target: "local", error: `processing: ${message}` });
     } finally {
       this.isProcessing = false;
     }
 
-    return totalNewTransactions;
+    return { synced: totalNewTransactions, failures };
   }
 
   /**
@@ -193,8 +257,11 @@ export class ExpenseTrackerService {
 
     // Process any existing messages first
     console.log("[Service] Running initial sync...");
-    const count = await this.processNewMessages();
-    console.log(`[Service] Initial sync complete: ${count} transactions`);
+    const initial = await this.processNewMessages();
+    console.log(`[Service] Initial sync complete: ${initial.synced} transactions`);
+    if (initial.failures.length > 0) {
+      console.warn(`[Service] Initial sync had ${initial.failures.length} failure(s); cursor held for retry.`);
+    }
 
     // Start watching for changes
     this.startWatching();


### PR DESCRIPTION
## Summary
  - Adds `POST /api/sync` endpoint that triggers `processNewMessages()` and returns `{ synced: N }`
  - Adds a "Sync now" row to the Data sources card in Manage (`/manage`) with loading state and a "Last sync: N new
  transactions" result hint
  - Fixes focus-induced scroll-to-top on click via `onMouseDown + preventDefault`

  ## Test plan
  - [ ] Open Manage → Data sources → click Sync
  - [ ] Button shows "Syncing…" during the request, reverts to "Sync" after
  - [ ] Hint updates to "Last sync: N new transactions" on completion
  - [ ] Page does not scroll to top on click
  - [ ] Clicking while syncing is a no-op