### PR TITLE
Fix Overview scroll regression + assistant message-history bug

### DIFF
--- a/client/src/components/AssistantChat.tsx
+++ b/client/src/components/AssistantChat.tsx
@@ -764,7 +764,7 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
             <span>
               ↵ send · ⇧↵ newline · <span style={{ color: T.muted }}>⌘K</span> spotlight
             </span>
-            <span>connected to {provider.name} · keys never leave this Mac</span>
+            <span>connected to {provider.name}</span>
           </div>
         </div>
       </section>

--- a/client/src/components/AssistantChat.tsx
+++ b/client/src/components/AssistantChat.tsx
@@ -151,7 +151,15 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
    * text content (the user-visible answer). User turns become the raw
    * text of the prompt they typed. The new turn the user just sent is
    * already in `thread.messages` by the time this runs.
+   *
+   * History is capped at the last `MAX_HISTORY_TURNS` core messages.
+   * Cheap insurance against unbounded growth — without a cap, a
+   * long-lived thread eventually exceeds the provider's context window
+   * and every follow-up returns 400. Token-aware budgeting would be
+   * the principled fix; this is the 80% solution that buys time for
+   * a real fix without shipping a known unbounded path.
    */
+  const MAX_HISTORY_TURNS = 30;
   const buildCoreHistory = (thread: AIThread): AICoreMessage[] => {
     const out: AICoreMessage[] = [];
     for (const m of thread.messages) {
@@ -166,6 +174,13 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
       } else {
         out.push({ role: "assistant", content: [{ type: "text", text }] });
       }
+    }
+    // Drop oldest turns when over the cap. Keep the most recent — they
+    // carry the active conversational state, while older ones are
+    // increasingly stale and unlikely to be referenced by the user's
+    // current question.
+    if (out.length > MAX_HISTORY_TURNS) {
+      return out.slice(out.length - MAX_HISTORY_TURNS);
     }
     return out;
   };

--- a/client/src/components/AssistantChat.tsx
+++ b/client/src/components/AssistantChat.tsx
@@ -23,6 +23,7 @@ import {
 } from "../lib/aiThreads";
 import { useAgentRunner } from "../hooks/useAgentRunner";
 import type { AssistantEvent } from "../lib/ai/orchestrator";
+import type { AICoreMessage } from "../lib/ai/types";
 
 interface Suggestion {
   icon: string;
@@ -142,7 +143,34 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
     runAgentForActive(trimmed);
   };
 
