### PR TITLE
Assistant: enable category creation from chat (Phase 1.0 of #29)

### DIFF
--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -11,6 +11,7 @@ import { useCategorizer } from "./useCategorizer";
 import { getProviderClient } from "../lib/ai/provider";
 import { runAgent, type AssistantEvent } from "../lib/ai/orchestrator";
 import { READONLY_TOOLS } from "../lib/ai/tools/readonly";
+import { WRITE_TOOLS } from "../lib/ai/tools/write";
 import type { AITool } from "../lib/ai/tools/types";
 import type { AICoreMessage } from "../lib/ai/types";
 import type { AIConfig } from "../lib/aiConfig";
@@ -20,7 +21,7 @@ import type { AIConfig } from "../lib/aiConfig";
 // (b) appends it to the "Available tools" section of the system
 // prompt — see buildSystemPrompt() below. Adding a NEW registry?
 // Concatenate it into ALL_TOOLS so both effects happen.
-const ALL_TOOLS: AITool[] = [...READONLY_TOOLS];
+const ALL_TOOLS: AITool[] = [...READONLY_TOOLS, ...WRITE_TOOLS];
 
 const BASE_SYSTEM_PROMPT = `You are Xarji's AI Assistant, a personal finance assistant embedded inside the Xarji dashboard.
 
@@ -48,7 +49,12 @@ Tool usage:
 - Do not guess specific financial numbers from memory.
 - Do not invent transactions, merchants, totals, dates, categories, or exchange rates.
 - For purely conversational, educational, or general budgeting questions, a tool call is not required.
-- Tools are read-only. Do not claim that you changed, deleted, categorized, edited, or created anything.
+
+Write tools:
+- Some tools mutate the user's data (e.g. \`create_category\`).
+- Auto-apply tools (those whose description says "AUTO-APPLIES") execute immediately. After calling one successfully, you may tell the user it's done — describe what was created/changed.
+- If a write tool fails (e.g. duplicate name), the error result tells you why. Use that to inform the user clearly and propose the next step.
+- Do not claim a change happened unless the corresponding tool call succeeded.
 
 Answer style:
 - Be concise and clear.

--- a/client/src/lib/ai/tools/write.ts
+++ b/client/src/lib/ai/tools/write.ts
@@ -1,0 +1,121 @@
+// Write tools the model can call to mutate the user's data. Unlike
+// readonly tools, these have side effects in InstantDB.
+//
+// Auto-apply policy (per issue #29):
+//   - CREATE  → executes immediately, returns the new entity
+//   - EDIT    → must require confirm (renders a card with Apply/Cancel)
+//   - DELETE  → must require confirm
+//
+// Phase 1.0 ships only `create_category` — the simplest auto-apply
+// case. Override + remove tools land in Phase 1.1 along with the
+// confirm-card UX.
+//
+// Tools call `db.transact()` directly via the imported singleton
+// (matches the pattern in client/src/hooks/useCategories.ts). The
+// singleton already handles the demo-mode swap in dev, so write tools
+// against `?demo=1` mutate the in-memory store, not the user's
+// InstantDB app.
+
+import { id } from "@instantdb/react";
+import { db } from "../../instant";
+import type { AITool } from "./types";
+
+const CATEGORY_PALETTE = [
+  "#FF5A3A", // coral
+  "#4BD9A2", // emerald
+  "#6AA3FF", // azure
+  "#E8A05A", // amber
+  "#B38DF7", // violet
+  "#FF7A9E", // rose
+  "#F1B84A", // gold
+  "#6b7280", // slate (matches Other)
+];
+
+const CATEGORY_ICONS = ["◐", "◆", "◉", "✦", "✧", "◇", "✶", "◈"];
+
+/** Pick a deterministic-but-varied default for color/icon when the model
+ *  doesn't supply them. The hash is derived from the category name so
+ *  re-running create_category with the same name returns the same
+ *  visual identity. */
+function pickDefaults(name: string): { color: string; icon: string } {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+  }
+  return {
+    color: CATEGORY_PALETTE[hash % CATEGORY_PALETTE.length],
+    icon: CATEGORY_ICONS[hash % CATEGORY_ICONS.length],
+  };
+}
+
+const createCategory: AITool = {
+  definition: {
+    name: "create_category",
+    description:
+      "Creates a new spending category. AUTO-APPLIES — the new category appears immediately in the user's category list with no confirmation step (creating an empty category is reversible by deleting it). Returns the new category's id and name. The model should call this when the user asks to make, add, or create a new category. The user can then ask the assistant to move transactions into the new category via apply_category_override (added in a follow-up).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description: "Display name for the new category (e.g. 'Coffee shops', 'Pet care'). Required.",
+        },
+        color: {
+          type: "string",
+          description: "Optional hex color for the category dot (e.g. '#FF5A3A'). If omitted, a default is picked based on the name.",
+        },
+        icon: {
+          type: "string",
+          description: "Optional one-character glyph rendered next to the category name. If omitted, a default is picked based on the name.",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  statusText: "Creating the category…",
+  executor: async (input, ctx) => {
+    const name = typeof input.name === "string" ? input.name.trim() : "";
+    if (!name) {
+      throw new Error("`name` is required and must be a non-empty string.");
+    }
+
+    // Reject duplicate names case-insensitively. The user can have a
+    // "Coffee" category and not see a confusing "Coffee" / "coffee"
+    // pair appear after the assistant's call. Better to surface the
+    // collision as a tool error so the model can decide what to do
+    // (mention the existing category, suggest a different name, etc.)
+    // than silently create a parallel one.
+    const existing = ctx.categories.find(
+      (c) => c.name.toLowerCase() === name.toLowerCase()
+    );
+    if (existing) {
+      throw new Error(
+        `A category named "${existing.name}" already exists. The user can move transactions into it without creating a new one.`
+      );
+    }
+
+    const defaults = pickDefaults(name);
+    const color = typeof input.color === "string" ? input.color : defaults.color;
+    const icon = typeof input.icon === "string" ? input.icon : defaults.icon;
+
+    const newId = id();
+    await db.transact(
+      db.tx.categories[newId].update({
+        name,
+        color,
+        icon,
+        isDefault: false,
+      })
+    );
+
+    return {
+      id: newId,
+      name,
+      color,
+      icon,
+      created: true,
+    };
+  },
+};
+
+export const WRITE_TOOLS: AITool[] = [createCategory];

--- a/docs/e2e/assistant.md
+++ b/docs/e2e/assistant.md
@@ -112,3 +112,46 @@ Open `http://localhost:5173/assistant`.
 - The input row at the bottom stays anchored above the viewport bottom (does NOT scroll off-screen with the content).
 - The sidebar and the conversations list (left column) are also independently scrollable.
 - The browser's outer scrollbar does NOT appear — the assistant page still fits within the viewport.
+
+---
+
+## Write tools (issue #29 / Phase 1)
+
+These tests cover the assistant's write-tool surface. Phase 1.0 ships `create_category` only — auto-apply, no confirm card. Phase 1.1 adds `apply_category_override` and `remove_category_override` with the confirm-card UX.
+
+### T-AI-07 — `create_category` auto-applies
+
+**Why this exists:** Pins the auto-apply policy decided in #29: empty category creation is reversible, so it executes immediately without a confirm step.
+
+**Steps**
+1. Start a fresh assistant conversation.
+2. Send: `"Make a new category called Coffee shops."`
+3. Wait for the response.
+4. Open `/categories` in another tab (or navigate after the response).
+
+**Expected**
+- The chat shows a `TOOL CALL create_category` pill (succeeded, sub-second).
+- The assistant's text response says something like \"Created the Coffee shops category. You can now move transactions into it.\" (exact wording will drift; just confirm it tells the user the action is done).
+- `/categories` left column lists `Coffee shops` somewhere in the category list.
+- No transactions are reassigned (the new category is empty until the user moves transactions into it via the override tool — coming in Phase 1.1).
+- The category persists across page reloads.
+
+### T-AI-08 — `create_category` rejects duplicate name
+
+**Steps**
+1. After T-AI-07 (or with a pre-existing `Coffee shops` category), send: `"Make a Coffee shops category."`
+
+**Expected**
+- The tool call returns an error result (visible as the `TOOL CALL` pill — the chat shows the error inline if the model surfaces it).
+- The assistant's text response acknowledges the existing category instead of pretending to create another one (e.g. \"You already have a Coffee shops category. Want me to move transactions into it?\").
+- Duplicate-detection is case-insensitive: `"Coffee Shops"`, `"coffee shops"`, `"COFFEE SHOPS"` all collide with `"Coffee shops"`.
+
+### T-AI-09 — Multi-write turn (multiple `create_category` in one response)
+
+**Steps**
+1. Send: `"Make three categories: Pet care, Dog food, Vet bills."`
+
+**Expected**
+- The assistant emits three `TOOL CALL create_category` pills in sequence.
+- All three categories appear in `/categories`.
+- The assistant's text response confirms all three were created.


### PR DESCRIPTION
**Phase 1.0 of [#29](https://github.com/tornikegomareli/Xarji/issues/29).** First write tool the assistant can call — reverses the embarrassing \"I can't create categories from here\" responses on the simplest case.

## What the user sees

> **User:** Please create some random category for me
> **Assistant:** ✓ tool call `create_category` 5ms
> Done. I created a new category: Random (icon ✦, color #E8A05A). Want me to move any transactions into Random?

Verified live on demo data ([screenshot in chat](https://github.com/tornikegomareli/Xarji/issues/29#issuecomment-4324835260)). The category persists across reload, appears in `/categories` left list, and the deterministic defaults give the same visual identity for the same name across runs.

## Auto-apply policy (decided in #29)

| Operation | Tool | Auto / Confirm |
|---|---|---|
| Create empty category | `create_category` | **auto** (this PR) |
| New merchant→category mapping | `apply_category_override` | auto (Phase 1.1) |
| Replace existing override | `apply_category_override` | confirm (Phase 1.1) |
| Remove an override | `remove_category_override` | confirm (Phase 1.1) |
| Delete a category | `delete_category` | confirm (deferred — destructive) |

Reasoning: empty category creation is reversible by deleting the category — net-zero damage from a wrong call. Anything that touches existing transaction-categorisation data requires explicit Apply.

## Three correctness details worth flagging

1. **Duplicate-name rejection is case-insensitive.** \"Coffee\" and \"coffee\" would render as a confusing pair in `/categories`, so the tool throws a structured error. The model reads the error and tells the user instead of pretending to create.

2. **Default color + icon are deterministic.** xorshift over character codes — same name → same visual identity across runs. Avoids the \"why did my Coffee shops category change colors?\" confusion.

3. **System prompt rewritten.** The old read-only-only block is replaced with a write-tools section that tells the model: auto-apply tools execute immediately, on success describe what was done. Removed the \"I can't create anything\" wording that was producing the bad responses.

## What's NOT in this PR

- `apply_category_override` / `remove_category_override` — Phase 1.1, depends on confirm-card UX design.
- `delete_category` — explicitly deferred. Destructive, no clear semantics for transactions previously assigned to it (re-categorise to Other? Block deletion if used? Both need design before implementing).
- `bulk_apply_override` — single primitives are cleaner.

## Verification

- `bun run build` clean
- 193 service tests pass
- Live: \"Please create some random category for me\" → succeeded as described above
- Live: \"Make three categories: Pet care, Dog food, Vet bills\" → all three created in one turn
- Live: duplicate-name rejection (will verify before merge)

## E2E coverage

T-AI-07, T-AI-08, T-AI-09 added to `docs/e2e/assistant.md`.