### PR TITLE
Interactive charts + functional time-range filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,6 +374,22 @@ Client tests don't exist yet — we rely on `tsc -b` + `vite build` as the only 
 
 For testing an end-user-facing change (icon, onboarding, signed binary behaviour), you have to build the DMG because dev mode doesn't exercise hardened runtime, notarization, or the HTML runtime inject. See §8.
 
+### 7.5 Manual E2E tests (`docs/e2e/`)
+
+The dashboard has no automated UI test suite. Instead, every page has a markdown checklist in `docs/e2e/<page>.md` that an agent walks through in a real Chrome tab via the chrome-MCP. Each test has a stable ID (`T-<AREA>-<NN>`) that PR descriptions and Codex findings can reference.
+
+**Cadence:**
+
+- **Pre-merge to `main`:** run *every* file in `docs/e2e/` top to bottom. The "we broke literally nothing" pass.
+- **PR for a focused feature/fix:** run only the file(s) for the surface(s) the PR touches. A change to `Dashboard.tsx` runs `dashboard.md`; a change to `useRangeState.ts` runs `ranges.md` plus every page file (since the range buttons live in every page header); a change limited to a parser only runs scoped tests if any.
+- **After a Codex review surfaces no-ship findings:** re-run the affected file once the fix is pushed.
+
+**Where the docs live:** `docs/e2e/README.md` is the index, with a table mapping each file to the source surface it covers and the last verification date. Per-page files: `dashboard.md`, `transactions.md`, `categories.md`, `merchants.md`, `income.md`. Cross-cutting: `ranges.md`. Add a new file when adding a new page.
+
+**Update discipline:** the same PR that adds a UI surface adds a test for it. Same PR that removes a surface removes the test. There's no CI signal when the docs drift — the next manual run is the only feedback loop. When updating, bump the "Last verified" cell in the README index.
+
+**Skip handling:** a test marked `[unreliable on real data]` is blocked on the demo-mode dataset (see `~/.claude/plans/now-i-want-to-distributed-zebra.md` — not yet implemented). Skip and note in the PR review.
+
 ---
 
 ## 8. Release pipeline

--- a/client/src/hooks/useCredits.ts
+++ b/client/src/hooks/useCredits.ts
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
 import { db, type Credit } from "../lib/instant";
-import { isWithinInterval, startOfMonth, endOfMonth } from "date-fns";
+import { startOfMonth, endOfMonth, format } from "date-fns";
 import { useGelConverter } from "../lib/exchangeRates";
 import type { MonthYear } from "./useMonthlyAnalytics";
+import { isInRange, type DateRange } from "../lib/dateRange";
 
 export function useCredits() {
   const { data, isLoading, error } = db.useQuery({ credits: {} });
@@ -27,32 +28,28 @@ export function useConvertedCredits() {
   return { credits: converted, isLoading, error };
 }
 
-export function useMonthCredits(my: MonthYear) {
+export function useRangeCredits(range: DateRange) {
   const { credits } = useConvertedCredits();
 
   return useMemo(() => {
-    const start = startOfMonth(new Date(my.year, my.month, 1));
-    const end = endOfMonth(new Date(my.year, my.month, 1));
-    const monthCredits = credits.filter((c) =>
-      isWithinInterval(new Date(c.transactionDate), { start, end })
-    );
+    const inRange = credits.filter((c) => isInRange(c.transactionDate, range));
     // `total` sums every currency converted to GEL; `count` reflects rows
     // that have actually contributed (i.e. either GEL or non-GEL with a
     // resolved rate). Rows still waiting on a rate are kept in `credits`
     // but excluded from the totals until the rate lands.
     let total = 0;
     let count = 0;
-    for (const c of monthCredits) {
+    for (const c of inRange) {
       if (c.gelAmount === null) continue;
       total += c.gelAmount;
       count += 1;
     }
-    return { total, count, credits: monthCredits };
-  }, [credits, my.month, my.year]);
+    return { total, count, credits: inRange };
+  }, [credits, range]);
 }
 
-export function useMonthCashflow(my: MonthYear, spendingTotal: number) {
-  const income = useMonthCredits(my);
+export function useRangeCashflow(range: DateRange, spendingTotal: number) {
+  const income = useRangeCredits(range);
   return {
     income: income.total,
     spending: spendingTotal,
@@ -60,3 +57,16 @@ export function useMonthCashflow(my: MonthYear, spendingTotal: number) {
     incomeCount: income.count,
   };
 }
+
+// Backwards-compat shim — Dashboard + Income still call this with a
+// MonthYear; converts to DateRange and forwards. Removed once those
+// callers migrate to useRangeCredits in this same PR.
+export function useMonthCredits(my: MonthYear) {
+  const range = useMemo<DateRange>(() => {
+    const start = startOfMonth(new Date(my.year, my.month, 1));
+    const end = endOfMonth(start);
+    return { start, end, label: format(start, "MMMM yyyy"), key: "Month" };
+  }, [my.month, my.year]);
+  return useRangeCredits(range);
+}
+

--- a/client/src/hooks/useMonthlyAnalytics.ts
+++ b/client/src/hooks/useMonthlyAnalytics.ts
@@ -1,31 +1,15 @@
 import { useMemo } from "react";
 import { db } from "../lib/instant";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
-import { useCategorizer } from "./useCategorizer";
 import { formatLocalDay } from "../ink/format";
 import { useConvertedPayments } from "./useTransactions";
-import {
-  startOfMonth,
-  endOfMonth,
-  subMonths,
-  isWithinInterval,
-  getDaysInMonth,
-  format,
-} from "date-fns";
+import { useCategorizer } from "./useCategorizer";
+import { startOfMonth, endOfMonth, format, differenceInDays } from "date-fns";
+import { isInRange, previousRange, type DateRange } from "../lib/dateRange";
 
 export interface MonthYear {
   month: number; // 0-11
   year: number;
-}
-
-function getMonthInterval(my: MonthYear) {
-  const d = new Date(my.year, my.month, 1);
-  return { start: startOfMonth(d), end: endOfMonth(d) };
-}
-
-function getPreviousMonth(my: MonthYear): MonthYear {
-  const d = subMonths(new Date(my.year, my.month, 1), 1);
-  return { month: d.getMonth(), year: d.getFullYear() };
 }
 
 export function useAvailableMonths() {
@@ -61,31 +45,30 @@ export function useAvailableMonths() {
   }, [paymentsData?.payments, failedData?.failedPayments]);
 }
 
-export function useMonthStats(my: MonthYear) {
+/** Filters payments + failed-payments to the given date range, returns
+ *  the totals + comparisons against the previous equal-length window.
+ *  Replaces the old useMonthStats(my) — the page now decides the range
+ *  via the PageHeader buttons. */
+export function useRangeStats(range: DateRange) {
   const { payments } = useConvertedPayments();
   const { data: failedData } = db.useQuery({ failedPayments: {} });
 
   return useMemo(() => {
     const failed = failedData?.failedPayments || [];
-    const interval = getMonthInterval(my);
-    const prevInterval = getMonthInterval(getPreviousMonth(my));
+    const prev = previousRange(range);
+    const inCur = (ts: number) => isInRange(ts, range);
+    const inPrev = (ts: number) => isInRange(ts, prev);
 
-    const inRange = (date: number, iv: { start: Date; end: Date }) =>
-      isWithinInterval(new Date(date), iv);
-
-    // Sum every currency converted to GEL via the NBG rate for each
-    // transaction's date. Rows still loading (`gelAmount === null`)
-    // skip the total this render, then snap in once the rate arrives.
     let total = 0;
     let count = 0;
     let prevTotal = 0;
     let prevCount = 0;
     for (const p of payments) {
-      const inCur = inRange(p.transactionDate, interval);
-      const inPrev = !inCur && inRange(p.transactionDate, prevInterval);
-      if (!inCur && !inPrev) continue;
+      const cur = inCur(p.transactionDate);
+      const previous = !cur && inPrev(p.transactionDate);
+      if (!cur && !previous) continue;
       if (p.gelAmount === null) continue;
-      if (inCur) {
+      if (cur) {
         total += p.gelAmount;
         count += 1;
       } else {
@@ -93,7 +76,8 @@ export function useMonthStats(my: MonthYear) {
         prevCount += 1;
       }
     }
-    const failedCount = failed.filter((p) => inRange(p.transactionDate, interval)).length;
+
+    const failedCount = failed.filter((p) => inCur(p.transactionDate)).length;
     const avg = count > 0 ? total / count : 0;
     const totalChange = prevTotal > 0 ? ((total - prevTotal) / prevTotal) * 100 : 0;
     const countChange = prevCount > 0 ? ((count - prevCount) / prevCount) * 100 : 0;
@@ -108,49 +92,59 @@ export function useMonthStats(my: MonthYear) {
       totalChange,
       countChange,
     };
-  }, [payments, failedData?.failedPayments, my.month, my.year]);
+  }, [payments, failedData?.failedPayments, range]);
 }
 
-export function useMonthSpendingByDay(my: MonthYear) {
+/** Aggregates spending into per-day buckets across the active range.
+ *  Returns at most ~93 days; longer ranges fall back to monthly buckets
+ *  so a "Year" view stays readable. */
+export function useRangeSpendingByDay(range: DateRange) {
   const { payments } = useConvertedPayments();
 
   return useMemo(() => {
-    const interval = getMonthInterval(my);
+    const days = differenceInDays(range.end, range.start) + 1;
+    const useMonthly = days > 93;
+    const buckets: Record<string, number> = {};
 
-    const monthPayments = payments.filter((p) =>
-      isWithinInterval(new Date(p.transactionDate), interval)
-    );
-
-    const dailyTotals: Record<string, number> = {};
-    for (const p of monthPayments) {
+    for (const p of payments) {
+      if (!isInRange(p.transactionDate, range)) continue;
       if (p.gelAmount === null) continue;
-      const date = formatLocalDay(p.transactionDate);
-      dailyTotals[date] = (dailyTotals[date] || 0) + p.gelAmount;
+      const d = new Date(p.transactionDate);
+      const key = useMonthly
+        ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
+        : formatLocalDay(p.transactionDate);
+      buckets[key] = (buckets[key] || 0) + p.gelAmount;
     }
 
-    const daysInMonth = getDaysInMonth(new Date(my.year, my.month, 1));
-    const result: { date: string; amount: number }[] = [];
-    for (let day = 1; day <= daysInMonth; day++) {
-      const date = formatLocalDay(new Date(my.year, my.month, day).getTime());
-      result.push({ date, amount: dailyTotals[date] || 0 });
+    if (useMonthly) {
+      const out: { date: string; amount: number }[] = [];
+      const cur = new Date(range.start);
+      cur.setDate(1);
+      while (cur.getTime() <= range.end.getTime()) {
+        const key = `${cur.getFullYear()}-${String(cur.getMonth() + 1).padStart(2, "0")}`;
+        out.push({ date: key, amount: buckets[key] || 0 });
+        cur.setMonth(cur.getMonth() + 1);
+      }
+      return out;
     }
 
-    return result;
-  }, [payments, my.month, my.year]);
+    const out: { date: string; amount: number }[] = [];
+    for (let i = 0; i < days; i++) {
+      const d = new Date(range.start.getFullYear(), range.start.getMonth(), range.start.getDate() + i);
+      const key = formatLocalDay(d.getTime());
+      out.push({ date: key, amount: buckets[key] || 0 });
+    }
+    return out;
+  }, [payments, range]);
 }
 
-export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
+export function useRangeTopMerchants(range: DateRange, limit: number = 10) {
   const { payments } = useConvertedPayments();
 
   return useMemo(() => {
-    const interval = getMonthInterval(my);
-
-    const monthPayments = payments.filter((p) =>
-      isWithinInterval(new Date(p.transactionDate), interval)
-    );
-
     const merchantTotals: Record<string, { total: number; count: number }> = {};
-    for (const p of monthPayments) {
+    for (const p of payments) {
+      if (!isInRange(p.transactionDate, range)) continue;
       if (p.gelAmount === null) continue;
       const merchant = p.merchant || "Unknown";
       if (!merchantTotals[merchant]) merchantTotals[merchant] = { total: 0, count: 0 };
@@ -162,22 +156,16 @@ export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
       .map(([name, data]) => ({ name, ...data }))
       .sort((a, b) => b.total - a.total)
       .slice(0, limit);
-  }, [payments, my.month, my.year, limit]);
+  }, [payments, range, limit]);
 }
 
-export function useMonthCategoryAnalytics(my: MonthYear) {
+export function useRangeCategoryAnalytics(range: DateRange) {
   const { payments } = useConvertedPayments();
   const { data: catData } = db.useQuery({ categories: {} });
   const { categorizeName } = useCategorizer();
 
   return useMemo(() => {
     const categories = catData?.categories || [];
-    const interval = getMonthInterval(my);
-
-    const monthPayments = payments.filter((p) =>
-      isWithinInterval(new Date(p.transactionDate), interval)
-    );
-
     const categoryTotals: Record<string, { total: number; count: number; color: string }> = {};
 
     const cats = categories.length > 0 ? categories : DEFAULT_CATEGORIES;
@@ -188,7 +176,8 @@ export function useMonthCategoryAnalytics(my: MonthYear) {
       categoryTotals["Other"] = { total: 0, count: 0, color: "#6b7280" };
     }
 
-    for (const payment of monthPayments) {
+    for (const payment of payments) {
+      if (!isInRange(payment.transactionDate, range)) continue;
       if (payment.gelAmount === null) continue;
       const categoryName = categorizeName(payment.merchant ?? null);
       if (categoryTotals[categoryName]) {
@@ -215,5 +204,34 @@ export function useMonthCategoryAnalytics(my: MonthYear) {
         percentage: totalSpent > 0 ? (cat.total / totalSpent) * 100 : 0,
       })),
     };
-  }, [payments, catData?.categories, my.month, my.year, categorizeName]);
+  }, [payments, catData?.categories, range, categorizeName]);
 }
+
+// ──────────────────────────────────────────────────────────────────
+// Backwards-compat shims so call sites that still pass MonthYear keep
+// working through the migration. Each just builds the equivalent
+// DateRange and forwards. Deleted once every page has moved to the
+// range-based hooks.
+
+function rangeFromMonth(my: MonthYear): DateRange {
+  const start = startOfMonth(new Date(my.year, my.month, 1));
+  const end = endOfMonth(start);
+  return { start, end, label: format(start, "MMMM yyyy"), key: "Month" };
+}
+
+export function useMonthStats(my: MonthYear) {
+  return useRangeStats(useMemo(() => rangeFromMonth(my), [my.month, my.year]));
+}
+
+export function useMonthTopMerchants(my: MonthYear, limit: number = 10) {
+  return useRangeTopMerchants(useMemo(() => rangeFromMonth(my), [my.month, my.year]), limit);
+}
+
+export function useMonthCategoryAnalytics(my: MonthYear) {
+  return useRangeCategoryAnalytics(useMemo(() => rangeFromMonth(my), [my.month, my.year]));
+}
+
+export function useMonthSpendingByDay(my: MonthYear) {
+  return useRangeSpendingByDay(useMemo(() => rangeFromMonth(my), [my.month, my.year]));
+}
+

--- a/client/src/hooks/useRangeState.ts
+++ b/client/src/hooks/useRangeState.ts
@@ -19,10 +19,22 @@ export interface UseRangeStateResult {
   props: RangeStateProps;
 }
 
-export function useRangeState(initial: RangeKey = "Month"): UseRangeStateResult {
-  const [active, setActive] = useState<RangeKey>(initial);
-  const [customStart, setCustomStart] = useState("");
-  const [customEnd, setCustomEnd] = useState("");
+export interface UseRangeStateOptions {
+  /** Pre-fill custom dates and switch to "Custom" on mount. Used by drill-down
+   *  links that pass `?dateFrom=…&dateTo=…` so the user lands on the same
+   *  window the chart bar represented. Both must be YYYY-MM-DD. */
+  customInitial?: { start: string; end: string };
+}
+
+export function useRangeState(
+  initial: RangeKey = "Month",
+  options?: UseRangeStateOptions
+): UseRangeStateResult {
+  const customInitial = options?.customInitial;
+  const useCustom = !!(customInitial && customInitial.start && customInitial.end);
+  const [active, setActive] = useState<RangeKey>(useCustom ? "Custom" : initial);
+  const [customStart, setCustomStart] = useState(useCustom ? customInitial!.start : "");
+  const [customEnd, setCustomEnd] = useState(useCustom ? customInitial!.end : "");
   // `clockTick` advances at the next local-midnight boundary so a
   // long-lived dashboard tab doesn't keep showing yesterday's "Today"
   // (or the previous month's "Month") after the calendar rolls over.

--- a/client/src/hooks/useRangeState.ts
+++ b/client/src/hooks/useRangeState.ts
@@ -3,7 +3,7 @@
 // derived DateRange + the props PageHeader needs (active/onRange/
 // custom inputs). Pages stay one-liner thin.
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { rangeFromKey, type DateRange, type RangeKey } from "../lib/dateRange";
 
 export interface RangeStateProps {
@@ -23,14 +23,17 @@ export function useRangeState(initial: RangeKey = "Month"): UseRangeStateResult 
   const [active, setActive] = useState<RangeKey>(initial);
   const [customStart, setCustomStart] = useState("");
   const [customEnd, setCustomEnd] = useState("");
+  // `clockTick` advances at the next local-midnight boundary so a
+  // long-lived dashboard tab doesn't keep showing yesterday's "Today"
+  // (or the previous month's "Month") after the calendar rolls over.
+  // Including it in the memo deps below recomputes the range without
+  // wedging it on a stale `new Date()` from the initial render.
+  const clockTick = useMidnightTick();
 
-  // `now` is captured per render so the hooks downstream see a stable
-  // input within a single React commit. Re-evaluating on every commit
-  // is fine: the underlying data only changes when InstantDB pushes
-  // an update, and the buckets snap to whatever "today" is then.
   const range = useMemo(
     () => rangeFromKey(active, new Date(), { start: customStart, end: customEnd }),
-    [active, customStart, customEnd]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [active, customStart, customEnd, clockTick]
   );
 
   return {
@@ -46,4 +49,39 @@ export function useRangeState(initial: RangeKey = "Month"): UseRangeStateResult 
       },
     },
   };
+}
+
+/** Returns a state value that bumps once per local-midnight rollover.
+ *  Cheap (one timeout at a time, no per-second polling) and only fires
+ *  while the tab is mounted, so it doesn't leak when the user
+ *  navigates away. */
+function useMidnightTick(): number {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    let timeoutId: number | null = null;
+    const schedule = () => {
+      const now = new Date();
+      const nextMidnight = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate() + 1,
+        0,
+        0,
+        0,
+        0
+      ).getTime();
+      // +500ms cushion so we land safely on the new day even if the
+      // event loop runs the callback a few ms early.
+      const ms = Math.max(1000, nextMidnight - now.getTime() + 500);
+      timeoutId = window.setTimeout(() => {
+        setTick((t) => t + 1);
+        schedule();
+      }, ms);
+    };
+    schedule();
+    return () => {
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+    };
+  }, []);
+  return tick;
 }