-  const runAgentForActive = (text: string) => {
+  /**
+   * Convert the thread's stored messages into the core provider shape
+   * the orchestrator wants. Past assistant turns may include tool-use
+   * + tool-result blocks that don't round-trip cleanly without their
+   * matched pairs, so we collapse each assistant turn down to its plain
+   * text content (the user-visible answer). User turns become the raw
+   * text of the prompt they typed. The new turn the user just sent is
+   * already in `thread.messages` by the time this runs.
+   */
+  const buildCoreHistory = (thread: AIThread): AICoreMessage[] => {
+    const out: AICoreMessage[] = [];
+    for (const m of thread.messages) {
+      const text = m.blocks
+        .filter((b): b is { kind: "text"; text: string } => b.kind === "text")
+        .map((b) => b.text)
+        .join("\n")
+        .trim();
+      if (!text) continue;
+      if (m.role === "user") {
+        out.push({ role: "user", content: text });
+      } else {
+        out.push({ role: "assistant", content: [{ type: "text", text }] });
+      }
+    }
+    return out;
+  };
+
+  const runAgentForActive = (_text: string) => {
     // Capture the originating thread id at send time so streamed
     // events route to that conversation even if the user switches
     // threads mid-response. Without this, every event handler called
@@ -200,7 +228,12 @@ export function AssistantChat({ config, onClear }: { config: AIConfig; onClear: 
     };
 
     const finalConfig = { ...config, model };
-    runAgent(finalConfig, text, handle)
+    // Pull the freshest thread state from storage so the user's latest
+    // turn (just appended in `send()` above) is included in the history
+    // sent to the provider.
+    const originThread = loadThreads().find((t) => t.id === originThreadId);
+    const history = originThread ? buildCoreHistory(originThread) : [];
+    runAgent(finalConfig, history, handle)
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         handle({

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -103,8 +103,7 @@ function ConfiguredShell() {
       <div
         style={{
           display: "flex",
-          height: "100vh",
-          overflow: "hidden",
+          minHeight: "100vh",
         }}
       >
         <Sidebar
@@ -119,7 +118,6 @@ function ConfiguredShell() {
             minWidth: 0,
             display: "flex",
             flexDirection: "column",
-            overflow: "auto",
           }}
         >
           <Outlet />

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -12,6 +12,7 @@ import { getProviderClient } from "../lib/ai/provider";
 import { runAgent, type AssistantEvent } from "../lib/ai/orchestrator";
 import { READONLY_TOOLS } from "../lib/ai/tools/readonly";
 import type { AITool } from "../lib/ai/tools/types";
+import type { AICoreMessage } from "../lib/ai/types";
 import type { AIConfig } from "../lib/aiConfig";
 
 // Tool registries the agent has access to. Adding a tool to one of
@@ -119,7 +120,7 @@ export function useAgentRunner() {
   return useCallback(
     async (
       config: AIConfig,
-      userPrompt: string,
+      messages: AICoreMessage[],
       emit: (event: AssistantEvent) => void,
       signal?: AbortSignal
     ): Promise<void> => {
@@ -128,7 +129,7 @@ export function useAgentRunner() {
         provider,
         model: config.model,
         systemPrompt: buildSystemPrompt(ALL_TOOLS),
-        userPrompt,
+        messages,
         tools: ALL_TOOLS,
         toolContext: {
           payments,

--- a/client/src/lib/ai/orchestrator.ts
+++ b/client/src/lib/ai/orchestrator.ts
@@ -30,7 +30,13 @@ export interface RunAgentOpts {
   provider: AIProviderClient;
   model: string;
   systemPrompt: string;
-  userPrompt: string;
+  /** Full conversation history rendered as core provider messages.
+   *  The new user turn must be the last entry. The orchestrator does
+   *  not append anything before the first provider call — callers are
+   *  responsible for getting the shape right. Earlier passes only
+   *  forwarded the latest user turn, which silently broke multi-turn
+   *  follow-ups (the model couldn't see what was just discussed). */
+  messages: AICoreMessage[];
   tools: AITool[];
   toolContext: AIToolContext;
   emit: (event: AssistantEvent) => void;
@@ -38,9 +44,9 @@ export interface RunAgentOpts {
 }
 
 export async function runAgent(opts: RunAgentOpts): Promise<void> {
-  const messages: AICoreMessage[] = [
-    { role: "user", content: opts.userPrompt },
-  ];
+  // Copy so the agent loop's append-on-each-iteration doesn't mutate
+  // the caller's history array.
+  const messages: AICoreMessage[] = [...opts.messages];
   const toolDefs = opts.tools.map((t) => t.definition);
   const toolByName = new Map(opts.tools.map((t) => [t.definition.name, t]));
 

--- a/client/src/pages/Assistant.tsx
+++ b/client/src/pages/Assistant.tsx
@@ -63,16 +63,35 @@ export function Assistant() {
     );
   }
 
+  // The chat is the only page in the app whose content fits a viewport
+  // exactly: the message scroller needs its own bounded height so it
+  // overflows internally instead of pushing the input row off-screen.
+  // Wrap it here (scoped to /assistant) so the global Layout shell
+  // stays simple — every other page scrolls the document the way it
+  // always did.
   return (
-    <AssistantChat
-      config={effectiveConfig}
-      onClear={() => {
-        // Disconnect = clear the local provider/model preference. The
-        // actual key lives on the service and is removed via
-        // SettingsAISection / AssistantChat's "Disconnect" path.
-        setStoredConfig(null);
-        refresh();
+    <div
+      style={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        minHeight: 0,
+        // 100vh minus the main padding (28px top + 28px bottom) so the
+        // chat's input row stays anchored above the viewport bottom
+        // instead of being pushed below by the surrounding shell.
+        height: "calc(100vh - 56px)",
       }}
-    />
+    >
+      <AssistantChat
+        config={effectiveConfig}
+        onClear={() => {
+          // Disconnect = clear the local provider/model preference. The
+          // actual key lives on the service and is removed via
+          // SettingsAISection / AssistantChat's "Disconnect" path.
+          setStoredConfig(null);
+          refresh();
+        }}
+      />
+    </div>
   );
 }

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -114,19 +114,20 @@ and update them in the same commit.
 
 | File | Surface | Last verified |
 |---|---|---|
-| [dashboard.md](dashboard.md) | `client/src/pages/Dashboard.tsx` — hero card, donut, 9-month trend, top-merchant tiles | 2026-04-27 (PR #23) |
+| [dashboard.md](dashboard.md) | `client/src/pages/Dashboard.tsx` — hero, donut, 9-month trend, top-merchant tiles, wheel-scroll regression guard | 2026-04-27 (PR #27) |
 | [transactions.md](transactions.md) | `client/src/pages/Transactions.tsx` — filters, day groups, side panel, URL drill-down ingestion | 2026-04-27 (PR #23) |
 | [categories.md](categories.md) | `client/src/pages/Categories.tsx` — left donut + list, per-cat detail, per-cat trend, merchant rows | 2026-04-27 (PR #23) |
 | [merchants.md](merchants.md) | `client/src/pages/Merchants.tsx` — table, search, drill-down rows | 2026-04-27 (PR #23) |
 | [income.md](income.md) | `client/src/pages/Income.tsx` — hero, income trend, ledger | 2026-04-27 (PR #23) |
 | [manage.md](manage.md) | `client/src/pages/Settings.tsx` mounted at `/manage` — Sync now button, CSRF, partial-failure UI | 2026-04-27 (PR #22) |
+| [assistant.md](assistant.md) | `AssistantChat.tsx` + orchestrator — empty state, streaming, multi-turn memory, autoscroll, long-loop survival | 2026-04-27 (PR #27) |
 | [ranges.md](ranges.md) | Cross-cutting `useRangeState` + `dateRange.ts` invariants and Codex-fix regressions | 2026-04-27 (PR #23) |
 
 ## Test ID convention
 
 Each test has an ID `T-<AREA>-<NN>`:
 
-- `AREA` = uppercase short tag: `DASH`, `TX`, `CAT`, `MERCH`, `INC`, `RANGE`.
+- `AREA` = uppercase short tag: `DASH`, `TX`, `CAT`, `MERCH`, `INC`, `MGT`, `AI`, `RANGE`.
 - `NN` = two-digit zero-padded sequence within the file. Numbers don't get
   reused — if you delete a test, leave a gap (or repurpose the ID with a
   comment) so old PR references still make sense.

--- a/docs/e2e/assistant.md
+++ b/docs/e2e/assistant.md
@@ -1,0 +1,114 @@
+# Assistant — manual E2E
+
+Surface: `client/src/components/AssistantChat.tsx`, `client/src/pages/Assistant.tsx`,
+`client/src/hooks/useAgentRunner.ts`, `client/src/lib/ai/orchestrator.ts`.
+
+**Demo mode required.** Confirm via Prereqs in `README.md` before running.
+
+**Real LLM provider required.** Unlike most other test files, the assistant tests
+hit a real LLM (OpenAI or Anthropic) via `/api/ai/stream` because the assistant's
+behaviour is the model's behaviour — there's nothing meaningful to assert against
+a stubbed stream. The user's installed Xarji.app must be running on `:8721` with
+at least one AI provider key configured (visible at the bottom of `/assistant`:
+"connected to OpenAI · keys never leave this Mac" or similar).
+
+These tests cost API tokens. Run them deliberately, not on every pre-merge sweep
+unless touching assistant code.
+
+Open `http://localhost:5173/assistant`.
+
+---
+
+## T-AI-01 — Empty-state landing renders
+
+**Steps**
+1. Navigate to `/assistant` with no existing conversations (or click "New conversation" to start fresh).
+
+**Expected**
+- Six suggestion cards render: "Create a 'Coffee shops' category", "Set a ₾800 food budget", "Plan to save for a Honda — $1,000", "Filter all transit > ₾20 last 30 days", "Summarize my April spending", "Find subscriptions I'm not using".
+- "What can Xarji do for you?" header visible.
+- Bottom-right strip shows the connected provider (e.g. "connected to OpenAI · keys never leave this Mac").
+- Input row at the bottom with placeholder "Ask anything — set a budget, plan savings, find unused subscriptions…".
+
+---
+
+## T-AI-02 — Single-turn prompt streams a response
+
+**Steps**
+1. Click any suggestion card (or type a short prompt and press Enter).
+2. Wait for the stream to complete.
+
+**Expected**
+- The user message appears as a coral-bg pill at the right.
+- "Thinking…" / "Looking it up…" / "Crunching numbers…" status pill renders while the model is mid-stream.
+- Tool-call pills render as the model invokes tools (e.g. `TOOL CALL compare_months 6ms`).
+- Final response streams in token-by-token below the tool calls.
+- Inline formatting works: `₾<amount>` and merchant names render in monospaced code-blocks; **bold** and `\`backticks\`` parse correctly.
+- Stream completes; the input row reverts from "Thinking…" placeholder to the normal one.
+- No errors in the browser console.
+
+---
+
+## T-AI-03 — Multi-turn memory: assistant sees prior turn context
+
+**Why this exists:** The orchestrator built a one-shot `messages: [{ role: "user", content: userPrompt }]` array on every call up until the fix in PR #27. The thread UI displayed prior turns visually but never sent them to the provider, so each follow-up arrived at the model with zero conversation context. This test pins multi-turn memory.
+
+**Steps**
+1. Start a fresh conversation.
+2. Send turn 1: a prompt with a memorable, unusual token. e.g. `"My favourite merchant this month is Wizz Air. Remember that for the rest of this conversation."`
+3. Wait for the response.
+4. Send turn 2: a follow-up that requires turn 1's context. e.g. `"What did I say my favourite merchant was?"`
+5. Wait for the response.
+
+**Expected**
+- Turn 2's response correctly identifies "Wizz Air" (or whatever merchant you used in turn 1).
+- The model does NOT respond with "I don't have context from earlier in this conversation" or similar amnesia language.
+- This works whether or not the model called tools in turn 1 — past tool calls aren't preserved across turns (text-only collapse), but the user's text is.
+
+---
+
+## T-AI-04 — Streaming long response: scroll-up doesn't yank user back
+
+**Why this exists:** PR #20's autoscroll dep change initially yanked the viewport back to the bottom on every streamed token, making prior context unreadable mid-response. The PR shipped with a `isAtBottomRef` fix that only autoscrolls when the user is already pinned to the bottom (within 60px).
+
+**Steps**
+1. Send a prompt that produces a long response. e.g. `"List every category I spent in this month and give me 2 bullet points each on what stood out."`
+2. As soon as the response starts streaming, scroll up to the top of the chat.
+3. Hold position while streaming continues.
+
+**Expected**
+- The viewport stays at the top. New tokens appear at the bottom but do NOT scroll the chat back down.
+- After the stream completes, the user can scroll back to the bottom themselves.
+- If the user is already at the bottom (within 60px) when a stream starts, autoscroll DOES follow as new tokens arrive.
+
+---
+
+## T-AI-05 — Long agentic loops survive the idle timeout
+
+**Why this exists:** PR #20 originally introduced `idleTimeout: 60` on the Bun server, which would have killed `/api/ai/stream` mid-response if the model paused for >60s during a multi-tool agentic loop. PR #20's followup commit set `idleTimeout: 0` (disabled) for the entire server. This test pins that the long-stall path stays alive.
+
+**Steps**
+1. Send a prompt that requires multiple tool calls. e.g. `"Compare every category between this month and last month and give me a recommendation per category."`
+2. Watch the streaming response. Multiple `TOOL CALL` pills should appear (likely `compare_months`, `list_categories`, possibly more).
+3. The model may pause for many seconds between events.
+
+**Expected**
+- The stream completes successfully even if the total elapsed time exceeds 60 seconds.
+- No "stream aborted" error message appears.
+- All tool results arrive. The final text response renders.
+
+---
+
+## T-AI-06 — Side-panel scrolling works (Layout-overflow regression guard)
+
+**Why this exists:** PR #20 set Layout's `<main>` to `overflow: auto` to give the chat a bounded viewport, then PR #27 reverted that to keep document scroll working everywhere else, and instead wrapped only the assistant page in `calc(100vh - 56px)`. This test confirms both the chat scroller AND the input row layout still work after the rewrap.
+
+**Steps**
+1. Send a long prompt that produces a response longer than the viewport.
+2. After the stream completes, attempt to scroll the chat content area with the mouse wheel.
+
+**Expected**
+- The chat content area scrolls within its bounded container.
+- The input row at the bottom stays anchored above the viewport bottom (does NOT scroll off-screen with the content).
+- The sidebar and the conversations list (left column) are also independently scrollable.
+- The browser's outer scrollbar does NOT appear — the assistant page still fits within the viewport.

--- a/docs/e2e/dashboard.md
+++ b/docs/e2e/dashboard.md
@@ -184,3 +184,20 @@ The donut is a snapshot widget when there's nothing to drill into; only ring cli
 - "You spent ₾0", "0 transactions", subline shows the day count for the range.
 - Spending mix card shows "No spending data yet."
 - Today & recent shows whatever existing recent activity (this card isn't range-scoped).
+
+---
+
+## T-DASH-12 — Wheel scroll works on Overview
+
+**Why this exists:** PR #20 once set the Layout shell to `height: 100vh` + `<main>` to `overflow: auto`, which silently killed mouse-wheel scrolling on every page that doesn't have an inner scroll container. Pinning this test prevents regressing into the same shape again.
+
+**Steps**
+1. Navigate to `http://localhost:5173/` (Overview).
+2. Confirm there's content below the fold (Top merchants tiles or further sections should be partially or fully out of viewport at default browser size).
+3. Hover the mouse over the empty space between cards (NOT over a chart or donut — Recharts can intercept wheel events on its own surfaces).
+4. Scroll the mouse wheel down.
+
+**Expected**
+- The page scrolls. The Top merchants row (or whatever is below the fold) comes into view.
+- Two-finger trackpad scroll behaves identically.
+- This works regardless of cursor position, INCLUDING over the sidebar.


### PR DESCRIPTION
Two unrelated fixes bundled together — both surfaced during the same post-merge eyeball test of yesterday's contributor PRs (#20–#22), and shipping them together avoids serialising a 1-line revert behind a multi-file refactor's review cycle.

## SCROLL — Overview was unscrollable after #20

PR #20 set the Layout shell to `height: 100vh` + `<main>` to `overflow: auto` so the AssistantChat could have a bounded viewport for its own scroller. That works for `/assistant` but kills mouse-wheel scrolling on every page that doesn't have an inner scroll container — including Overview, the most-used page in the app.

Fix:
- Reverted `Layout.tsx` to its pre-#20 shape (`minHeight: 100vh`, no overflow constraint on `<main>`). Document scroll behaves the way it did for the prior 22 PRs.
- Moved the bounded-viewport requirement to `/assistant` itself: `Assistant.tsx` now wraps `<AssistantChat>` in a `calc(100vh - 56px)` container so the chat keeps its scroll-pinned input row without forcing every other page into the same constraint.

## MEMORY — Assistant was amnesiac since #15

`runAgent` built a one-shot `messages: [{ role: "user", content: userPrompt }]` array on every call. The thread UI displayed prior turns visually but never sent them upstream, so each follow-up prompt arrived at the provider with no conversation context. Reproduced on demo data: turn 1 \"Make a Coffee shops category\", turn 2 \"Try it again\" → the model treated turn 2 as a brand new conversation.

Fix:
- Refactored `RunAgentOpts.userPrompt: string` → `messages: AICoreMessage[]`. Caller is responsible for getting the shape right.
- `useAgentRunner` forwards messages unchanged.
- `AssistantChat.runAgentForActive` builds `buildCoreHistory(thread)` from the in-memory thread (which already has the new user turn appended by `send()`). User turns keep their text; assistant turns are collapsed to text-only.

**Tradeoff:** past tool calls are invisible to the model on follow-ups. The model sees what it _said_, not what it _called_. For a personal-finance assistant doing fresh queries each turn, text-only history is enough. If we want full tool-history fidelity later, we'd persist `AIContentPart[]` directly in `aiThreads.ts` instead of the user-facing block list.

## Pre-existing vs regression

- Scroll: regression introduced by #20.
- Memory: pre-existing since #15 landed (assistant has been amnesiac since day one). Bundled here because it's a major UX miss surfaced by the same testing pass.

## Verification

- `bun run build` clean.
- 193 service tests pass.
- Live: Overview wheel-scrolls again. Assistant chat keeps the input row anchored above the viewport bottom. Multi-turn assistant memory verified by reproducing the original \"Try it again\" follow-up — the model now correctly references the prior turn's context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport/scroll behavior so chat and surrounding layout scroll correctly.

* **Improvements**
  * Chat now sends preserved multi-turn conversation history (capped to recent turns) for more context-aware responses.
  * Agent invocation updated to accept structured message history.

* **UI**
  * Shortened connection status text in the UI.

* **Documentation**
  * Added and updated E2E assistant and dashboard test plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->