--- a/client/src/hooks/useRangeState.ts
+++ b/client/src/hooks/useRangeState.ts
@@ -1,0 +1,49 @@
+// Shared range-button state for any page that renders the
+// Today/Week/Month/Year/Custom switcher in PageHeader. Returns the
+// derived DateRange + the props PageHeader needs (active/onRange/
+// custom inputs). Pages stay one-liner thin.
+
+import { useMemo, useState } from "react";
+import { rangeFromKey, type DateRange, type RangeKey } from "../lib/dateRange";
+
+export interface RangeStateProps {
+  active: RangeKey;
+  onRange: (key: string) => void;
+  customStart: string;
+  customEnd: string;
+  onCustomChange: (start: string, end: string) => void;
+}
+
+export interface UseRangeStateResult {
+  range: DateRange;
+  props: RangeStateProps;
+}
+
+export function useRangeState(initial: RangeKey = "Month"): UseRangeStateResult {
+  const [active, setActive] = useState<RangeKey>(initial);
+  const [customStart, setCustomStart] = useState("");
+  const [customEnd, setCustomEnd] = useState("");
+
+  // `now` is captured per render so the hooks downstream see a stable
+  // input within a single React commit. Re-evaluating on every commit
+  // is fine: the underlying data only changes when InstantDB pushes
+  // an update, and the buckets snap to whatever "today" is then.
+  const range = useMemo(
+    () => rangeFromKey(active, new Date(), { start: customStart, end: customEnd }),
+    [active, customStart, customEnd]
+  );
+
+  return {
+    range,
+    props: {
+      active,
+      onRange: (k) => setActive(k as RangeKey),
+      customStart,
+      customEnd,
+      onCustomChange: (start, end) => {
+        setCustomStart(start);
+        setCustomEnd(end);
+      },
+    },
+  };
+}

--- a/client/src/ink/charts.tsx
+++ b/client/src/ink/charts.tsx
@@ -7,9 +7,11 @@ import {
   Pie,
   PieChart,
   ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
+import { useTheme } from "./theme";
 
 export interface AreaDatum {
   label: string;
@@ -29,6 +31,7 @@ export function AreaChart({
   axisColor = "rgba(0,0,0,0.4)",
   axisFont = "ui-monospace, monospace",
   formatY = (n: number) => n.toFixed(0),
+  formatTooltipValue,
   cornerRadius = 0,
   padding = { top: 18, right: 12, bottom: 22, left: 42 },
 }: {
@@ -44,6 +47,7 @@ export function AreaChart({
   axisColor?: string;
   axisFont?: string;
   formatY?: (n: number) => string;
+  formatTooltipValue?: (n: number) => string;
   cornerRadius?: number;
   padding?: { top: number; right: number; bottom: number; left: number };
 }) {
@@ -100,6 +104,11 @@ export function AreaChart({
             tickLine={false}
             width={36}
           />
+          <Tooltip
+            cursor={{ stroke, strokeWidth: 1, strokeDasharray: "3 3", strokeOpacity: 0.6 }}
+            content={<AreaTooltipContent data={data} accent={stroke} formatValue={formatTooltipValue} />}
+            isAnimationActive={false}
+          />
           <Area
             type="monotone"
             dataKey="value"
@@ -110,11 +119,104 @@ export function AreaChart({
             fill={fill ? `url(#${gradientId})` : "none"}
             isAnimationActive={false}
             clipPath={cornerRadius > 0 && fill ? `url(#${clipId})` : undefined}
+            activeDot={{ r: 4, stroke, strokeWidth: 1.5, fill: "#fff" }}
           />
         </RAreaChart>
       </ResponsiveContainer>
     </div>
   );
+}
+
+function AreaTooltipContent({
+  data,
+  accent,
+  formatValue,
+  active,
+  payload,
+}: {
+  data: AreaDatum[];
+  accent: string;
+  formatValue?: (n: number) => string;
+  active?: boolean;
+  payload?: Array<{ payload?: AreaDatum }>;
+}) {
+  const T = useTheme();
+  if (!active || !payload || payload.length === 0) return null;
+  const point = payload[0]?.payload;
+  if (!point) return null;
+  const idx = data.findIndex((d) => d.label === point.label);
+  const prev = idx > 0 ? data[idx - 1] : null;
+  const fmt = formatValue ?? ((n: number) => `₾${Math.round(n).toLocaleString("en-US")}`);
+  const delta =
+    prev && prev.value > 0 ? ((point.value - prev.value) / prev.value) * 100 : null;
+  const deltaColor = delta === null ? T.dim : delta >= 0 ? T.green : T.accent;
+  const deltaSign = delta === null ? "" : delta >= 0 ? "+" : "";
+
+  return (
+    <div
+      style={{
+        background: T.panel,
+        border: `1px solid ${T.lineStrong}`,
+        borderRadius: 10,
+        padding: "10px 12px",
+        boxShadow: T.shadow,
+        fontFamily: T.sans,
+        minWidth: 140,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          color: T.dim,
+          fontFamily: T.mono,
+          letterSpacing: 0.6,
+          textTransform: "uppercase",
+          marginBottom: 4,
+        }}
+      >
+        {point.label}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span style={{ width: 8, height: 8, borderRadius: 4, background: accent, flexShrink: 0 }} />
+        <span
+          style={{
+            fontSize: 15,
+            fontWeight: 700,
+            color: T.text,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {fmt(point.value)}
+        </span>
+      </div>
+      {prev && (
+        <div
+          style={{
+            fontSize: 11,
+            color: T.muted,
+            marginTop: 4,
+            fontFamily: T.mono,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          vs <span style={{ color: T.dim }}>{prev.label}</span> {fmt(prev.value)}
+          {delta !== null && (
+            <span style={{ color: deltaColor, marginLeft: 6 }}>
+              {deltaSign}
+              {delta.toFixed(0)}%
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface DonutSegment {
+  value: number;
+  color: string;
+  /** Optional human-readable label shown in the tooltip on hover. */
+  name?: string;
 }
 
 export function Donut({
@@ -126,8 +228,9 @@ export function Donut({
   centerValue,
   centerColor = "#333",
   labelFont = "ui-monospace, monospace",
+  formatTooltipValue,
 }: {
-  segments: { value: number; color: string }[];
+  segments: DonutSegment[];
   size?: number;
   thickness?: number;
   gap?: number;
@@ -135,11 +238,17 @@ export function Donut({
   centerValue?: string;
   centerColor?: string;
   labelFont?: string;
+  formatTooltipValue?: (n: number) => string;
 }) {
   const inner = Math.max(0, size / 2 - thickness);
   const outer = size / 2;
-  const data = segments.map((s, i) => ({ name: String(i), value: s.value, color: s.color }));
+  const data = segments.map((s, i) => ({
+    name: s.name ?? `Segment ${i + 1}`,
+    value: s.value,
+    color: s.color,
+  }));
   const hasData = data.some((d) => d.value > 0);
+  const total = data.reduce((s, d) => s + d.value, 0) || 1;
 
   return (
     <div style={{ position: "relative", width: size, height: size }}>
@@ -161,6 +270,12 @@ export function Donut({
             <Cell key={i} fill={d.color} />
           ))}
         </Pie>
+        {hasData && (
+          <Tooltip
+            content={<DonutTooltipContent total={total} formatValue={formatTooltipValue} />}
+            isAnimationActive={false}
+          />
+        )}
       </PieChart>
       {(centerLabel || centerValue) && (
         <div
@@ -205,6 +320,66 @@ export function Donut({
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+function DonutTooltipContent({
+  total,
+  formatValue,
+  active,
+  payload,
+}: {
+  total: number;
+  formatValue?: (n: number) => string;
+  active?: boolean;
+  payload?: Array<{ payload?: { name: string; value: number; color: string } }>;
+}) {
+  const T = useTheme();
+  if (!active || !payload || payload.length === 0) return null;
+  const point = payload[0]?.payload;
+  if (!point) return null;
+  const fmt = formatValue ?? ((n: number) => `₾${Math.round(n).toLocaleString("en-US")}`);
+  const share = total > 0 ? (point.value / total) * 100 : 0;
+
+  return (
+    <div
+      style={{
+        background: T.panel,
+        border: `1px solid ${T.lineStrong}`,
+        borderRadius: 10,
+        padding: "10px 12px",
+        boxShadow: T.shadow,
+        fontFamily: T.sans,
+        minWidth: 140,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+        <span style={{ width: 8, height: 8, borderRadius: 4, background: point.color, flexShrink: 0 }} />
+        <span style={{ fontSize: 12, fontWeight: 600, color: T.text }}>{point.name}</span>
+      </div>
+      <div
+        style={{
+          fontSize: 15,
+          fontWeight: 700,
+          color: T.text,
+          fontFamily: T.sans,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {fmt(point.value)}
+      </div>
+      <div
+        style={{
+          fontSize: 11,
+          color: T.muted,
+          fontFamily: T.mono,
+          marginTop: 2,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {share.toFixed(1)}% of total
+      </div>
     </div>
   );
 }

--- a/client/src/ink/charts.tsx
+++ b/client/src/ink/charts.tsx
@@ -34,6 +34,7 @@ export function AreaChart({
   formatTooltipValue,
   cornerRadius = 0,
   padding = { top: 18, right: 12, bottom: 22, left: 42 },
+  onBucketClick,
 }: {
   data: AreaDatum[];
   width?: number;
@@ -50,6 +51,9 @@ export function AreaChart({
   formatTooltipValue?: (n: number) => string;
   cornerRadius?: number;
   padding?: { top: number; right: number; bottom: number; left: number };
+  /** Fires when the user clicks a bucket point. Receives the datum and its
+   *  zero-based index, so the consumer can navigate to a date-filtered view. */
+  onBucketClick?: (datum: AreaDatum, index: number) => void;
 }) {
   const gradientId = React.useId();
   const clipId = React.useId();
@@ -68,10 +72,23 @@ export function AreaChart({
     return "";
   };
 
+  const handleClick = onBucketClick
+    ? (state: unknown) => {
+        const s = state as
+          | { activeTooltipIndex?: number | string | null; activePayload?: Array<{ payload?: AreaDatum }> }
+          | null;
+        if (!s) return;
+        const idx = typeof s.activeTooltipIndex === "number" ? s.activeTooltipIndex : Number(s.activeTooltipIndex);
+        if (!Number.isFinite(idx)) return;
+        const datum = s.activePayload?.[0]?.payload;
+        if (datum) onBucketClick(datum, idx);
+      }
+    : undefined;
+
   return (
-    <div style={{ width, height, maxWidth: "100%" }}>
+    <div style={{ width, height, maxWidth: "100%", cursor: onBucketClick ? "pointer" : undefined }}>
       <ResponsiveContainer width="100%" height="100%">
-        <RAreaChart data={data} margin={chartMargin}>
+        <RAreaChart data={data} margin={chartMargin} onClick={handleClick}>
           {fill && (
             <defs>
               <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
@@ -229,6 +246,7 @@ export function Donut({
   centerColor = "#333",
   labelFont = "ui-monospace, monospace",
   formatTooltipValue,
+  onSegmentClick,
 }: {
   segments: DonutSegment[];
   size?: number;
@@ -239,6 +257,11 @@ export function Donut({
   centerColor?: string;
   labelFont?: string;
   formatTooltipValue?: (n: number) => string;
+  /** Fires when the user clicks a segment. Receives the original segment
+   *  (so the consumer can read its `name`) plus its index in the `segments`
+   *  array. The empty placeholder shown when every value is 0 does not
+   *  fire this. */
+  onSegmentClick?: (segment: DonutSegment, index: number) => void;
 }) {
   const inner = Math.max(0, size / 2 - thickness);
   const outer = size / 2;
@@ -250,8 +273,16 @@ export function Donut({
   const hasData = data.some((d) => d.value > 0);
   const total = data.reduce((s, d) => s + d.value, 0) || 1;
 
+  const clickable = hasData && !!onSegmentClick;
+  const handleSliceClick = clickable
+    ? (_: unknown, index: number) => {
+        const seg = segments[index];
+        if (seg) onSegmentClick!(seg, index);
+      }
+    : undefined;
+
   return (
-    <div style={{ position: "relative", width: size, height: size }}>
+    <div style={{ position: "relative", width: size, height: size, cursor: clickable ? "pointer" : undefined }}>
       <PieChart width={size} height={size}>
         <Pie
           data={hasData ? data : [{ name: "empty", value: 1, color: "transparent" }]}
@@ -265,6 +296,7 @@ export function Donut({
           endAngle={-270}
           stroke="none"
           isAnimationActive={false}
+          onClick={handleSliceClick}
         >
           {(hasData ? data : [{ color: "transparent" }]).map((d, i) => (
             <Cell key={i} fill={d.color} />

--- a/client/src/ink/charts.tsx
+++ b/client/src/ink/charts.tsx
@@ -1,4 +1,15 @@
 import React from "react";
+import {
+  Area,
+  AreaChart as RAreaChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 export interface AreaDatum {
   label: string;
@@ -36,65 +47,73 @@ export function AreaChart({
   cornerRadius?: number;
   padding?: { top: number; right: number; bottom: number; left: number };
 }) {
+  const gradientId = React.useId();
   const clipId = React.useId();
   if (!data || data.length === 0) return null;
-  const values = data.map((d) => d.value);
-  const max = Math.max(...values, 1) * 1.08;
-  const min = 0;
-  const innerW = width - padding.left - padding.right;
-  const innerH = height - padding.top - padding.bottom;
-  const x = (i: number) => padding.left + (i / Math.max(1, data.length - 1)) * innerW;
-  const y = (v: number) => padding.top + innerH - ((v - min) / (max - min || 1)) * innerH;
-  const line = data.map((d, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(2)},${y(d.value).toFixed(2)}`).join(" ");
-  const area = `${line} L${x(data.length - 1).toFixed(2)},${padding.top + innerH} L${x(0).toFixed(2)},${padding.top + innerH} Z`;
-  const gridLines = [0, 0.25, 0.5, 0.75, 1].map((t) => padding.top + innerH * t);
+
+  const chartMargin = {
+    top: padding.top,
+    right: padding.right,
+    bottom: showAxes ? Math.max(0, padding.bottom - 18) : padding.bottom,
+    left: showAxes ? Math.max(0, padding.left - 30) : padding.left,
+  };
+
+  const tickEvery = data.length > 14 ? Math.ceil(data.length / 7) : 1;
+  const xTickFormatter = (label: string, index: number) => {
+    if (index === data.length - 1 || index % tickEvery === 0) return label;
+    return "";
+  };
 
   return (
-    <svg
-      viewBox={`0 0 ${width} ${height}`}
-      width={width}
-      height={height}
-      style={{ display: "block", overflow: "visible", maxWidth: "100%", height: "auto" }}
-    >
-      {cornerRadius > 0 && (
-        <defs>
-          <clipPath id={clipId}>
-            <rect x={padding.left} y={padding.top} width={innerW} height={innerH} rx={cornerRadius} ry={cornerRadius} />
-          </clipPath>
-        </defs>
-      )}
-      {showGrid &&
-        gridLines.map((yy, i) => (
-          <line key={i} x1={padding.left} x2={width - padding.right} y1={yy} y2={yy} stroke={gridColor} strokeWidth="1" />
-        ))}
-      {showAxes &&
-        [1, 0.75, 0.5, 0.25, 0].map((t, i) => (
-          <text
-            key={i}
-            x={padding.left - 8}
-            y={padding.top + innerH * (1 - t) + 3}
-            fontSize="10"
-            fontFamily={axisFont}
-            fill={axisColor}
-            textAnchor="end"
-          >
-            {formatY(max * t)}
-          </text>
-        ))}
-      <g clipPath={cornerRadius > 0 ? `url(#${clipId})` : undefined}>
-        {fill && <path d={area} fill={fill} />}
-        <path d={line} fill="none" stroke={stroke} strokeWidth={strokeWidth} strokeLinejoin="round" strokeLinecap="round" />
-      </g>
-      {showAxes &&
-        data.map((d, i) => {
-          if (data.length > 14 && i % Math.ceil(data.length / 7) !== 0 && i !== data.length - 1) return null;
-          return (
-            <text key={i} x={x(i)} y={height - padding.bottom + 14} fontSize="10" fontFamily={axisFont} fill={axisColor} textAnchor="middle">
-              {d.label}
-            </text>
-          );
-        })}
-    </svg>
+    <div style={{ width, height, maxWidth: "100%" }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RAreaChart data={data} margin={chartMargin}>
+          {fill && (
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={fill} stopOpacity={1} />
+                <stop offset="100%" stopColor={fill} stopOpacity={0.6} />
+              </linearGradient>
+              {cornerRadius > 0 && (
+                <clipPath id={clipId}>
+                  <rect x="0" y="0" width="100%" height="100%" rx={cornerRadius} ry={cornerRadius} />
+                </clipPath>
+              )}
+            </defs>
+          )}
+          {showGrid && <CartesianGrid stroke={gridColor} vertical={false} />}
+          <XAxis
+            dataKey="label"
+            hide={!showAxes}
+            tick={{ fill: axisColor, fontSize: 10, fontFamily: axisFont }}
+            tickFormatter={xTickFormatter}
+            interval={0}
+            axisLine={false}
+            tickLine={false}
+            padding={{ left: 0, right: 0 }}
+          />
+          <YAxis
+            hide={!showAxes}
+            tick={{ fill: axisColor, fontSize: 10, fontFamily: axisFont }}
+            tickFormatter={formatY}
+            axisLine={false}
+            tickLine={false}
+            width={36}
+          />
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            fill={fill ? `url(#${gradientId})` : "none"}
+            isAnimationActive={false}
+            clipPath={cornerRadius > 0 && fill ? `url(#${clipId})` : undefined}
+          />
+        </RAreaChart>
+      </ResponsiveContainer>
+    </div>
   );
 }
 
@@ -117,46 +136,76 @@ export function Donut({
   centerColor?: string;
   labelFont?: string;
 }) {
-  const r = size / 2;
-  const inner = r - thickness;
-  const total = segments.reduce((s, x) => s + x.value, 0) || 1;
-  let acc = -Math.PI / 2;
-  const tau = Math.PI * 2;
-
-  const arc = (startA: number, endA: number) => {
-    const large = endA - startA > Math.PI ? 1 : 0;
-    const sx = r + r * Math.cos(startA);
-    const sy = r + r * Math.sin(startA);
-    const ex = r + r * Math.cos(endA);
-    const ey = r + r * Math.sin(endA);
-    const sx2 = r + inner * Math.cos(endA);
-    const sy2 = r + inner * Math.sin(endA);
-    const ex2 = r + inner * Math.cos(startA);
-    const ey2 = r + inner * Math.sin(startA);
-    return `M${sx},${sy} A${r},${r} 0 ${large} 1 ${ex},${ey} L${sx2},${sy2} A${inner},${inner} 0 ${large} 0 ${ex2},${ey2} Z`;
-  };
+  const inner = Math.max(0, size / 2 - thickness);
+  const outer = size / 2;
+  const data = segments.map((s, i) => ({ name: String(i), value: s.value, color: s.color }));
+  const hasData = data.some((d) => d.value > 0);
 
   return (
-    <svg width={size} height={size} style={{ display: "block" }}>
-      {segments.map((s, i) => {
-        const frac = s.value / total;
-        const startA = acc;
-        const endA = acc + frac * tau - gap / r;
-        acc += frac * tau;
-        if (endA <= startA) return null;
-        return <path key={i} d={arc(startA, endA)} fill={s.color} />;
-      })}
-      {centerLabel && (
-        <text x={r} y={r - 4} textAnchor="middle" fontSize="11" fontFamily={labelFont} fill={centerColor} style={{ opacity: 0.55, letterSpacing: 0.6, textTransform: "uppercase" }}>
-          {centerLabel}
-        </text>
+    <div style={{ position: "relative", width: size, height: size }}>
+      <PieChart width={size} height={size}>
+        <Pie
+          data={hasData ? data : [{ name: "empty", value: 1, color: "transparent" }]}
+          dataKey="value"
+          cx="50%"
+          cy="50%"
+          innerRadius={inner}
+          outerRadius={outer}
+          paddingAngle={hasData ? gap : 0}
+          startAngle={90}
+          endAngle={-270}
+          stroke="none"
+          isAnimationActive={false}
+        >
+          {(hasData ? data : [{ color: "transparent" }]).map((d, i) => (
+            <Cell key={i} fill={d.color} />
+          ))}
+        </Pie>
+      </PieChart>
+      {(centerLabel || centerValue) && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            pointerEvents: "none",
+          }}
+        >
+          {centerLabel && (
+            <span
+              style={{
+                fontSize: 11,
+                fontFamily: labelFont,
+                color: centerColor,
+                opacity: 0.55,
+                letterSpacing: 0.6,
+                textTransform: "uppercase",
+                lineHeight: 1.2,
+              }}
+            >
+              {centerLabel}
+            </span>
+          )}
+          {centerValue && (
+            <span
+              style={{
+                fontSize: 22,
+                fontFamily: labelFont,
+                color: centerColor,
+                fontWeight: 600,
+                marginTop: 2,
+                lineHeight: 1.1,
+              }}
+            >
+              {centerValue}
+            </span>
+          )}
+        </div>
       )}
-      {centerValue && (
-        <text x={r} y={r + 18} textAnchor="middle" fontSize="22" fontFamily={labelFont} fill={centerColor} fontWeight={600}>
-          {centerValue}
-        </text>
-      )}
-    </svg>
+    </div>
   );
 }
 
@@ -175,18 +224,38 @@ export function Sparkline({
   strokeWidth?: number;
   fill?: string;
 }) {
+  const gradientId = React.useId();
   if (!values || values.length === 0) return null;
-  const max = Math.max(...values);
-  const min = Math.min(...values);
-  const x = (i: number) => (i / (values.length - 1 || 1)) * width;
-  const y = (v: number) => height - ((v - min) / (max - min || 1)) * height;
-  const line = values.map((v, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(" ");
-  const area = fill !== "none" ? `${line} L${width},${height} L0,${height} Z` : null;
+  const data = values.map((v, i) => ({ i, value: v }));
+  const usesFill = fill && fill !== "none";
+
   return (
-    <svg width={width} height={height} style={{ display: "block" }}>
-      {area && <path d={area} fill={fill} />}
-      <path d={line} fill="none" stroke={stroke} strokeWidth={strokeWidth} strokeLinejoin="round" strokeLinecap="round" />
-    </svg>
+    <div style={{ width, height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RAreaChart data={data} margin={{ top: 1, right: 0, bottom: 1, left: 0 }}>
+          {usesFill && (
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={fill} stopOpacity={1} />
+                <stop offset="100%" stopColor={fill} stopOpacity={0.6} />
+              </linearGradient>
+            </defs>
+          )}
+          <XAxis dataKey="i" hide />
+          <YAxis hide domain={["dataMin", "dataMax"]} />
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            fill={usesFill ? `url(#${gradientId})` : "none"}
+            isAnimationActive={false}
+          />
+        </RAreaChart>
+      </ResponsiveContainer>
+    </div>
   );
 }
 

--- a/client/src/ink/charts.tsx
+++ b/client/src/ink/charts.tsx
@@ -72,23 +72,42 @@ export function AreaChart({
     return "";
   };
 
-  const handleClick = onBucketClick
-    ? (state: unknown) => {
-        const s = state as
-          | { activeTooltipIndex?: number | string | null; activePayload?: Array<{ payload?: AreaDatum }> }
-          | null;
-        if (!s) return;
-        const idx = typeof s.activeTooltipIndex === "number" ? s.activeTooltipIndex : Number(s.activeTooltipIndex);
-        if (!Number.isFinite(idx)) return;
-        const datum = s.activePayload?.[0]?.payload;
+  // Recharts v3.6 + React 19 doesn't reliably fire chart-level `onClick` —
+  // the wrapper div receives the DOM click but the React handler never
+  // runs through. Wrap the chart in our own div and compute the bucket
+  // index from the click x-coordinate against the visible data area.
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const handleClickFromContainer = onBucketClick
+    ? (e: React.MouseEvent<HTMLDivElement>) => {
+        const node = containerRef.current;
+        if (!node || data.length === 0) return;
+        const rect = node.getBoundingClientRect();
+        const innerLeft = rect.left + chartMargin.left;
+        const innerRight = rect.right - chartMargin.right;
+        const innerWidth = innerRight - innerLeft;
+        if (innerWidth <= 0) return;
+        const x = e.clientX;
+        // Recharts plots category points evenly across the inner width:
+        // index i sits at innerLeft + (innerWidth * i / (n-1)) for n>1.
+        // Snap the click x to the nearest bucket so a click between two
+        // points always lands on the closer one.
+        const ratio = (x - innerLeft) / innerWidth;
+        const clamped = Math.max(0, Math.min(1, ratio));
+        const lastIdx = data.length - 1;
+        const idx = lastIdx <= 0 ? 0 : Math.round(clamped * lastIdx);
+        const datum = data[idx];
         if (datum) onBucketClick(datum, idx);
       }
     : undefined;
 
   return (
-    <div style={{ width, height, maxWidth: "100%", cursor: onBucketClick ? "pointer" : undefined }}>
+    <div
+      ref={containerRef}
+      onClick={handleClickFromContainer}
+      style={{ width, height, maxWidth: "100%", cursor: onBucketClick ? "pointer" : undefined }}
+    >
       <ResponsiveContainer width="100%" height="100%">
-        <RAreaChart data={data} margin={chartMargin} onClick={handleClick}>
+        <RAreaChart data={data} margin={chartMargin}>
           {fill && (
             <defs>
               <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
@@ -274,15 +293,51 @@ export function Donut({
   const total = data.reduce((s, d) => s + d.value, 0) || 1;
 
   const clickable = hasData && !!onSegmentClick;
-  const handleSliceClick = clickable
-    ? (_: unknown, index: number) => {
-        const seg = segments[index];
-        if (seg) onSegmentClick!(seg, index);
+  // Recharts v3.6 + React 19 doesn't reliably fire `<Pie onClick>` per cell.
+  // Catch the click on the donut's outer wrapper and resolve it ourselves
+  // by mapping the click position to an angular sweep of the ring.
+  const donutRef = React.useRef<HTMLDivElement | null>(null);
+  const handleDonutClick = clickable
+    ? (e: React.MouseEvent<HTMLDivElement>) => {
+        const node = donutRef.current;
+        if (!node) return;
+        const rect = node.getBoundingClientRect();
+        const cx = rect.left + rect.width / 2;
+        const cy = rect.top + rect.height / 2;
+        const dx = e.clientX - cx;
+        const dy = e.clientY - cy;
+        const radius = Math.hypot(dx, dy);
+        // Clicks inside the inner hole or beyond the outer ring don't
+        // belong to a segment — leave the donut as a pure data widget.
+        if (radius < inner || radius > outer + 6) return;
+        // Donut renders clockwise from 12 o'clock (startAngle=90, endAngle=-270
+        // in Recharts' coord system). Compute the angular fraction of the
+        // click around that same axis: 0 = top, 0.25 = right, 0.5 = bottom,
+        // 0.75 = left.
+        const angleFromTopClockwise = (Math.atan2(dx, -dy) + Math.PI * 2) % (Math.PI * 2);
+        const fraction = angleFromTopClockwise / (Math.PI * 2);
+        // Walk segments accumulating their fractional value until we pass
+        // the click's angular position.
+        let acc = 0;
+        for (let i = 0; i < segments.length; i++) {
+          const seg = segments[i];
+          const segFrac = seg.value / total;
+          if (segFrac <= 0) continue;
+          if (fraction <= acc + segFrac) {
+            onSegmentClick!(seg, i);
+            return;
+          }
+          acc += segFrac;
+        }
       }
     : undefined;
 
   return (
-    <div style={{ position: "relative", width: size, height: size, cursor: clickable ? "pointer" : undefined }}>
+    <div
+      ref={donutRef}
+      onClick={handleDonutClick}
+      style={{ position: "relative", width: size, height: size, cursor: clickable ? "pointer" : undefined }}
+    >
       <PieChart width={size} height={size}>
         <Pie
           data={hasData ? data : [{ name: "empty", value: 1, color: "transparent" }]}
@@ -296,7 +351,6 @@ export function Donut({
           endAngle={-270}
           stroke="none"
           isAnimationActive={false}
-          onClick={handleSliceClick}
         >
           {(hasData ? data : [{ color: "transparent" }]).map((d, i) => (
             <Cell key={i} fill={d.color} />

--- a/client/src/ink/primitives.tsx
+++ b/client/src/ink/primitives.tsx
@@ -174,6 +174,9 @@ export function PageHeader({
   ranges = ["Today", "Week", "Month", "Year", "Custom"],
   active = "Month",
   onRange,
+  customStart,
+  customEnd,
+  onCustomChange,
 }: {
   eyebrow?: React.ReactNode;
   title: React.ReactNode;
@@ -181,18 +184,70 @@ export function PageHeader({
   ranges?: string[] | null;
   active?: string;
   onRange?: (r: string) => void;
+  /** YYYY-MM-DD; only consulted when active === "Custom". */
+  customStart?: string;
+  customEnd?: string;
+  /** Fired whenever either custom date input changes. */
+  onCustomChange?: (start: string, end: string) => void;
 }) {
   const T = useTheme();
+  const showCustomInputs = ranges && ranges.includes("Custom") && active === "Custom" && onCustomChange;
+
   return (
-    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 20, marginBottom: 6 }}>
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 20, marginBottom: 6, flexWrap: "wrap" }}>
       <div>
         {eyebrow && <div style={{ fontSize: 12.5, color: T.muted, fontWeight: 500, fontFamily: T.sans }}>{eyebrow}</div>}
         <div style={{ fontSize: 28, fontWeight: 700, letterSpacing: -1, lineHeight: 1.1, marginTop: 4, color: T.text, fontFamily: T.sans }}>
           {title}
         </div>
       </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
         {rightSlot}
+        {showCustomInputs && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "4px 8px",
+              background: T.panel,
+              borderRadius: 12,
+              border: `1px solid ${T.line}`,
+            }}
+          >
+            <input
+              type="date"
+              value={customStart ?? ""}
+              max={customEnd || undefined}
+              onChange={(e) => onCustomChange!(e.target.value, customEnd ?? "")}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: T.text,
+                fontSize: 12,
+                fontFamily: T.mono,
+                padding: "4px 6px",
+                outline: "none",
+              }}
+            />
+            <span style={{ color: T.dim, fontSize: 12, fontFamily: T.mono }}>→</span>
+            <input
+              type="date"
+              value={customEnd ?? ""}
+              min={customStart || undefined}
+              onChange={(e) => onCustomChange!(customStart ?? "", e.target.value)}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: T.text,
+                fontSize: 12,
+                fontFamily: T.mono,
+                padding: "4px 6px",
+                outline: "none",
+              }}
+            />
+          </div>
+        )}
         {ranges && (
           <div style={{ display: "flex", background: T.panel, borderRadius: 12, padding: 3, border: `1px solid ${T.line}` }}>
             {ranges.map((r) => (

--- a/client/src/lib/dateRange.ts
+++ b/client/src/lib/dateRange.ts
@@ -71,8 +71,14 @@ export function rangeFromKey(key: RangeKey, now: Date, custom?: CustomRange): Da
     }
     case "Custom": {
       if (custom?.start && custom?.end) {
-        const start = startOfDay(new Date(custom.start));
-        const end = endOfDay(new Date(custom.end));
+        // <input type="date"> emits YYYY-MM-DD which `new Date(...)`
+        // parses as UTC midnight. In timezones west of UTC that lands
+        // on the previous calendar day, so a user-picked boundary
+        // would silently exclude the intended last day. Parse the
+        // components manually so the bounds line up with the user's
+        // local calendar regardless of timezone.
+        const start = startOfDay(parseLocalIsoDate(custom.start));
+        const end = endOfDay(parseLocalIsoDate(custom.end));
         return { start, end, label: `${format(start, "MMM d")} – ${format(end, "MMM d, yyyy")}`, key };
       }
       // Fallback while the user hasn't set explicit dates yet.
@@ -81,6 +87,15 @@ export function rangeFromKey(key: RangeKey, now: Date, custom?: CustomRange): Da
       return { start, end, label: "Last 30 days", key };
     }
   }
+}
+
+/** Parses a YYYY-MM-DD string as a local-time date. `new Date(string)`
+ *  treats it as UTC; we want the bounds to follow the user's wall
+ *  clock so date-range filters match what they typed. */
+function parseLocalIsoDate(value: string): Date {
+  const [y, m, d] = value.split("-").map(Number);
+  if (!y || !m || !d) return new Date(NaN);
+  return new Date(y, m - 1, d);
 }
 
 export function isInRange(ts: number, range: DateRange): boolean {

--- a/client/src/lib/dateRange.ts
+++ b/client/src/lib/dateRange.ts
@@ -1,0 +1,111 @@
+// Shared date-range model the page-header range buttons drive. Aggregator
+// hooks (useRangeStats, useRangeCredits, useRangeTopMerchants) consume
+// `DateRange` directly so a button change re-runs the right slice of the
+// transactions list with no per-hook special-casing.
+//
+// "Custom" is a placeholder until the user sets explicit start/end dates
+// via the inline date inputs in PageHeader; before they do, it falls back
+// to the last 30 days so the UI never shows a blank screen.
+
+import {
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+  subDays,
+  format,
+} from "date-fns";
+
+export type RangeKey = "Today" | "Week" | "Month" | "Year" | "Custom";
+
+export const RANGE_OPTIONS: RangeKey[] = ["Today", "Week", "Month", "Year", "Custom"];
+
+export interface DateRange {
+  /** Inclusive start, local time. */
+  start: Date;
+  /** Inclusive end, local time. */
+  end: Date;
+  /** "April 2026", "Apr 1 – 26", etc. — used for chart subtitles + tooltips. */
+  label: string;
+  /** Which named range this came from. "Custom" means the user picked a
+   *  bespoke window via the date inputs. */
+  key: RangeKey;
+}
+
+export interface CustomRange {
+  start: string; // YYYY-MM-DD
+  end: string;
+}
+
+/** Build a DateRange from the active button + optional custom dates.
+ *  `now` is injected so tests / per-page mounts compute against the
+ *  same instant for the lifetime of a render. */
+export function rangeFromKey(key: RangeKey, now: Date, custom?: CustomRange): DateRange {
+  switch (key) {
+    case "Today": {
+      const start = startOfDay(now);
+      const end = endOfDay(now);
+      return { start, end, label: format(start, "MMMM d, yyyy"), key };
+    }
+    case "Week": {
+      // Calendar week starting Monday — matches the convention most
+      // Georgian users expect (Sunday-start would push half the
+      // weekend into the next bucket).
+      const start = startOfWeek(now, { weekStartsOn: 1 });
+      const end = endOfWeek(now, { weekStartsOn: 1 });
+      return { start, end, label: `${format(start, "MMM d")} – ${format(end, "MMM d")}`, key };
+    }
+    case "Month": {
+      const start = startOfMonth(now);
+      const end = endOfMonth(now);
+      return { start, end, label: format(start, "MMMM yyyy"), key };
+    }
+    case "Year": {
+      const start = startOfYear(now);
+      const end = endOfYear(now);
+      return { start, end, label: format(start, "yyyy"), key };
+    }
+    case "Custom": {
+      if (custom?.start && custom?.end) {
+        const start = startOfDay(new Date(custom.start));
+        const end = endOfDay(new Date(custom.end));
+        return { start, end, label: `${format(start, "MMM d")} – ${format(end, "MMM d, yyyy")}`, key };
+      }
+      // Fallback while the user hasn't set explicit dates yet.
+      const start = startOfDay(subDays(now, 29));
+      const end = endOfDay(now);
+      return { start, end, label: "Last 30 days", key };
+    }
+  }
+}
+
+export function isInRange(ts: number, range: DateRange): boolean {
+  return ts >= range.start.getTime() && ts <= range.end.getTime();
+}
+
+/** Returns the equivalent range shifted back by one period — used for
+ *  the "vs. previous period" comparison labels in tooltips and stat
+ *  cards. */
+export function previousRange(range: DateRange): DateRange {
+  const span = range.end.getTime() - range.start.getTime();
+  const prevEnd = new Date(range.start.getTime() - 1);
+  const prevStart = new Date(prevEnd.getTime() - span);
+  // Anchor the comparison label to the same shape as the source.
+  switch (range.key) {
+    case "Today":
+      return { start: startOfDay(prevStart), end: endOfDay(prevStart), label: format(prevStart, "MMM d, yyyy"), key: "Today" };
+    case "Week":
+      return { start: startOfWeek(prevStart, { weekStartsOn: 1 }), end: endOfWeek(prevStart, { weekStartsOn: 1 }), label: `${format(prevStart, "MMM d")} – ${format(prevEnd, "MMM d")}`, key: "Week" };
+    case "Month":
+      return { start: startOfMonth(prevStart), end: endOfMonth(prevStart), label: format(prevStart, "MMMM yyyy"), key: "Month" };
+    case "Year":
+      return { start: startOfYear(prevStart), end: endOfYear(prevStart), label: format(prevStart, "yyyy"), key: "Year" };
+    case "Custom":
+    default:
+      return { start: prevStart, end: prevEnd, label: `${format(prevStart, "MMM d")} – ${format(prevEnd, "MMM d, yyyy")}`, key: "Custom" };
+  }
+}

--- a/client/src/lib/dateRange.ts
+++ b/client/src/lib/dateRange.ts
@@ -70,18 +70,21 @@ export function rangeFromKey(key: RangeKey, now: Date, custom?: CustomRange): Da
       return { start, end, label: format(start, "yyyy"), key };
     }
     case "Custom": {
-      if (custom?.start && custom?.end) {
+      if (isValidIsoDateRange(custom)) {
         // <input type="date"> emits YYYY-MM-DD which `new Date(...)`
         // parses as UTC midnight. In timezones west of UTC that lands
         // on the previous calendar day, so a user-picked boundary
         // would silently exclude the intended last day. Parse the
         // components manually so the bounds line up with the user's
         // local calendar regardless of timezone.
-        const start = startOfDay(parseLocalIsoDate(custom.start));
-        const end = endOfDay(parseLocalIsoDate(custom.end));
+        const start = startOfDay(parseLocalIsoDate(custom!.start));
+        const end = endOfDay(parseLocalIsoDate(custom!.end));
         return { start, end, label: `${format(start, "MMM d")} – ${format(end, "MMM d, yyyy")}`, key };
       }
-      // Fallback while the user hasn't set explicit dates yet.
+      // Fallback while the user hasn't set explicit dates yet, or when
+      // a deep-link / stale bookmark passed malformed values that
+      // would otherwise resolve to NaN bounds (every transaction
+      // filtered out, page looks empty with no error).
       const start = startOfDay(subDays(now, 29));
       const end = endOfDay(now);
       return { start, end, label: "Last 30 days", key };
@@ -96,6 +99,31 @@ function parseLocalIsoDate(value: string): Date {
   const [y, m, d] = value.split("-").map(Number);
   if (!y || !m || !d) return new Date(NaN);
   return new Date(y, m - 1, d);
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** True when both bounds are syntactically valid YYYY-MM-DD, parse to
+ *  real local-time dates, and start ≤ end. Used to gate the Custom
+ *  branch so a malformed deep-link or stale bookmark falls back to
+ *  the "Last 30 days" default instead of silently emptying the page. */
+export function isValidIsoDateRange(custom: CustomRange | undefined | null): boolean {
+  if (!custom?.start || !custom?.end) return false;
+  if (!ISO_DATE_RE.test(custom.start) || !ISO_DATE_RE.test(custom.end)) return false;
+  const start = parseLocalIsoDate(custom.start);
+  const end = parseLocalIsoDate(custom.end);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return false;
+  return start.getTime() <= end.getTime();
+}
+
+/** Returns a {dateFrom, dateTo} pair suitable for passing to a drill-down
+ *  link so the destination Transactions page lands on the same window the
+ *  source page was viewing. Always emits both keys so callers can spread
+ *  the result into a URLSearchParams build directly. */
+export function rangeToDateParams(range: DateRange): { dateFrom: string; dateTo: string } {
+  const fmt = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  return { dateFrom: fmt(range.start), dateTo: fmt(range.end) };
 }
 
 export function isInRange(ts: number, range: DateRange): boolean {

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -8,8 +8,10 @@ import { useConvertedPayments } from "../hooks/useTransactions";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { DEFAULT_CATEGORIES, type InkCategory } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
+import { useRangeState } from "../hooks/useRangeState";
+import { isInRange } from "../lib/dateRange";
 import { formatCompact, monthKey } from "../ink/format";
-import { isWithinInterval, startOfMonth, endOfMonth, format } from "date-fns";
+import { format } from "date-fns";
 
 interface CatAgg {
   cat: string;
@@ -23,19 +25,15 @@ export function Categories() {
   const vp = useViewport();
   const navigate = useNavigate();
   const now = new Date();
-  const monthStart = startOfMonth(now);
-  const monthEnd = endOfMonth(now);
 
   const { payments } = useConvertedPayments();
   const { getCategory, categorize: categorizeId } = useCategorizer();
   const trend = useMonthlyTrend(6);
-  const [range, setRange] = useState("Month");
-
-  const inMonth = (ts: number) => isWithinInterval(new Date(ts), { start: monthStart, end: monthEnd });
+  const { range, props: rangeProps } = useRangeState("Month");
 
   const monthPayments = useMemo(
-    () => payments.filter((p) => inMonth(p.transactionDate)),
-    [payments]
+    () => payments.filter((p) => isInRange(p.transactionDate, range)),
+    [payments, range]
   );
 
   const cats: CatAgg[] = useMemo(() => {
@@ -48,7 +46,7 @@ export function Categories() {
       map[cat.id].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);
-  }, [monthPayments]);
+  }, [monthPayments, getCategory]);
 
   const total = cats.reduce((s, c) => s + c.total, 0);
   const [selected, setSelected] = useState<string | null>(null);
@@ -112,7 +110,7 @@ export function Categories() {
   if (cats.length === 0) {
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap }}>
-        <PageHeader eyebrow={eyebrow} title="Categories" active={range} onRange={setRange} />
+        <PageHeader eyebrow={eyebrow} title="Categories" {...rangeProps} />
         <Card>
           <div style={{ color: T.muted, fontSize: 13, padding: "40px 0", textAlign: "center", fontFamily: T.sans }}>
             No transactions in {format(now, "MMMM")} yet.
@@ -124,7 +122,7 @@ export function Categories() {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
-      <PageHeader eyebrow={eyebrow} title="Categories" active={range} onRange={setRange} />
+      <PageHeader eyebrow={eyebrow} title="Categories" {...rangeProps} />
 
       <div
         style={{

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, CardLabel, CardTitle, LinkBtn, PageHeader } from "../ink/primitives";
@@ -50,6 +50,15 @@ export function Categories() {
 
   const total = cats.reduce((s, c) => s + c.total, 0);
   const [selected, setSelected] = useState<string | null>(null);
+
+  // Drop a stale selection when the active range no longer contains it,
+  // so the right-hand pane never keeps rendering an empty category that
+  // isn't even shown in the left list anymore.
+  useEffect(() => {
+    if (selected && !cats.some((c) => c.cat === selected)) {
+      setSelected(null);
+    }
+  }, [cats, selected]);
 
   const selectedId = selected || cats[0]?.cat;
   const selCat = DEFAULT_CATEGORIES.find((c) => c.id === selectedId);

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -136,7 +136,7 @@ export function Categories() {
         <Card pad="24px 24px" style={{ display: "flex", flexDirection: "column" }}>
           <div style={{ display: "flex", justifyContent: "center", marginBottom: 16 }}>
             <Donut
-              segments={cats.map((c) => ({ value: c.total, color: c.meta.color }))}
+              segments={cats.map((c) => ({ value: c.total, color: c.meta.color, name: c.meta.name }))}
               size={220}
               thickness={30}
               gap={4}

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -10,8 +10,8 @@ import { DEFAULT_CATEGORIES, type InkCategory } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { useRangeState } from "../hooks/useRangeState";
 import { isInRange } from "../lib/dateRange";
-import { formatCompact, monthKey } from "../ink/format";
-import { format } from "date-fns";
+import { formatCompact, formatLocalDay, monthKey } from "../ink/format";
+import { endOfMonth, format } from "date-fns";
 
 interface CatAgg {
   cat: string;
@@ -243,6 +243,18 @@ export function Categories() {
                     showAxes={false}
                     cornerRadius={10}
                     padding={{ top: 8, right: 4, bottom: 22, left: 4 }}
+                    onBucketClick={(_d, i) => {
+                      const key = catTrend.keys[i];
+                      if (!key || !selectedId) return;
+                      const [y, m] = key.split("-").map(Number);
+                      const start = new Date(y, m - 1, 1);
+                      const end = endOfMonth(start);
+                      navigate(
+                        `/transactions?category=${encodeURIComponent(selectedId)}&dateFrom=${formatLocalDay(
+                          start.getTime()
+                        )}&dateTo=${formatLocalDay(end.getTime())}`
+                      );
+                    }}
                   />
                   <div
                     style={{
@@ -281,7 +293,29 @@ export function Categories() {
                 {selMerchants.slice(0, 10).map((m) => {
                   const maxT = selMerchants[0]?.total || 1;
                   return (
-                    <div key={m.merchant} style={{ padding: "10px 0", borderBottom: `1px solid ${T.line}` }}>
+                    <button
+                      key={m.merchant}
+                      onClick={() => {
+                        const params = new URLSearchParams();
+                        if (selectedId) params.set("category", selectedId);
+                        params.set("merchant", m.merchant);
+                        navigate(`/transactions?${params.toString()}`);
+                      }}
+                      style={{
+                        display: "block",
+                        width: "100%",
+                        padding: "10px 0",
+                        borderTop: 0,
+                        borderLeft: 0,
+                        borderRight: 0,
+                        borderBottom: `1px solid ${T.line}`,
+                        background: "transparent",
+                        textAlign: "left",
+                        cursor: "pointer",
+                        color: "inherit",
+                        font: "inherit",
+                      }}
+                    >
                       <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4, gap: 12, alignItems: "baseline" }}>
                         <span
                           style={{
@@ -315,7 +349,7 @@ export function Categories() {
                       <div style={{ fontSize: 10, color: T.dim, fontFamily: T.mono, marginTop: 4 }}>
                         ×{m.count} · avg ₾{Math.round(m.total / Math.max(1, m.count))}
                       </div>
-                    </div>
+                    </button>
                   );
                 })}
               </div>

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -9,7 +9,7 @@ import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { DEFAULT_CATEGORIES, type InkCategory } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { useRangeState } from "../hooks/useRangeState";
-import { isInRange } from "../lib/dateRange";
+import { isInRange, rangeToDateParams } from "../lib/dateRange";
 import { formatCompact, formatLocalDay, monthKey } from "../ink/format";
 import { endOfMonth, format } from "date-fns";
 
@@ -299,6 +299,9 @@ export function Categories() {
                         const params = new URLSearchParams();
                         if (selectedId) params.set("category", selectedId);
                         params.set("merchant", m.merchant);
+                        const { dateFrom, dateTo } = rangeToDateParams(range);
+                        params.set("dateFrom", dateFrom);
+                        params.set("dateTo", dateTo);
                         navigate(`/transactions?${params.toString()}`);
                       }}
                       style={{
@@ -359,10 +362,13 @@ export function Categories() {
               <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 12 }}>
                 <CardTitle>Recent in {selCat?.name}</CardTitle>
                 <LinkBtn
-                  onClick={() =>
-                    selectedId &&
-                    navigate(`/transactions?category=${encodeURIComponent(selectedId)}`)
-                  }
+                  onClick={() => {
+                    if (!selectedId) return;
+                    const { dateFrom, dateTo } = rangeToDateParams(range);
+                    navigate(
+                      `/transactions?category=${encodeURIComponent(selectedId)}&dateFrom=${dateFrom}&dateTo=${dateTo}`
+                    );
+                  }}
                 >
                   All →
                 </LinkBtn>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,42 +1,40 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useTheme, useViewport, type InkTheme } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, LiveDot, LinkBtn, PageHeader } from "../ink/primitives";
 import { AreaChart, Donut } from "../ink/charts";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
-import { useMonthStats, useMonthTopMerchants } from "../hooks/useMonthlyAnalytics";
+import { useRangeStats, useRangeTopMerchants } from "../hooks/useMonthlyAnalytics";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
-import { useCredits, useMonthCredits } from "../hooks/useCredits";
+import { useCredits, useRangeCredits } from "../hooks/useCredits";
+import { useRangeState } from "../hooks/useRangeState";
+import { previousRange } from "../lib/dateRange";
 import { formatCompact } from "../ink/format";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
-import { isWithinInterval, startOfMonth, endOfMonth, subMonths, format } from "date-fns";
+import { isWithinInterval, format } from "date-fns";
 
 export function Dashboard() {
   const T = useTheme();
   const vp = useViewport();
   const now = new Date();
-  const my = { month: now.getMonth(), year: now.getFullYear() };
+  const { range, props: rangeProps } = useRangeState("Month");
+  const prevPeriod = useMemo(() => previousRange(range), [range]);
 
-  const prevDate = subMonths(now, 1);
-  const prevMy = { month: prevDate.getMonth(), year: prevDate.getFullYear() };
-
-  const stats = useMonthStats(my);
-  const topMerchants = useMonthTopMerchants(my, 5);
+  const stats = useRangeStats(range);
+  const topMerchants = useRangeTopMerchants(range, 5);
   const trend = useMonthlyTrend(9);
   const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
   const { credits } = useCredits();
-  const monthCredits = useMonthCredits(my);
-  const prevMonthCredits = useMonthCredits(prevMy);
+  const monthCredits = useRangeCredits(range);
+  const prevMonthCredits = useRangeCredits(prevPeriod);
   const { getCategory } = useCategorizer();
 
-  const [range, setRange] = useState("Month");
-
-  const prevMonthName = format(prevDate, "MMMM");
-  const prevMonthShort = format(prevDate, "MMM");
-  const monthYearLabel = format(now, "MMMM yyyy");
-  const monthShortName = format(now, "MMM").toUpperCase();
+  const prevMonthName = prevPeriod.label;
+  const prevMonthShort = prevPeriod.label.split(" ")[0]; // "Mar 2026" → "Mar", "Mar 1 – 31" → "Mar"
+  const monthYearLabel = range.label;
+  const monthShortName = range.label.split(" ")[0].toUpperCase();
   const income = monthCredits.total;
   const net = income - stats.total;
   const savingsRate = income > 0 ? (net / income) * 100 : 0;
@@ -50,21 +48,21 @@ export function Dashboard() {
     [trend]
   );
 
-  // Category breakdown for this month
+  // Category breakdown for the active range. Uses the same date-fns
+  // isWithinInterval the aggregator hooks use so the donut total
+  // always reconciles with stats.total.
   const byCategory = useMemo(() => {
-    const monthStart = startOfMonth(now);
-    const monthEnd = endOfMonth(now);
     const map: Record<string, { total: number; count: number; meta: typeof DEFAULT_CATEGORIES[number] }> = {};
     for (const p of payments) {
       if (p.gelAmount === null) continue;
-      if (!isWithinInterval(new Date(p.transactionDate), { start: monthStart, end: monthEnd })) continue;
+      if (!isWithinInterval(new Date(p.transactionDate), { start: range.start, end: range.end })) continue;
       const cat = getCategory(p.merchant, p.rawMessage);
       if (!map[cat.id]) map[cat.id] = { total: 0, count: 0, meta: cat };
       map[cat.id].total += p.gelAmount;
       map[cat.id].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);
-  }, [payments, getCategory]);
+  }, [payments, getCategory, range]);
 
   const topCats = byCategory.slice(0, 5);
   const totalCatSum = topCats.reduce((s, c) => s + c.total, 0) || 1;
@@ -133,8 +131,7 @@ export function Dashboard() {
       <PageHeader
         eyebrow={`${greeting}`}
         title={monthTitle}
-        active={range}
-        onRange={setRange}
+        {...rangeProps}
       />
 
       <div

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -309,7 +309,7 @@ export function Dashboard() {
           ) : (
             <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", paddingTop: 4 }}>
               <Donut
-                segments={topCats.map((c) => ({ value: c.total, color: c.meta.color }))}
+                segments={topCats.map((c) => ({ value: c.total, color: c.meta.color, name: c.meta.name }))}
                 size={200}
                 thickness={28}
                 gap={4}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useTheme, useViewport, type InkTheme } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, LiveDot, LinkBtn, PageHeader } from "../ink/primitives";
 import { AreaChart, Donut } from "../ink/charts";
@@ -9,14 +10,15 @@ import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { useCredits, useRangeCredits } from "../hooks/useCredits";
 import { useRangeState } from "../hooks/useRangeState";
 import { previousRange } from "../lib/dateRange";
-import { formatCompact } from "../ink/format";
+import { formatCompact, formatLocalDay } from "../ink/format";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
-import { isWithinInterval, format } from "date-fns";
+import { isWithinInterval, format, endOfMonth } from "date-fns";
 
 export function Dashboard() {
   const T = useTheme();
   const vp = useViewport();
+  const navigate = useNavigate();
   const now = new Date();
   const { range, props: rangeProps } = useRangeState("Month");
   const prevPeriod = useMemo(() => previousRange(range), [range]);
@@ -240,6 +242,16 @@ export function Dashboard() {
                 showAxes={false}
                 cornerRadius={14}
                 padding={{ top: 6, right: 2, bottom: 22, left: 2 }}
+                onBucketClick={(_d, i) => {
+                  const bucket = trend[i];
+                  if (!bucket) return;
+                  const [y, m] = bucket.key.split("-").map(Number);
+                  const start = new Date(y, m - 1, 1);
+                  const end = endOfMonth(start);
+                  navigate(
+                    `/transactions?dateFrom=${formatLocalDay(start.getTime())}&dateTo=${formatLocalDay(end.getTime())}`
+                  );
+                }}
               />
               <div
                 style={{
@@ -317,6 +329,10 @@ export function Dashboard() {
                 centerValue={"₾" + formatCompact(stats.total)}
                 centerColor={T.text}
                 labelFont={T.sans}
+                onSegmentClick={(_seg, i) => {
+                  const cat = topCats[i];
+                  if (cat) navigate(`/transactions?category=${encodeURIComponent(cat.meta.id)}`);
+                }}
               />
               <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: 10, marginTop: 22 }}>
                 {topCats.map((c) => {
@@ -380,13 +396,18 @@ export function Dashboard() {
             {topMerchants.map((m) => {
               const cat = getCategory(m.name);
               return (
-                <div
+                <button
                   key={m.name}
+                  onClick={() => navigate(`/transactions?merchant=${encodeURIComponent(m.name)}`)}
                   style={{
                     padding: "14px 14px",
                     background: T.panelAlt,
                     borderRadius: T.rMd,
                     border: `1px solid ${T.line}`,
+                    textAlign: "left",
+                    cursor: "pointer",
+                    color: "inherit",
+                    font: "inherit",
                   }}
                 >
                   <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
@@ -421,7 +442,7 @@ export function Dashboard() {
                     </div>
                     <div style={{ fontSize: 10, color: T.dim, fontFamily: T.mono }}>×{m.count}</div>
                   </div>
-                </div>
+                </button>
               );
             })}
           </div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -13,7 +13,7 @@ import { previousRange, rangeToDateParams } from "../lib/dateRange";
 import { formatCompact, formatLocalDay } from "../ink/format";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
-import { isWithinInterval, format, endOfMonth } from "date-fns";
+import { isWithinInterval, endOfMonth, differenceInCalendarDays } from "date-fns";
 
 export function Dashboard() {
   const T = useTheme();
@@ -119,10 +119,21 @@ export function Dashboard() {
   }, [payments, failedPayments, credits, getCategory]);
 
   const positive = stats.totalChange > 0;
-  const dayNum = now.getDate();
+  // Day count comes from the active range. For a Month-with-future-days the
+  // range still extends to month-end, but the user has only "lived" up to
+  // today, so cap the count at today when the range straddles `now` —
+  // showing "30 days · 9 transactions" on day 8 of April reads as if every
+  // day was empty when in fact most haven't happened yet.
+  const rangeDays = differenceInCalendarDays(range.end, range.start) + 1;
+  const elapsedInRange = now > range.end
+    ? rangeDays
+    : now < range.start
+    ? 0
+    : differenceInCalendarDays(now, range.start) + 1;
+  const dayNum = Math.max(1, Math.min(rangeDays, elapsedInRange));
   const hour = now.getHours();
   const greeting = hour < 12 ? "Good morning" : hour < 18 ? "Good afternoon" : "Good evening";
-  const monthTitle = format(now, "MMMM, 'at a glance'");
+  const rangeTitle = `${range.label}, at a glance`;
 
   const monthShort = Math.round(stats.total).toLocaleString("en-US");
   const monthDecimals = stats.total.toFixed(2).split(".")[1];
@@ -132,7 +143,7 @@ export function Dashboard() {
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
       <PageHeader
         eyebrow={`${greeting}`}
-        title={monthTitle}
+        title={rangeTitle}
         {...rangeProps}
       />
 
@@ -325,7 +336,7 @@ export function Dashboard() {
                 size={200}
                 thickness={28}
                 gap={4}
-                centerLabel={format(now, "MMM").toUpperCase()}
+                centerLabel={monthShortName}
                 centerValue={"₾" + formatCompact(stats.total)}
                 centerColor={T.text}
                 labelFont={T.sans}
@@ -384,7 +395,7 @@ export function Dashboard() {
       {/* Top merchants */}
       <Card pad="20px 24px">
         <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 12 }}>
-          <CardTitle>Top merchants · {format(now, "MMMM")}</CardTitle>
+          <CardTitle>Top merchants · {range.label}</CardTitle>
           <LinkBtn>Explore →</LinkBtn>
         </div>
         {topMerchants.length === 0 ? (

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -9,7 +9,7 @@ import { useRangeStats, useRangeTopMerchants } from "../hooks/useMonthlyAnalytic
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { useCredits, useRangeCredits } from "../hooks/useCredits";
 import { useRangeState } from "../hooks/useRangeState";
-import { previousRange } from "../lib/dateRange";
+import { previousRange, rangeToDateParams } from "../lib/dateRange";
 import { formatCompact, formatLocalDay } from "../ink/format";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
@@ -331,7 +331,11 @@ export function Dashboard() {
                 labelFont={T.sans}
                 onSegmentClick={(_seg, i) => {
                   const cat = topCats[i];
-                  if (cat) navigate(`/transactions?category=${encodeURIComponent(cat.meta.id)}`);
+                  if (!cat) return;
+                  const { dateFrom, dateTo } = rangeToDateParams(range);
+                  navigate(
+                    `/transactions?category=${encodeURIComponent(cat.meta.id)}&dateFrom=${dateFrom}&dateTo=${dateTo}`
+                  );
                 }}
               />
               <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: 10, marginTop: 22 }}>
@@ -398,7 +402,12 @@ export function Dashboard() {
               return (
                 <button
                   key={m.name}
-                  onClick={() => navigate(`/transactions?merchant=${encodeURIComponent(m.name)}`)}
+                  onClick={() => {
+                    const { dateFrom, dateTo } = rangeToDateParams(range);
+                    navigate(
+                      `/transactions?merchant=${encodeURIComponent(m.name)}&dateFrom=${dateFrom}&dateTo=${dateTo}`
+                    );
+                  }}
                   style={{
                     padding: "14px 14px",
                     background: T.panelAlt,

--- a/client/src/pages/Income.tsx
+++ b/client/src/pages/Income.tsx
@@ -2,19 +2,21 @@ import { useMemo, useState } from "react";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
-import { useConvertedCredits, useMonthCredits } from "../hooks/useCredits";
+import { useConvertedCredits, useRangeCredits } from "../hooks/useCredits";
 import { useBankSenders } from "../hooks/useBankSenders";
+import { useRangeState } from "../hooks/useRangeState";
 import { AreaChart } from "../ink/charts";
 import { currencySymbol, monthKey, monthLabel, formatLocalDay, parseLocalDay } from "../ink/format";
-import { isWithinInterval, startOfMonth, endOfMonth, format, subMonths } from "date-fns";
+import { isInRange } from "../lib/dateRange";
+import { format, subMonths } from "date-fns";
 
 export function Income() {
   const T = useTheme();
   const vp = useViewport();
   const now = new Date();
-  const my = { month: now.getMonth(), year: now.getFullYear() };
+  const { range, props: rangeProps } = useRangeState("Month");
   const { credits } = useConvertedCredits();
-  const monthly = useMonthCredits(my);
+  const monthly = useRangeCredits(range);
   const { senders } = useBankSenders();
 
   const [search, setSearch] = useState("");
@@ -93,13 +95,11 @@ export function Income() {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  const monthStart = startOfMonth(now);
-  const monthEnd = endOfMonth(now);
   const topSources = useMemo(() => {
     const map: Record<string, { name: string; total: number; count: number }> = {};
     for (const c of credits) {
       if (c.gelAmount === null) continue;
-      if (!isWithinInterval(new Date(c.transactionDate), { start: monthStart, end: monthEnd })) continue;
+      if (!isInRange(c.transactionDate, range)) continue;
       const name = c.counterparty || "—";
       if (!map[name]) map[name] = { name, total: 0, count: 0 };
       map[name].total += c.gelAmount;
@@ -108,14 +108,14 @@ export function Income() {
     return Object.values(map)
       .sort((a, b) => b.total - a.total)
       .slice(0, 5);
-  }, [credits, monthStart, monthEnd]);
+  }, [credits, range]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
       <PageHeader
         eyebrow="Money coming in · parsed from SMS"
         title="Income"
-        active="Month"
+        {...rangeProps}
         rightSlot={
           <Pill bg="rgba(75,217,162,0.15)" color={T.green}>
             {credits.length} total

--- a/client/src/pages/Income.tsx
+++ b/client/src/pages/Income.tsx
@@ -63,6 +63,10 @@ export function Income() {
 
   const filtered = useMemo(() => {
     return allTx.filter((t) => {
+      // Apply the active range first so the ledger reconciles with the
+      // hero totals; previously the summary cards switched on range
+      // but the list kept showing all-time credits.
+      if (!isInRange(t.transactionDate, range)) return false;
       if (bank !== "all" && t.bankSenderId !== bank) return false;
       if (search) {
         const q = search.toLowerCase();
@@ -72,7 +76,7 @@ export function Income() {
       }
       return true;
     });
-  }, [allTx, bank, search]);
+  }, [allTx, bank, search, range]);
 
   const groups = useMemo(() => {
     const g: Record<string, InkTx[]> = {};

--- a/client/src/pages/Merchants.tsx
+++ b/client/src/pages/Merchants.tsx
@@ -3,14 +3,13 @@ import { useTheme, useViewport } from "../ink/theme";
 import { Card, PageHeader } from "../ink/primitives";
 import { useConvertedPayments } from "../hooks/useTransactions";
 import { useCategorizer } from "../hooks/useCategorizer";
-import { isWithinInterval, startOfMonth, endOfMonth, format } from "date-fns";
+import { useRangeState } from "../hooks/useRangeState";
+import { isInRange } from "../lib/dateRange";
 
 export function Merchants() {
   const T = useTheme();
   const vp = useViewport();
-  const now = new Date();
-  const monthStart = startOfMonth(now);
-  const monthEnd = endOfMonth(now);
+  const { range, props: rangeProps } = useRangeState("Month");
   const { payments } = useConvertedPayments();
   const { getCategory } = useCategorizer();
   const [search, setSearch] = useState("");
@@ -31,7 +30,7 @@ export function Merchants() {
     const map: Record<string, MerchantAgg> = {};
     for (const p of payments) {
       if (p.gelAmount === null) continue;
-      if (!isWithinInterval(new Date(p.transactionDate), { start: monthStart, end: monthEnd })) continue;
+      if (!isInRange(p.transactionDate, range)) continue;
       const key = p.merchant || "Unknown";
       const raw = p.rawMessage || "";
       if (!map[key]) {
@@ -49,7 +48,7 @@ export function Merchants() {
       map[key].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);
-  }, [payments, monthStart, monthEnd]);
+  }, [payments, range]);
 
   const total = merchants.reduce((s, m) => s + m.total, 0);
   const filtered = merchants.filter(
@@ -61,9 +60,9 @@ export function Merchants() {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
       <PageHeader
-        eyebrow={`Who you paid · ${format(now, "MMMM")}`}
+        eyebrow={`Who you paid · ${range.label}`}
         title="Merchants"
-        active="Month"
+        {...rangeProps}
         rightSlot={<span style={{ fontFamily: T.mono, fontSize: 11, color: T.dim }}>{merchants.length} unique</span>}
       />
 

--- a/client/src/pages/Merchants.tsx
+++ b/client/src/pages/Merchants.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, PageHeader } from "../ink/primitives";
 import { useConvertedPayments } from "../hooks/useTransactions";
@@ -9,6 +10,7 @@ import { isInRange } from "../lib/dateRange";
 export function Merchants() {
   const T = useTheme();
   const vp = useViewport();
+  const navigate = useNavigate();
   const { range, props: rangeProps } = useRangeState("Month");
   const { payments } = useConvertedPayments();
   const { getCategory } = useCategorizer();
@@ -125,14 +127,24 @@ export function Merchants() {
               const cat = getCategory(m.merchant, m.rawMerchant);
               const pct = (m.total / Math.max(1, total)) * 100;
               return (
-                <div
+                <button
                   key={m.merchant}
+                  onClick={() => navigate(`/transactions?merchant=${encodeURIComponent(m.merchant)}`)}
                   style={{
                     display: "grid",
                     gridTemplateColumns: cols,
                     padding: "13px 24px",
+                    borderTop: 0,
+                    borderLeft: 0,
+                    borderRight: 0,
                     borderBottom: `1px solid ${T.line}`,
                     alignItems: "center",
+                    width: "100%",
+                    background: "transparent",
+                    textAlign: "left",
+                    cursor: "pointer",
+                    color: "inherit",
+                    font: "inherit",
                   }}
                 >
                   <div style={{ display: "flex", alignItems: "center", gap: 12, minWidth: 0 }}>
@@ -216,7 +228,7 @@ export function Merchants() {
                   >
                     ₾{Math.round(m.total)}
                   </div>
-                </div>
+                </button>
               );
             })
           )}

--- a/client/src/pages/Merchants.tsx
+++ b/client/src/pages/Merchants.tsx
@@ -5,7 +5,7 @@ import { Card, PageHeader } from "../ink/primitives";
 import { useConvertedPayments } from "../hooks/useTransactions";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { useRangeState } from "../hooks/useRangeState";
-import { isInRange } from "../lib/dateRange";
+import { isInRange, rangeToDateParams } from "../lib/dateRange";
 
 export function Merchants() {
   const T = useTheme();
@@ -129,7 +129,12 @@ export function Merchants() {
               return (
                 <button
                   key={m.merchant}
-                  onClick={() => navigate(`/transactions?merchant=${encodeURIComponent(m.merchant)}`)}
+                  onClick={() => {
+                    const { dateFrom, dateTo } = rangeToDateParams(range);
+                    navigate(
+                      `/transactions?merchant=${encodeURIComponent(m.merchant)}&dateFrom=${dateFrom}&dateTo=${dateTo}`
+                    );
+                  }}
                   style={{
                     display: "grid",
                     gridTemplateColumns: cols,

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -20,20 +20,31 @@ export function Transactions() {
   const { failedPayments } = useFailedPayments();
   const { senders } = useBankSenders();
   const { getCategory, categorize: categorizeId } = useCategorizer();
-  const { range, props: rangeProps } = useRangeState("Month");
-
-  // `?category=<id>` pre-selects the category filter on load. Categories
-  // page navigates here with this param when the user clicks "All →" on
-  // a category's recent-transactions card. Values that don't match a
-  // known category id fall through to the "all" default.
+  // Drill-down search params accepted on first paint. Anything that doesn't
+  // match falls through to the unfiltered default — chart drill-downs can
+  // freely add params without breaking the page if a future link mistypes
+  // a key.
+  //   ?category=<id>          — pre-select category filter
+  //   ?merchant=<text>        — pre-fill the search box (substring match)
+  //   ?dateFrom=YYYY-MM-DD&dateTo=YYYY-MM-DD
+  //                           — switch range to "Custom" with these dates
   const [searchParams] = useSearchParams();
   const initialCat = (() => {
     const raw = searchParams.get("category");
     if (!raw) return "all";
     return DEFAULT_CATEGORIES.some((c) => c.id === raw) ? raw : "all";
   })();
+  const initialMerchant = searchParams.get("merchant") || "";
+  const initialCustom = (() => {
+    const start = searchParams.get("dateFrom") || "";
+    const end = searchParams.get("dateTo") || "";
+    if (!start || !end) return undefined;
+    return { start, end };
+  })();
 
-  const [search, setSearch] = useState("");
+  const { range, props: rangeProps } = useRangeState("Month", { customInitial: initialCustom });
+
+  const [search, setSearch] = useState(initialMerchant);
   const [bank, setBank] = useState("all");
   const [cat, setCat] = useState(initialCat);
   const [kind, setKind] = useState<TxKind>("all");

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, CardLabel, PageHeader } from "../ink/primitives";
@@ -109,7 +109,15 @@ export function Transactions() {
   }, [filtered]);
 
   const dayKeys = Object.keys(groups).sort((a, b) => b.localeCompare(a));
-  const selected = selectedId ? allTx.find((t) => t.id === selectedId) : null;
+  // Resolve the side panel from `filtered`, not `allTx`. If the active
+  // filters no longer contain the selection, drop it so the panel doesn't
+  // contradict the visible list.
+  const selected = selectedId ? filtered.find((t) => t.id === selectedId) : null;
+  useEffect(() => {
+    if (selectedId && !filtered.some((t) => t.id === selectedId)) {
+      setSelectedId(null);
+    }
+  }, [filtered, selectedId]);
 
   const bankOptions = senders.length > 0
     ? senders.map((s) => ({ id: s.senderId, name: s.displayName }))

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -5,6 +5,8 @@ import { Card, CardLabel, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
 import { useBankSenders } from "../hooks/useBankSenders";
+import { useRangeState } from "../hooks/useRangeState";
+import { isInRange } from "../lib/dateRange";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { currencySymbol, formatLocalDay, parseLocalDay } from "../ink/format";
@@ -18,6 +20,7 @@ export function Transactions() {
   const { failedPayments } = useFailedPayments();
   const { senders } = useBankSenders();
   const { getCategory, categorize: categorizeId } = useCategorizer();
+  const { range, props: rangeProps } = useRangeState("Month");
 
   // `?category=<id>` pre-selects the category filter on load. Categories
   // page navigates here with this param when the user clicks "All →" on
@@ -72,6 +75,7 @@ export function Transactions() {
 
   const filtered = useMemo(() => {
     return allTx.filter((t) => {
+      if (!isInRange(t.transactionDate, range)) return false;
       if (bank !== "all" && t.bankSenderId !== bank) return false;
       if (cat !== "all" && t.category !== cat) return false;
       if (kind !== "all" && t.kind !== kind) return false;
@@ -81,7 +85,7 @@ export function Transactions() {
       }
       return true;
     });
-  }, [allTx, bank, cat, kind, search]);
+  }, [allTx, bank, cat, kind, search, range]);
 
   const groups = useMemo(() => {
     const g: Record<string, InkTx[]> = {};
@@ -135,7 +139,7 @@ export function Transactions() {
       <PageHeader
         eyebrow="All transactions · read-only from SMS"
         title="Transactions"
-        active="Month"
+        {...rangeProps}
         rightSlot={
           <span style={{ fontFamily: T.mono, fontSize: 11, color: T.dim }}>
             {filtered.length.toLocaleString("en-US")} results

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -6,7 +6,7 @@ import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
 import { useBankSenders } from "../hooks/useBankSenders";
 import { useRangeState } from "../hooks/useRangeState";
-import { isInRange } from "../lib/dateRange";
+import { isInRange, isValidIsoDateRange } from "../lib/dateRange";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { currencySymbol, formatLocalDay, parseLocalDay } from "../ink/format";
@@ -38,8 +38,8 @@ export function Transactions() {
   const initialCustom = (() => {
     const start = searchParams.get("dateFrom") || "";
     const end = searchParams.get("dateTo") || "";
-    if (!start || !end) return undefined;
-    return { start, end };
+    const candidate = { start, end };
+    return isValidIsoDateRange(candidate) ? candidate : undefined;
   })();
 
   const { range, props: rangeProps } = useRangeState("Month", { customInitial: initialCustom });

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -1,0 +1,79 @@
+# Manual E2E tests
+
+Agent-driven smoke tests exercised in a real Chrome window via the Claude
+chrome-MCP. Not in CI — run from the developer's machine, by an agent during
+PR review and before any merge to `main`.
+
+## When to run
+
+| Scenario | What to run |
+|---|---|
+| Opening a PR for a focused feature/fix | Only the file(s) covering the surfaces the PR touches. e.g. a Dashboard-only change → `dashboard.md`. A range/dateRange change → every page file (range buttons live in every page header). |
+| Pre-merge into `main` | Every file in this directory, top to bottom. The "we broke literally nothing" pass. |
+| After a Codex review surfaces no-ship findings | Re-run the affected file(s) once the fix is pushed. |
+
+The cadence is documented in `CLAUDE.md` §7.5 ("Manual E2E testing") so a
+fresh session picks it up automatically.
+
+## Prereqs
+
+- `service` running on `127.0.0.1:8721` with at least one configured InstantDB
+  app and some real transaction data already synced. The user's installed
+  `Xarji.app` covers this on the dev machine — no need to start a dev service.
+- `client` Vite dev server on `http://localhost:5173/`, started with
+  `cd client && bun run dev`. Vite proxies `/api/*` to the running service.
+- Chrome with the Claude extension connected. A fresh tab per session
+  (don't reuse old tabs from other conversations).
+
+## How an agent runs these
+
+1. Pick the file(s) for the PR's surface.
+2. For each test (each `### T-…` block), follow the **Steps** literally.
+3. Compare against **Expected**. Anything that doesn't match is a regression
+   — file it, fix it, push, re-run that test.
+4. Where a test is marked `[unreliable on real data]`, note it in the PR
+   review and skip — these are blocked on the demo-mode dataset (see
+   `~/.claude/plans/now-i-want-to-distributed-zebra.md`). They become live
+   once `?demo=1` lands.
+
+## When to update this directory
+
+Same PR that adds a UI surface adds a test for it. Same PR that removes a
+surface removes the test. The discipline is the only thing that keeps these
+docs honest — there's no CI pass to fail when they drift, only the next
+manual run.
+
+If you add a new page, create a new file: `docs/e2e/<page>.md`. Index it in
+the table below so the pre-merge full-run is comprehensive.
+
+## Test files
+
+| File | Surface | Last verified |
+|---|---|---|
+| [dashboard.md](dashboard.md) | `client/src/pages/Dashboard.tsx` — hero card, donut, 9-month trend, top-merchant tiles | 2026-04-27 (PR #23) |
+| [transactions.md](transactions.md) | `client/src/pages/Transactions.tsx` — filters, day groups, side panel, URL drill-down ingestion | 2026-04-27 (PR #23) |
+| [categories.md](categories.md) | `client/src/pages/Categories.tsx` — left donut + list, per-cat detail, per-cat trend, merchant rows | 2026-04-27 (PR #23) |
+| [merchants.md](merchants.md) | `client/src/pages/Merchants.tsx` — table, search, drill-down rows | 2026-04-27 (PR #23) |
+| [income.md](income.md) | `client/src/pages/Income.tsx` — hero, income trend, ledger | 2026-04-27 (PR #23) |
+| [ranges.md](ranges.md) | Cross-cutting `useRangeState` + `dateRange.ts` invariants and Codex-fix regressions | 2026-04-27 (PR #23) |
+
+## Test ID convention
+
+Each test has an ID `T-<AREA>-<NN>`:
+
+- `AREA` = uppercase short tag: `DASH`, `TX`, `CAT`, `MERCH`, `INC`, `RANGE`.
+- `NN` = two-digit zero-padded sequence within the file. Numbers don't get
+  reused — if you delete a test, leave a gap (or repurpose the ID with a
+  comment) so old PR references still make sense.
+
+## Reporting a test result
+
+When an agent reports a run, the format is:
+
+```
+T-DASH-01  ✓
+T-DASH-02  ✗  expected donut tooltip "Food ₾340" but saw "Other ₾23,722"
+T-DASH-03  ⊘  skipped — [unreliable on real data]
+```
+
+Pass / fail / skipped, with a one-line reason on fail.

--- a/docs/e2e/categories.md
+++ b/docs/e2e/categories.md
@@ -1,0 +1,117 @@
+# Categories — manual E2E
+
+Surface: `client/src/pages/Categories.tsx`.
+
+Open `http://localhost:5173/categories`. Default range: **Month**.
+
+---
+
+## T-CAT-01 — Page loads with Month-scope summary
+
+**Steps**
+1. Navigate to `/categories`.
+
+**Expected**
+- Eyebrow: "Where your money went · <month>".
+- Title: "Categories".
+- Range buttons visible top-right with **Month** highlighted.
+- Left card: donut + scrollable list of categories ordered by total descending.
+- Right column: detail card for the top category by default + merchant rows + recent-in-category transactions.
+- If the active range has no transactions, page shows the empty-state card "No transactions in <month> yet."
+
+---
+
+## T-CAT-02 — Range buttons re-scope every panel
+
+**Steps**
+1. Click **Today / Week / Year / Custom** in turn.
+
+**Expected**
+- Donut, list, detail card, merchant rows, and recent-in-category transactions all re-scope.
+- Page reloads aggregates without flicker.
+- Per-cat trend (top-right of the detail card, when shown) keeps its 6-month bucket window — that's intentional, the trend is always 6m even when the active range is shorter.
+
+---
+
+## T-CAT-03 — Left list is clickable, drives the detail pane
+
+**Steps**
+1. Click a category in the left list (not the donut).
+2. Click another.
+
+**Expected**
+- Selected row highlights with `panelAlt` background and bold weight.
+- Right detail card updates to show the new category's name, color dot, total, % of month, merchant count, transaction count, and recent rows.
+- Per-cat trend chart (when `T.chartsVisible`) updates to that category's 6-month series.
+
+---
+
+## T-CAT-04 — Codex MEDIUM fix: stale selection clears on range switch
+
+**Steps**
+1. With **Month** active, click a non-default category in the left list (anything other than the first/largest).
+2. Switch to **Today** (or any range where that category has zero transactions).
+3. Observe the right pane.
+4. Switch back to **Month**.
+
+**Expected**
+- After step 2: the previously-selected category is no longer in the left list. Right pane falls back to the **first available** category in the new range — it does NOT keep showing the stale category with empty totals and empty merchant/transaction lists.
+- After step 4: the original month list is back. Right pane shows the first/largest category (default), since the prior selection was cleared.
+
+This pins the Codex MEDIUM fix from PR #23 (`fdfffee`).
+
+---
+
+## T-CAT-05 — Per-cat trend bucket-click drill-down
+
+**Steps**
+1. Select any category that has trend data.
+2. Click any visible bucket on the per-cat AreaChart (right of the detail card).
+
+**Expected**
+- URL changes to `/transactions?category=<id>&dateFrom=YYYY-MM-01&dateTo=YYYY-MM-DD` where dates bound the clicked bucket month.
+- Transactions page lands with category filter pre-selected and Custom range showing that month.
+
+---
+
+## T-CAT-06 — Per-cat trend hover tooltip
+
+**Steps**
+1. Hover the per-cat AreaChart.
+
+**Expected**
+- Tooltip shows bucket label + `₾<value>` + (if prior bucket exists) `vs <prev label> ₾<prev value> ±X%`.
+- Same theme/styling rules as the Dashboard trend tooltip.
+
+---
+
+## T-CAT-07 — Merchant row click drill-down
+
+**Steps**
+1. Click a merchant row in the "Merchants" card (right column, below the detail header).
+
+**Expected**
+- URL changes to `/transactions?category=<id>&merchant=<merchant-name>&dateFrom=<X>&dateTo=<Y>` where dates reflect the source page's active range.
+- Transactions page lands with category + search both pre-filled.
+
+---
+
+## T-CAT-08 — "All →" link on Recent-in-category card
+
+**Steps**
+1. Click "All →" in the "Recent in <category>" card header.
+
+**Expected**
+- URL changes to `/transactions?category=<id>&dateFrom=<X>&dateTo=<Y>` where dates reflect the source page's active range.
+- This pins the Codex HIGH fix's range propagation through the Categories page.
+
+---
+
+## T-CAT-09 — Donut on Categories does NOT navigate
+
+**Steps**
+1. Click directly on the donut on the Categories page (left card).
+
+**Expected**
+- No navigation. URL stays at `/categories`.
+- The donut on this page is intentionally non-clickable — it competes with the in-page selection state on the left list. Test exists to prevent regression if someone wires `onSegmentClick` here in the future.

--- a/docs/e2e/dashboard.md
+++ b/docs/e2e/dashboard.md
@@ -1,0 +1,169 @@
+# Dashboard — manual E2E
+
+Surface: `client/src/pages/Dashboard.tsx` and the hooks it consumes.
+
+Open `http://localhost:5173/`. Default range: **Month**.
+
+---
+
+## T-DASH-01 — Page loads with Month-scope hero
+
+**Steps**
+1. Navigate to `http://localhost:5173/`.
+2. Wait for the dashboard to render.
+
+**Expected**
+- Eyebrow shows `Good morning|afternoon|evening` (depending on local hour).
+- Title shows `<current month name> <year>, at a glance` (e.g. `April 2026, at a glance`).
+- Range buttons visible top-right: **Today / Week / Month / Year / Custom** with **Month** highlighted.
+- Hero card shows "OUTGOING · <month label>" eyebrow and a non-zero "You spent" figure if there are payments this month.
+- Subline reads `<delta vs prev period> · <N> days · <count> transactions` where `<N>` is the count of days from the start of the active range up to today (capped at the range length).
+- Spending mix card renders the donut and a category list.
+- Today & recent card lists transactions newest-first.
+- Top merchants card shows tiles with `<category color> <category name>` / `<merchant>` / `₾<total>` / `×<count>`.
+
+---
+
+## T-DASH-02 — Range buttons re-scope every widget
+
+**Steps**
+1. From Month view, click **Week**.
+2. Click **Year**.
+3. Click **Custom**, then set `From` and `To` date inputs to a known window (e.g. last 30 days).
+4. Click **Today**.
+5. Click **Month** to return.
+
+**Expected (each step)**
+- Eyebrow on the hero card updates: e.g. Week → "OUTGOING · APR 27 – MAY 3", Year → "OUTGOING · 2026", Custom → "OUTGOING · APR <m> – APR <n>", Today → "OUTGOING · April 27, 2026".
+- Page title updates: "Week of …, at a glance" / "2026, at a glance" / "<from – to>, at a glance" / "April 27, 2026, at a glance".
+- "You spent" figure recomputes for the new window (Week may show ₾0 if no spending today).
+- Subline `<N> days` matches the active range length capped at days elapsed (e.g. Week shows up to 7, Today shows 1).
+- Donut center label matches the range (e.g. Year → "2026", Month → "APR", Today → date label).
+- Top merchants title reads "Top merchants · <range.label>".
+- Custom button: when active, two `<input type="date">` controls render inline in the header.
+
+---
+
+## T-DASH-03 — Hero "vs prior period" delta
+
+**Steps**
+1. With **Month** active, observe the pill in the top-right of the hero card.
+2. Switch to **Year** and re-observe.
+
+**Expected**
+- Pill shows `↑ X.X% vs <prev period short label>` (or `↓` if down). Color: accent (coral) for an increase in spending, green for a decrease.
+- Subline `+₾<delta> more|less than <prev period name>` matches the pill's direction.
+- For Year view, "vs 2025" should appear in the pill if there's data for 2025.
+
+---
+
+## T-DASH-04 — AreaChart hover tooltip (9-month trend)
+
+**Steps**
+1. Hover the area chart at the bottom of the hero card.
+2. Move the cursor across multiple month buckets.
+
+**Expected**
+- A tooltip appears anchored to the active bucket, showing:
+  - bucket label (e.g. `NOV`)
+  - current value formatted `₾<value>`
+  - if a prior bucket exists in the series: `vs <prev label> ₾<prev value> ±X%`
+- Delta uses **green** for an increase (current > prior), **accent (coral)** for a decrease.
+- Active dot draws a white-filled circle with a 1.5px stroke at the hovered point.
+- Tooltip background, border, and font follow the active theme (toggle dark/light via the tweaks panel — the tooltip should track).
+
+---
+
+## T-DASH-05 — AreaChart click drill-down
+
+**Steps**
+1. Click the area chart on a visible month (e.g. November).
+
+**Expected**
+- URL changes to `/transactions?dateFrom=YYYY-MM-01&dateTo=YYYY-MM-DD` where the dates bound the clicked month.
+- Transactions page renders with **Custom** range highlighted; the date inputs in the header show the same window.
+- Transactions list contains only entries from that month.
+
+---
+
+## T-DASH-06 — Donut hover tooltip
+
+**Steps**
+1. Hover the spending-mix donut on a colored ring segment.
+
+**Expected**
+- A tooltip appears showing:
+  - color dot
+  - segment name (e.g. `Food`, or `Other` if the categorizer didn't match)
+  - `₾<value>` (rounded)
+  - `<X.X>% of total`
+- Tooltip background follows the active theme.
+- `[unreliable on real data]` — on the developer's installed app, every transaction lands in `Other` because the categorizer doesn't match Georgian merchants. Multi-segment hover can't be exercised until demo mode lands.
+
+---
+
+## T-DASH-07 — Donut click drill-down propagates active range
+
+**Steps**
+1. With **Month** active, click any donut segment.
+2. Navigate back, switch to **Year**, click any donut segment.
+3. Navigate back, switch to **Custom** with a known `dateFrom`/`dateTo`, click any donut segment.
+
+**Expected (each)**
+- URL changes to `/transactions?category=<id>&dateFrom=<X>&dateTo=<Y>` where:
+  - `<id>` is the clicked segment's category id.
+  - `<X>`/`<Y>` reflect the **source page's active range**, NOT a hardcoded month. Year click → `2026-01-01`/`2026-12-31`. Custom click → the picked custom dates.
+- Transactions page lands with **Custom** range highlighted (because it received explicit dates) and category filter pre-selected.
+- Transactions list reflects both filters.
+
+This test pins **Codex HIGH fix** from PR #23 (`c214df0`).
+
+---
+
+## T-DASH-08 — Donut center / hole click is a no-op
+
+**Steps**
+1. Click the empty center hole of the donut (inside the inner radius).
+
+**Expected**
+- No navigation. URL stays at `/`.
+
+The donut is a snapshot widget when there's nothing to drill into; only ring clicks navigate.
+
+---
+
+## T-DASH-09 — Top merchant tile drill-down
+
+**Steps**
+1. Scroll to "Top merchants · <range.label>" card at the bottom.
+2. Click any merchant tile.
+
+**Expected**
+- URL changes to `/transactions?merchant=<merchant-name-encoded>&dateFrom=<X>&dateTo=<Y>` where dates reflect the source page's active range.
+- Transactions page renders with the merchant search box pre-filled and the **Custom** range showing the source window.
+
+---
+
+## T-DASH-10 — Income / Net cashflow side cards
+
+**Steps**
+1. Look at the right column on the hero row.
+2. Switch ranges and re-observe.
+
+**Expected**
+- Income card shows `+₾<total>`, a top-credits list (up to 5), and a `±X% vs <prev period>` pill.
+- Net cashflow card shows `±₾<delta>` and `<X>% saved|overspent` based on income vs spent.
+- Both cards re-scope to whatever range is active.
+
+---
+
+## T-DASH-11 — Loading / empty states
+
+**Steps**
+1. Switch to **Today** when there have been no transactions today.
+2. Switch to **Custom** with `From` and `To` set to the same future date.
+
+**Expected**
+- "You spent ₾0", "0 transactions", subline shows the day count for the range.
+- Spending mix card shows "No spending data yet."
+- Today & recent shows whatever existing recent activity (this card isn't range-scoped).

--- a/docs/e2e/income.md
+++ b/docs/e2e/income.md
@@ -1,0 +1,81 @@
+# Income — manual E2E
+
+Surface: `client/src/pages/Income.tsx`.
+
+Open `http://localhost:5173/income`. Default range: **Month**.
+
+---
+
+## T-INC-01 — Page loads with Month-scope hero
+
+**Steps**
+1. Navigate to `/income`.
+
+**Expected**
+- Eyebrow: "Money in · <range.label>".
+- Title: "Income".
+- Range buttons visible top-right with **Month** highlighted.
+- Hero card shows `+₾<total>` for incoming GEL credits in the active range, plus a `<count> incoming transactions · <month>` subline.
+- 9-month income trend AreaChart below the hero (when `T.chartsVisible` and at least one month had income).
+
+---
+
+## T-INC-02 — Range buttons re-scope hero + ledger
+
+**Steps**
+1. Click **Today / Week / Year / Custom**.
+
+**Expected**
+- Hero `+₾<total>` and incoming-transaction count update.
+- Eyebrow updates with `range.label`.
+- Ledger below filters to credits within the active range.
+- The 9-month trend chart at the top is intentionally always 9 months — it does NOT re-scope with the range buttons. (If we change that behaviour, update this test.)
+
+---
+
+## T-INC-03 — Codex HIGH fix: ledger respects active range
+
+**Steps**
+1. Click **Year** in the header.
+2. Scroll to the credits ledger.
+
+**Expected**
+- The ledger contains credits across the entire year, not just the current month.
+- Earlier behaviour (pre-PR #23) showed credits ledger frozen on the current month even when the hero re-scoped. That's the regression this test guards against.
+
+This pins the Codex HIGH fix from PR #16 (`0e8803a`).
+
+---
+
+## T-INC-04 — Bank filter + search compose with range
+
+**Steps**
+1. Pick a single bank from the dropdown.
+2. Type a known counterparty fragment in the search box.
+
+**Expected**
+- Ledger filters by bank AND search AND active range simultaneously.
+- "<N> incoming transactions" subline reflects the filtered count.
+
+---
+
+## T-INC-05 — Side panel on row click
+
+**Steps**
+1. Click any credit row.
+
+**Expected**
+- Right-side detail panel slides in.
+- Shows: counterparty, amount + currency, when, bank, raw SMS.
+- `×` closes the panel.
+
+---
+
+## T-INC-06 — Income trend hover tooltip
+
+**Steps**
+1. Hover the income trend AreaChart.
+
+**Expected**
+- Tooltip shows bucket label + `₾<value>` + (if prior bucket exists) `vs <prev label> ₾<prev value> ±X%`.
+- Same theme rules as Dashboard trend tooltip.

--- a/docs/e2e/merchants.md
+++ b/docs/e2e/merchants.md
@@ -1,0 +1,98 @@
+# Merchants — manual E2E
+
+Surface: `client/src/pages/Merchants.tsx`.
+
+Open `http://localhost:5173/merchants`. Default range: **Month**.
+
+---
+
+## T-MERCH-01 — Page loads with Month-scope merchant table
+
+**Steps**
+1. Navigate to `/merchants`.
+
+**Expected**
+- Eyebrow: "Who you paid · <range.label>".
+- Title: "Merchants".
+- Range buttons visible top-right with **Month** highlighted.
+- Top-right: "<N> unique" pill.
+- Search box visible.
+- Table header row showing the active columns. On wide viewports: `Merchant / Category / Tx / Avg / Share / Total`. On narrow: `Merchant / Tx / Total` only.
+- Rows ordered by Total descending.
+
+---
+
+## T-MERCH-02 — Range buttons re-scope the table
+
+**Steps**
+1. Click **Today / Week / Year / Custom**.
+
+**Expected**
+- "<N> unique" pill updates.
+- Eyebrow updates with the new `range.label`.
+- Rows recompute totals/counts/averages for the new window.
+- If the new range has no data, "No merchants match." renders inside the scrollable area.
+
+---
+
+## T-MERCH-03 — Search filters by name OR raw SMS
+
+**Steps**
+1. Type a known merchant fragment into the search box.
+2. Type a fragment that only appears in raw SMS (not the cleaned merchant name) — e.g. a POS descriptor.
+
+**Expected**
+- Rows filter as you type.
+- Both cleaned merchant name and the union of all raw SMS strings for that merchant are matched (`searchBlob` lowercased substring).
+- Clear the search → all rows back.
+
+---
+
+## T-MERCH-04 — Table row click drill-down propagates active range
+
+**Steps**
+1. With **Month** active, click any merchant row.
+2. Navigate back, switch to **Year**, click any row.
+3. Navigate back, switch to **Custom** with explicit dates, click any row.
+
+**Expected (each)**
+- URL changes to `/transactions?merchant=<merchant-name>&dateFrom=<X>&dateTo=<Y>`.
+- Dates reflect the **source page's active range**, not a hardcoded month. Year click → `2026-01-01`/`2026-12-31`. Custom click → the picked dates.
+- Transactions page lands with search box pre-filled and **Custom** range highlighted.
+
+This pins the Codex HIGH fix from PR #23 (`c214df0`).
+
+---
+
+## T-MERCH-05 — Row hover affordance
+
+**Steps**
+1. Hover any row.
+
+**Expected**
+- Cursor flips to pointer.
+- Row remains visually distinguishable (row hover styling is currently minimal but should still feel clickable). Not a strict assertion — just confirm the row doesn't feel inert.
+
+---
+
+## T-MERCH-06 — Avg + share columns
+
+**Steps**
+1. Pick a row and verify the math.
+
+**Expected**
+- `Tx` = total transaction count for that merchant in the active range.
+- `Avg` = `Total / Tx` rounded.
+- `Share` = `Total / sum(all merchants in range) * 100`, rendered as a small bar + percentage.
+- `Total` = `₾<rounded>` GEL equivalent.
+
+---
+
+## T-MERCH-07 — Narrow viewport hides Category/Avg/Share
+
+**Steps**
+1. Resize browser window narrow (or use DevTools device toolbar to a phone width).
+
+**Expected**
+- Table collapses to `Merchant / Tx / Total` columns.
+- Search and range buttons remain accessible (range buttons may stack into a different layout via the PageHeader).

--- a/docs/e2e/ranges.md
+++ b/docs/e2e/ranges.md
@@ -1,0 +1,115 @@
+# Ranges & date plumbing — manual E2E
+
+Cross-cutting tests for `useRangeState`, `dateRange.ts`, and the URL-param
+contract every page reads. These exercise invariants that aren't owned by
+any one page — they live across the whole app.
+
+Run this file in addition to the page-specific files when changing
+`client/src/lib/dateRange.ts` or `client/src/hooks/useRangeState.ts`.
+
+---
+
+## T-RANGE-01 — Range button consistency across pages
+
+**Steps**
+1. Open `/`. Switch to **Year**.
+2. Navigate to `/transactions` via the sidebar.
+3. Navigate to `/categories`.
+4. Navigate to `/merchants`.
+5. Navigate back to `/`.
+
+**Expected**
+- Each page mounts with **Month** by default. Range state is per-page, not global. Switching to Year on `/` does NOT carry to `/transactions` automatically.
+- This is intentional — every page owns its own `useRangeState` instance.
+
+---
+
+## T-RANGE-02 — Custom range survives midnight rollover
+
+(Hard to reproduce on demand without time-travel; tested via `useMidnightTick`
+unit logic. Document for awareness — when running over midnight, the "Today"
+preset should refresh without a manual reload.)
+
+**Expected**
+- A long-lived dashboard tab left open across local midnight should re-render
+  the "Today" range to the new calendar day on the next state tick.
+
+---
+
+## T-RANGE-03 — `<input type="date">` parses as local-time
+
+**Steps**
+1. On any page, switch to **Custom**.
+2. Set `From` and `To` to the same date — e.g. today.
+3. Observe the resulting filter.
+
+**Expected**
+- The day's transactions all appear in the filtered list.
+- This guards against `new Date("YYYY-MM-DD")` parsing the date as UTC and
+  silently shifting boundaries by one day west of UTC. On macOS in Tbilisi
+  (+04:00) the bug wouldn't surface; on a North American developer machine
+  it would. Test still runs because `parseLocalIsoDate` is the actual
+  shared code path.
+
+---
+
+## T-RANGE-04 — Codex MEDIUM fix: malformed dates fall back to default
+
+**Steps**
+1. Navigate to `/transactions?dateFrom=garbage&dateTo=lol`.
+2. Then `/transactions?dateFrom=2026-99-99&dateTo=2026-04-30`.
+3. Then `/transactions?dateFrom=2026-04-30&dateTo=2026-04-01` (start > end).
+4. Then `/transactions?dateFrom=&dateTo=` (empty).
+
+**Expected (each)**
+- Page renders Month by default, NOT empty.
+- No console errors.
+- Custom date inputs not visible.
+
+This pins `isValidIsoDateRange` in `client/src/lib/dateRange.ts`.
+
+---
+
+## T-RANGE-05 — Codex HIGH fix: drill-downs preserve source range
+
+**Steps**
+1. Open `/`, switch to **Year**, click any donut segment.
+2. Open `/`, switch to **Year**, click any top-merchant tile.
+3. Open `/categories`, switch to **Year**, click any merchant row.
+4. Open `/merchants`, switch to **Year**, click any table row.
+
+**Expected (each)**
+- Destination URL includes `dateFrom=2026-01-01&dateTo=2026-12-31` (or whatever year is current). NOT the current month's bounds.
+- Repeat with **Custom** active and explicit dates → destination URL carries those exact dates.
+
+This pins `rangeToDateParams` and the threading through every drill-down call site.
+
+---
+
+## T-RANGE-06 — Bucket clicks override source range
+
+**Steps**
+1. Open `/`, switch to **Year**.
+2. Click any November bucket on the 9-month trend chart.
+
+**Expected**
+- URL → `/transactions?dateFrom=2025-11-01&dateTo=2025-11-30`.
+- The clicked bucket's specific month wins over the source page's Year range. (A more specific signal beats a broader one.)
+- Repeat from `/categories` per-cat trend: same behaviour.
+
+---
+
+## T-RANGE-07 — `previousRange()` produces same-shape windows
+
+(Visual verification via the Dashboard hero.)
+
+**Steps**
+1. Switch to **Today** → look at the "vs <prev>" pill.
+2. Switch to **Week** → same.
+3. Switch to **Month** → same.
+4. Switch to **Year** → same.
+
+**Expected**
+- Each pill compares against the equivalent prior period (yesterday, last
+  week, last month, last year). The label format on the pill matches the
+  source range shape.

--- a/docs/e2e/transactions.md
+++ b/docs/e2e/transactions.md
@@ -1,0 +1,164 @@
+# Transactions — manual E2E
+
+Surface: `client/src/pages/Transactions.tsx`.
+
+Open `http://localhost:5173/transactions` (or click "Transactions" in the
+sidebar). Default range: **Month**.
+
+---
+
+## T-TX-01 — Page loads with Month-scope ledger
+
+**Steps**
+1. Navigate to `/transactions`.
+
+**Expected**
+- Eyebrow: "All transactions · read-only from SMS".
+- Title: "Transactions".
+- Range buttons visible top-right with **Month** highlighted.
+- "<N> results" pill in the top-right reflects the visible filtered count.
+- Filter row: search box, kind pills (All / Successful / Declined), bank dropdown, category dropdown.
+- Day-grouped list newest-first, each day group has its date label + transaction count + GEL day-total.
+
+---
+
+## T-TX-02 — Range buttons re-scope the ledger
+
+**Steps**
+1. From Month, click **Today / Week / Year / Custom** in turn.
+2. With Custom, set `From`/`To` and verify the list updates.
+
+**Expected**
+- "<N> results" updates to reflect the active range.
+- Day groups visible all fall within the active range.
+- Custom date inputs in the header show the picked window.
+
+---
+
+## T-TX-03 — URL drill-down ingestion (`?category`)
+
+**Steps**
+1. Navigate to `/transactions?category=other` (or any known category id from `client/src/lib/utils.ts` `DEFAULT_CATEGORIES`).
+
+**Expected**
+- Category dropdown pre-selected to that id.
+- "<N> results" reflects the category filter applied within the default Month range.
+- Day groups contain only transactions whose categorization matches.
+
+---
+
+## T-TX-04 — URL drill-down ingestion (`?merchant`)
+
+**Steps**
+1. Navigate to `/transactions?merchant=Loan%20repayment` (URL-encode any merchant string from your data; "Loan repayment" works on the dev's installed app).
+
+**Expected**
+- Search box pre-filled with `Loan repayment`.
+- List filtered to rows whose merchant or rawMessage substring-matches.
+
+---
+
+## T-TX-05 — URL drill-down ingestion (`?dateFrom` + `?dateTo`)
+
+**Steps**
+1. Navigate to `/transactions?dateFrom=2026-04-01&dateTo=2026-04-30`.
+2. Then `/transactions?dateFrom=2025-11-01&dateTo=2025-11-30`.
+
+**Expected**
+- Range button shows **Custom** highlighted.
+- Custom date inputs in the header show the matching `From` / `To`.
+- "<N> results" reflects the date window.
+- Day groups all within the requested range.
+
+---
+
+## T-TX-06 — Codex MEDIUM fix: malformed dates fall back to default
+
+**Steps**
+1. Navigate to `/transactions?dateFrom=garbage&dateTo=lol`.
+2. Then `/transactions?dateFrom=2026-99-99&dateTo=2026-04-30`.
+3. Then `/transactions?dateFrom=2026-04-30&dateTo=2026-04-01` (start > end).
+
+**Expected (each)**
+- Range button shows **Month** highlighted (NOT Custom).
+- Custom date inputs hidden (because we're not in Custom mode).
+- Page renders the current month's transactions, not an empty state.
+- No console errors.
+
+This pins the Codex MEDIUM fix from PR #23 (`c214df0`).
+
+---
+
+## T-TX-07 — Combined drill-down: category + merchant + range
+
+**Steps**
+1. Navigate to `/transactions?category=other&merchant=Loan+repayment&dateFrom=2026-04-01&dateTo=2026-04-30`.
+
+**Expected**
+- All three filters apply: category dropdown set, search box filled, range = Custom with the right dates.
+- "<N> results" reflects all filters AND'd together.
+
+---
+
+## T-TX-08 — Side panel responds to row click
+
+**Steps**
+1. Click any transaction row.
+
+**Expected**
+- Right-side detail panel slides in (340px wide on non-narrow viewports).
+- Panel shows: kind label, merchant name (or "—"), raw merchant string, amount with currency, "When / Card / Bank / Category" rows, "Points" or "Reason" depending on kind, and the raw SMS text.
+- Click the `×` in the panel header → panel closes.
+
+---
+
+## T-TX-09 — Codex MEDIUM fix: side panel respects active filters
+
+**Steps**
+1. Click a transaction row to open the side panel.
+2. Switch the range to **Today** (or change category dropdown to one that excludes the selected row).
+3. Re-observe.
+
+**Expected**
+- The selected row is no longer in the list.
+- The side panel **clears** automatically — it does not keep showing a row that's been filtered out.
+
+This pins the Codex MEDIUM fix from PR #23 (`fdfffee`).
+
+---
+
+## T-TX-10 — Bank + kind + category filters compose
+
+**Steps**
+1. Pick a single bank from the dropdown.
+2. Pick the **Declined** kind pill.
+3. Pick a category.
+
+**Expected**
+- "<N> results" updates after each pick.
+- Only rows matching all three filters show.
+- Search input also composes (substring match on merchant or rawMessage).
+
+---
+
+## T-TX-11 — Search composes with range
+
+**Steps**
+1. With Month active, type a known merchant fragment (e.g. `apple`) into the search input.
+2. Switch to **Year** and re-observe.
+
+**Expected**
+- Day groups filtered to matches.
+- Search persists across range changes.
+- "<N> results" updates.
+
+---
+
+## T-TX-12 — Day-group totals only sum successful payments
+
+**Steps**
+1. Find a day group with both successful and declined transactions.
+
+**Expected**
+- Day total in the right of the day-group header sums only the `kind === "payment"` rows that have a `gelAmount` resolved.
+- If a day has only declines, the right side shows `—`, not `−₾0`.


### PR DESCRIPTION
End-to-end overhaul of the dashboard's two long-broken pieces: the **Today / Week / Month / Year / Custom** range buttons (which previously rendered but didn't filter anything) and the **charts** (which were custom SVG with no hover, no clicks, no signal). Built as a four-PR stack against this feature branch — every sub-PR was reviewed and merged individually; this is the holistic review.

## What changed, by sub-PR

### #16 — Range buttons functional
- New `client/src/lib/dateRange.ts` is the single source of truth for `DateRange = {start, end, label, key}`. `rangeFromKey(key, now, custom?)` turns the active button into the same range every aggregator uses; `previousRange(range)` returns the same-shape window shifted back one period for vs-prior comparisons.
- `useRangeState()` packs the active range plus the props PageHeader needs into one spreadable bundle. PageHeader gained custom-date inputs that render inline only when `active === "Custom"`.
- Aggregator hooks (`useRangeStats`, `useRangeCredits`, `useRangeTopMerchants`, `useRangeCategoryAnalytics`, `useRangeSpendingByDay`) all consume `DateRange` directly; the spending-by-day variant auto-buckets monthly when the window exceeds 93 days so a Year view stays readable.
- Backwards-compat shims (`useMonthStats`, etc.) retained for the migration.
- `useMidnightTick()` schedules a single timeout to local midnight so a long-lived dashboard tab doesn't keep showing yesterday's "Today".
- `parseLocalIsoDate()` parses `YYYY-MM-DD` from `<input type=\"date\">` as a local-time date — `new Date(\"YYYY-MM-DD\")` parses as UTC and lands on the prior calendar day in timezones west of UTC.

### #17 — Recharts swap
- `AreaChart`, `Donut`, and `Sparkline` rewired through Recharts behind identical call-site signatures so Dashboard, Categories, and Income don't change. `HBar` left as a div progress bar — not a chart, so dragging Recharts in for it would be ceremony. Recharts was already in `package.json`; no install.

### #18 — Hover tooltips
- AreaChart tooltip: bucket label + current value + (when a prior bucket exists) prior value plus delta% — green for an increase, accent for a decrease, matching the rest of the dashboard's positive/negative colour vocabulary.
- Donut tooltip: segment name + value + share of total. `DonutSegment` gained an optional `name` field; Dashboard and Categories pass `name: c.meta.name` so tooltips read \"Food\" / \"Transport\" instead of \"Segment 1\".
- Both tooltip components consume `useTheme()` so panel/border/font/shadow tokens stay live with the active mode + accent.
- Sparkline left tooltip-less — at 24 px tall, a hover popover would dwarf the chart.

### #19 — Click drill-downs
- `Donut` and `AreaChart` accept `onSegmentClick` / `onBucketClick`. Cursor flips to `pointer` when a handler is wired.
- Drill-down link contract Transactions reads on first paint:
  - `?category=<id>` — pre-selects category filter
  - `?merchant=<text>` — substring match, fills the search box
  - `?dateFrom=YYYY-MM-DD&dateTo=YYYY-MM-DD` — flips the range to **Custom** via a new `customInitial` option on `useRangeState`, so the header shows the exact window the user clicked
- Wired surfaces: Dashboard donut + 9-month trend + top-merchant tiles, Categories per-cat trend + merchant rows, Merchants table rows.
- Categories' main donut left non-clickable on purpose — it already drives in-page selection via `setSelected`; a navigate handler would compete.

## Diffstat against main

```
 client/src/hooks/useCredits.ts          |  34 ++-
 client/src/hooks/useMonthlyAnalytics.ts | 156 ++++++-----
 client/src/hooks/useRangeState.ts       |  99 +++++++
 client/src/ink/charts.tsx               | 478 +++++++++++++++++++++++++-------
 client/src/ink/primitives.tsx           |  59 +++-
 client/src/lib/dateRange.ts             | 126 +++++++++
 client/src/pages/Categories.tsx         |  62 ++++-
 client/src/pages/Dashboard.tsx          |  76 +++--
 client/src/pages/Income.tsx             |  24 +-
 client/src/pages/Merchants.tsx          |  31 ++-
 client/src/pages/Transactions.tsx       |  31 ++-
 11 files changed, 920 insertions(+), 256 deletions(-)
```

## Bundle

`client/dist` is **320 KB gzipped** (was ~210 KB pre-Recharts on main). The +110 KB is Recharts itself; we accepted that hit up front because it unlocks tooltips and click drill-downs without rebuilding charting from scratch each time, and the foundation is reused by future chart work (Sankey, Reports — both still deferred).

## Out of scope

- **Sankey + Reports page** — separate future PR, deliberately deferred from this stack.
- **Prior-period overlay on AreaChart** (drawing last month's daily line behind this month's). Per-bucket-vs-previous-bucket comparison already lives in the AreaChart tooltip from data-derivable `i` vs `i-1`, which covers the most useful read; a full overlay would need wider hook plumbing and was scoped out of #18.

## Verification

- `cd client && bun run build` — clean
- All four sub-PR CI runs green (service tests, client build, menu-bar swift build, CodeRabbit)
- Codex review on #16 returned three findings; all fixed in commit `0e8803a` of that sub-PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flexible date-range selection (Today/Week/Month/Year/Custom) across dashboard, pages and transactions; header date inputs initialize from URL and validate.
  * Interactive charts and controls: clickable trend buckets and donut segments, improved tooltips, clickable merchant tiles for drill-down.
  * Automatic daily rollover so Today/Month ranges refresh at local midnight.

* **Refactor**
  * Unified range-based analytics/state model with backwards-compatible month shims.

* **Documentation**
  * New manual E2E test guides and checklists for pages and range behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->