### PR TITLE
Assistant write tools: create_category + apply_category_override (Phase 1 of #29)

### DIFF
--- a/client/src/components/CategoryPicker.tsx
+++ b/client/src/components/CategoryPicker.tsx
@@ -7,8 +7,9 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useTheme, type InkTheme } from "../ink/theme";
-import { DEFAULT_CATEGORIES, type InkCategory } from "../lib/utils";
+import { type InkCategory } from "../lib/utils";
 import { useMerchantOverrides } from "../hooks/useMerchantOverrides";
+import { useCategorizer } from "../hooks/useCategorizer";
 
 export function CategoryPicker({
   merchant,
@@ -22,6 +23,7 @@ export function CategoryPicker({
   const T = useTheme();
   const ref = useRef<HTMLDivElement | null>(null);
   const { byMerchant, setOverride, clearOverride } = useMerchantOverrides();
+  const { allCategories } = useCategorizer();
   const [busy, setBusy] = useState(false);
   const hasOverride = !!byMerchant.get(merchant.trim().toLowerCase());
 
@@ -94,7 +96,7 @@ export function CategoryPicker({
         Move {merchant} to
       </div>
       <div style={{ display: "flex", flexDirection: "column", maxHeight: 280, overflowY: "auto" }}>
-        {DEFAULT_CATEGORIES.map((cat) => (
+        {allCategories.map((cat) => (
           <CategoryRow
             key={cat.id}
             T={T}

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -2,7 +2,7 @@
 // etc.) into the provider-agnostic orchestrator. Returns a `runAgent`
 // function the AssistantChat calls per user prompt.
 
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useConvertedPayments, useFailedPayments } from "./useTransactions";
 import { useConvertedCredits } from "./useCredits";
 import { useCategories } from "./useCategories";
@@ -126,8 +126,18 @@ export function useAgentRunner() {
   const { failedPayments } = useFailedPayments();
   const { categories } = useCategories();
   const { senders } = useBankSenders();
-  const { categorizeName } = useCategorizer();
+  const { categorizeName, allCategories } = useCategorizer();
   const { overrides } = useMerchantOverrides();
+
+  // Ref-based snapshot of live state. Updated on every render so that
+  // tools called LATER in a single agentic loop see fresh data after
+  // earlier tools in the same loop mutated InstantDB. Without this, an
+  // assistant turn that does `create_category` then `apply_category_
+  // override` validates the second call against the snapshot taken
+  // BEFORE the first call ran, rejecting the just-created id. Codex
+  // HIGH on PR #32.
+  const liveRef = useRef({ allCategories, overrides, categories });
+  liveRef.current = { allCategories, overrides, categories };
 
   return useCallback(
     async (
@@ -152,6 +162,12 @@ export function useAgentRunner() {
           overrides,
           now: new Date(),
           categorizeName,
+          // Getters that read fresh state via the ref — see comment on
+          // liveRef above for the why. The non-getter fields above are
+          // captured once for the run; tools that mutate state should
+          // use the getters for everything they touch.
+          getAllCategories: () => liveRef.current.allCategories,
+          getOverrides: () => liveRef.current.overrides,
         },
         emit,
         signal,

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -11,16 +11,18 @@ import { useCategorizer } from "./useCategorizer";
 import { getProviderClient } from "../lib/ai/provider";
 import { runAgent, type AssistantEvent } from "../lib/ai/orchestrator";
 import { READONLY_TOOLS } from "../lib/ai/tools/readonly";
+import { WRITE_TOOLS } from "../lib/ai/tools/write";
 import type { AITool } from "../lib/ai/tools/types";
 import type { AICoreMessage } from "../lib/ai/types";
 import type { AIConfig } from "../lib/aiConfig";
+import { useMerchantOverrides } from "./useMerchantOverrides";
 
 // Tool registries the agent has access to. Adding a tool to one of
 // these lists automatically (a) makes it callable by the model and
 // (b) appends it to the "Available tools" section of the system
 // prompt — see buildSystemPrompt() below. Adding a NEW registry?
 // Concatenate it into ALL_TOOLS so both effects happen.
-const ALL_TOOLS: AITool[] = [...READONLY_TOOLS];
+const ALL_TOOLS: AITool[] = [...READONLY_TOOLS, ...WRITE_TOOLS];
 
 const BASE_SYSTEM_PROMPT = `You are Xarji's AI Assistant, a personal finance assistant embedded inside the Xarji dashboard.
 
@@ -48,7 +50,16 @@ Tool usage:
 - Do not guess specific financial numbers from memory.
 - Do not invent transactions, merchants, totals, dates, categories, or exchange rates.
 - For purely conversational, educational, or general budgeting questions, a tool call is not required.
-- Tools are read-only. Do not claim that you changed, deleted, categorized, edited, or created anything.
+
+Write tools:
+- Some tools mutate the user's data: \`create_category\` and \`apply_category_override\`.
+- Both AUTO-APPLY: they execute immediately when called, no confirmation step in chat.
+- After a successful write, you may tell the user it's done — describe what was created or moved.
+- If a write tool fails, the error result tells you why. Use that to inform the user clearly.
+- The user can edit a category, delete a category, or clear an override directly from the dashboard UI:
+  - Delete a category: open Categories (\`/categories\`), click the × on the category row.
+  - Clear a merchant override: open Transactions (\`/transactions\`), click the merchant's category badge, then "Clear override".
+- For deletions or edits that don't have a tool, tell the user how to do it in the UI.
 
 Answer style:
 - Be concise and clear.
@@ -116,6 +127,7 @@ export function useAgentRunner() {
   const { categories } = useCategories();
   const { senders } = useBankSenders();
   const { categorizeName } = useCategorizer();
+  const { overrides } = useMerchantOverrides();
 
   return useCallback(
     async (
@@ -137,6 +149,7 @@ export function useAgentRunner() {
           failedPayments,
           categories,
           bankSenders: senders,
+          overrides,
           now: new Date(),
           categorizeName,
         },
@@ -144,6 +157,6 @@ export function useAgentRunner() {
         signal,
       });
     },
-    [payments, credits, failedPayments, categories, senders, categorizeName]
+    [payments, credits, failedPayments, categories, senders, overrides, categorizeName]
   );
 }

--- a/client/src/hooks/useCategories.ts
+++ b/client/src/hooks/useCategories.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { db, type Category } from "../lib/instant";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "./useCategorizer";
+import { useMerchantOverrides } from "./useMerchantOverrides";
 import { id } from "@instantdb/react";
 
 export function useCategories() {
@@ -15,6 +16,14 @@ export function useCategories() {
 }
 
 export function useCategoryActions() {
+  // Read overrides synchronously so deleteCategory can clean up any
+  // dangling rows in the same transact call. Without this, deleting
+  // "Coffee shops" leaves merchantCategoryOverrides rows pointing at
+  // a category id that no longer exists; the categorizer falls
+  // through to the regex result on dangling lookups (defensive), but
+  // the data still rots silently.
+  const { overrides } = useMerchantOverrides();
+
   const addCategory = async (category: Omit<Category, "id">) => {
     const categoryId = id();
     await db.transact(
@@ -30,9 +39,17 @@ export function useCategoryActions() {
   };
 
   const deleteCategory = async (categoryId: string) => {
-    await db.transact(
-      db.tx.categories[categoryId].delete()
-    );
+    // Build the op list as `unknown[]` because db.tx returns a chainable
+    // proxy whose op type isn't readily exposed by @instantdb/react. The
+    // demo-db typings accept any[] anyway and the real InstantDB client
+    // is typed against the same shape.
+    const ops: unknown[] = [db.tx.categories[categoryId].delete()];
+    for (const o of overrides) {
+      if (o.categoryId === categoryId) {
+        ops.push(db.tx.merchantCategoryOverrides[o.id].delete());
+      }
+    }
+    await db.transact(ops as Parameters<typeof db.transact>[0]);
   };
 
   const initializeDefaultCategories = async () => {

--- a/client/src/hooks/useCategorizer.ts
+++ b/client/src/hooks/useCategorizer.ts
@@ -38,19 +38,55 @@ export function useCategorizer(): Categorizer {
   const { byMerchant } = useMerchantOverrides();
   const { categories: dbCategories } = useCategories();
 
-  // DB categories override defaults on id collision so a user-renamed
-  // "Groceries" → "Food shop" propagates everywhere. New custom
-  // categories (those with ids not in DEFAULT_CATEGORIES) get appended.
-  // Order: defaults first (predictable for the regex categoriser's
-  // fallback), then any custom categories the user created.
+  // Merge DB categories with DEFAULT_CATEGORIES, deduping by *name*
+  // (case-insensitive) rather than by id.
+  //
+  // Why name-based: persisted "default" rows (from
+  // initializeDefaultCategories or the demo seed) use random UUIDs or
+  // prefixed ids ("cat-groceries"), NOT the canonical ids hardcoded
+  // in DEFAULT_CATEGORIES. An id-only merge produces a "Groceries"
+  // (canonical id) AND a "Groceries" (UUID/cat- id) in the same list
+  // — a duplicate the user sees in pickers and dropdowns, and the
+  // wrong target for overrides since two ids both display as the
+  // same name.
+  //
+  // DB rows win on name collision so user renames / recolors
+  // propagate. The DB row's id is preserved so existing
+  // merchantCategoryOverride rows pointing at it keep resolving.
+  // Custom categories (DB rows with names that don't collide with
+  // any default) are appended as-is.
   const allCategories = useMemo<InkCategory[]>(() => {
-    const byId = new Map<string, InkCategory>();
-    for (const c of DEFAULT_CATEGORIES) byId.set(c.id, c);
-    for (const c of dbCategories) {
-      byId.set(c.id, { id: c.id, name: c.name, color: c.color, icon: c.icon });
+    const byName = new Map<string, InkCategory>();
+    for (const c of DEFAULT_CATEGORIES) {
+      byName.set(c.name.toLowerCase(), c);
     }
-    return Array.from(byId.values());
+    for (const c of dbCategories) {
+      byName.set(c.name.toLowerCase(), {
+        id: c.id,
+        name: c.name,
+        color: c.color,
+        icon: c.icon,
+      });
+    }
+    return Array.from(byName.values());
   }, [dbCategories]);
+
+  // Lookup table: canonical default id → entry in allCategories
+  // (DB-backed if the user has the default seeded, hardcoded otherwise).
+  // Built by mapping each DEFAULT_CATEGORIES entry's NAME to the merged
+  // entry. Lets `getCategory` resolve a regex-derived "groceries" to
+  // the user's renamed/recolored version of Groceries even though the
+  // merged entry's id is a DB UUID.
+  const byCanonicalId = useMemo(() => {
+    const out = new Map<string, InkCategory>();
+    for (const def of DEFAULT_CATEGORIES) {
+      const merged = allCategories.find(
+        (c) => c.name.toLowerCase() === def.name.toLowerCase()
+      );
+      if (merged) out.set(def.id, merged);
+    }
+    return out;
+  }, [allCategories]);
 
   const getCategory = useCallback(
     (merchant: string | null | undefined, raw?: string | null): InkCategory => {
@@ -66,14 +102,12 @@ export function useCategorizer(): Categorizer {
           // don't want this hot path silently fixing data.
         }
       }
-      // Resolve the regex result against the merged category list so a
-      // renamed default (e.g. "Subscriptions" → "Recurring") propagates.
-      // Falls back to defaultGetCategory if the merged lookup fails so
-      // we never return undefined.
+      // Regex returns a canonical id like "groceries". Resolve via the
+      // canonical-id → merged-entry map so renamed defaults propagate.
       const id = categorizeId(merchant, raw);
-      return allCategories.find((c) => c.id === id) ?? defaultGetCategory(merchant, raw);
+      return byCanonicalId.get(id) ?? defaultGetCategory(merchant, raw);
     },
-    [byMerchant, allCategories]
+    [byMerchant, allCategories, byCanonicalId]
   );
 
   const categorize = useCallback(
@@ -86,9 +120,13 @@ export function useCategorizer(): Categorizer {
           return override.categoryId;
         }
       }
-      return categorizeId(merchant, raw);
+      // Regex returns a canonical id; if the user has that default
+      // seeded into DB under a UUID, return THAT id so callers grouping
+      // by id agree with `getCategory()`.
+      const canonicalId = categorizeId(merchant, raw);
+      return byCanonicalId.get(canonicalId)?.id ?? canonicalId;
     },
-    [byMerchant, allCategories]
+    [byMerchant, allCategories, byCanonicalId]
   );
 
   const categorizeName = useCallback(

--- a/client/src/hooks/useCategorizer.ts
+++ b/client/src/hooks/useCategorizer.ts
@@ -16,6 +16,7 @@ import {
   type InkCategory,
 } from "../lib/utils";
 import { useMerchantOverrides } from "./useMerchantOverrides";
+import { useCategories } from "./useCategories";
 
 export interface Categorizer {
   /** Returns the category id (e.g. "groceries") for a merchant. */
@@ -25,34 +26,69 @@ export interface Categorizer {
   /** Convenience for places that historically called `autoCategorize`
    *  to get the human-facing category name (e.g. "Groceries"). */
   categorizeName: (merchant: string | null | undefined) => string;
+  /** Merged list of DEFAULT_CATEGORIES + DB-backed categories (DB wins
+   *  on id collision so a renamed default uses the user's name).
+   *  Use this anywhere you'd previously have hardcoded `DEFAULT_CATEGORIES`
+   *  — pickers, dropdowns, lookup-by-id calls — so user-created
+   *  categories show up consistently. */
+  allCategories: InkCategory[];
 }
 
 export function useCategorizer(): Categorizer {
   const { byMerchant } = useMerchantOverrides();
+  const { categories: dbCategories } = useCategories();
+
+  // DB categories override defaults on id collision so a user-renamed
+  // "Groceries" → "Food shop" propagates everywhere. New custom
+  // categories (those with ids not in DEFAULT_CATEGORIES) get appended.
+  // Order: defaults first (predictable for the regex categoriser's
+  // fallback), then any custom categories the user created.
+  const allCategories = useMemo<InkCategory[]>(() => {
+    const byId = new Map<string, InkCategory>();
+    for (const c of DEFAULT_CATEGORIES) byId.set(c.id, c);
+    for (const c of dbCategories) {
+      byId.set(c.id, { id: c.id, name: c.name, color: c.color, icon: c.icon });
+    }
+    return Array.from(byId.values());
+  }, [dbCategories]);
 
   const getCategory = useCallback(
     (merchant: string | null | undefined, raw?: string | null): InkCategory => {
       if (merchant) {
         const override = byMerchant.get(merchant.trim().toLowerCase());
         if (override) {
-          const hit = DEFAULT_CATEGORIES.find((c) => c.id === override.categoryId);
+          const hit = allCategories.find((c) => c.id === override.categoryId);
           if (hit) return hit;
+          // Override points at a category that no longer exists (deleted
+          // or never created). Fall through to the regex categoriser
+          // rather than returning a broken record. The dangling override
+          // should be cleaned up by the delete-category code path; we
+          // don't want this hot path silently fixing data.
         }
       }
-      return defaultGetCategory(merchant, raw);
+      // Resolve the regex result against the merged category list so a
+      // renamed default (e.g. "Subscriptions" → "Recurring") propagates.
+      // Falls back to defaultGetCategory if the merged lookup fails so
+      // we never return undefined.
+      const id = categorizeId(merchant, raw);
+      return allCategories.find((c) => c.id === id) ?? defaultGetCategory(merchant, raw);
     },
-    [byMerchant]
+    [byMerchant, allCategories]
   );
 
   const categorize = useCallback(
     (merchant: string | null | undefined, raw?: string | null): string => {
       if (merchant) {
         const override = byMerchant.get(merchant.trim().toLowerCase());
-        if (override) return override.categoryId;
+        // Only honour an override if the target still exists. Dangling
+        // overrides re-route to the regex result.
+        if (override && allCategories.some((c) => c.id === override.categoryId)) {
+          return override.categoryId;
+        }
       }
       return categorizeId(merchant, raw);
     },
-    [byMerchant]
+    [byMerchant, allCategories]
   );
 
   const categorizeName = useCallback(
@@ -60,5 +96,8 @@ export function useCategorizer(): Categorizer {
     [getCategory]
   );
 
-  return useMemo(() => ({ categorize, getCategory, categorizeName }), [categorize, getCategory, categorizeName]);
+  return useMemo(
+    () => ({ categorize, getCategory, categorizeName, allCategories }),
+    [categorize, getCategory, categorizeName, allCategories]
+  );
 }

--- a/client/src/lib/ai/tools/readonly.ts
+++ b/client/src/lib/ai/tools/readonly.ts
@@ -233,7 +233,7 @@ const listCategories: AITool = {
   definition: {
     name: "list_categories",
     description:
-      "Returns the user's categories with their color and icon, plus the GEL-equivalent total for the current month for each.",
+      "Returns the user's full category set (built-in defaults plus any custom categories) with id, name, color, icon, and the GEL-equivalent total for the current month for each. Use the returned ids verbatim when calling apply_category_override.",
     inputSchema: { type: "object", properties: {} },
   },
   statusText: "Looking at your categories…",
@@ -249,8 +249,14 @@ const listCategories: AITool = {
       v.count += 1;
       monthTotals.set(cat, v);
     }
+    // Use the merged live list (DEFAULT_CATEGORIES + DB rows, deduped
+    // by name with DB winning, custom categories appended) so the
+    // model sees defaults that aren't yet persisted in DB. Without
+    // this, on a fresh account the model would see zero categories
+    // from list_categories and have no way to target Groceries /
+    // Dining / etc. via apply_category_override.
     return {
-      categories: ctx.categories.map((c) => ({
+      categories: ctx.getAllCategories().map((c) => ({
         id: c.id,
         name: c.name,
         color: c.color,

--- a/client/src/lib/ai/tools/types.ts
+++ b/client/src/lib/ai/tools/types.ts
@@ -8,11 +8,24 @@ import type { AIBlock } from "../../aiThreads";
 import type { ConvertedPayment } from "../../../hooks/useTransactions";
 import type { ConvertedCredit } from "../../../hooks/useCredits";
 import type { FailedPayment, Category, BankSender, MerchantCategoryOverride } from "../../instant";
+import type { InkCategory } from "../../utils";
+
+/** A snapshot getter that returns the freshest value available at the
+ *  moment of read. Backed by a ref the React layer mutates on every
+ *  render; tools call this inside their executors to see the live state
+ *  even when an earlier tool in the same agentic loop just mutated it
+ *  (e.g. create_category followed by apply_category_override in the
+ *  same multi-iteration run). Without this, captured-at-runAgent-start
+ *  snapshots produce stale-data bugs across chained writes. */
+export type Live<T> = () => T;
 
 export interface AIToolContext {
   payments: ConvertedPayment[];
   credits: ConvertedCredit[];
   failedPayments: FailedPayment[];
+  /** Raw DB-backed category rows. Use sparingly — most tools should
+   *  prefer `getAllCategories()` which merges DEFAULT_CATEGORIES so
+   *  tools can target defaults that aren't yet persisted in DB. */
   categories: Category[];
   bankSenders: BankSender[];
   /** Live merchant-override rows. Write tools (apply_category_override)
@@ -28,6 +41,17 @@ export interface AIToolContext {
    *  static `autoCategorize` so an "I moved Spotify to Subscriptions"
    *  override actually shows up in the AI's view of the data. */
   categorizeName: (merchant: string | null | undefined) => string;
+  /** Returns the merged category list (DEFAULT_CATEGORIES + DB rows,
+   *  deduped by name with DB winning). Use this from tools that need
+   *  to expose categories to the model (list_categories) or validate
+   *  category ids in input (apply_category_override). Reads live state
+   *  via a getter so chained writes in the same agentic loop see fresh
+   *  data. */
+  getAllCategories: Live<InkCategory[]>;
+  /** Returns live merchant-override rows. Same staleness story as
+   *  getAllCategories — use this from write tools that need to find
+   *  an existing row's id. */
+  getOverrides: Live<MerchantCategoryOverride[]>;
 }
 
 export interface AITool {

--- a/client/src/lib/ai/tools/types.ts
+++ b/client/src/lib/ai/tools/types.ts
@@ -7,7 +7,7 @@ import type { AIToolDefinition } from "../types";
 import type { AIBlock } from "../../aiThreads";
 import type { ConvertedPayment } from "../../../hooks/useTransactions";
 import type { ConvertedCredit } from "../../../hooks/useCredits";
-import type { FailedPayment, Category, BankSender } from "../../instant";
+import type { FailedPayment, Category, BankSender, MerchantCategoryOverride } from "../../instant";
 
 export interface AIToolContext {
   payments: ConvertedPayment[];
@@ -15,6 +15,12 @@ export interface AIToolContext {
   failedPayments: FailedPayment[];
   categories: Category[];
   bankSenders: BankSender[];
+  /** Live merchant-override rows. Write tools (apply_category_override)
+   *  read this to find an existing row's id so updates reuse it instead
+   *  of failing the unique-merchant constraint. Read tools also have
+   *  access in case the model wants to reason about which merchants
+   *  have been manually re-categorised. */
+  overrides: MerchantCategoryOverride[];
   now: Date;
   /** Override-aware category-name lookup for a merchant. Honours the
    *  user's manual `merchantCategoryOverrides` rows; falls back to the

--- a/client/src/lib/ai/tools/write.ts
+++ b/client/src/lib/ai/tools/write.ts
@@ -24,7 +24,6 @@
 
 import { id } from "@instantdb/react";
 import { db } from "../../instant";
-import { DEFAULT_CATEGORIES } from "../../utils";
 import type { AITool } from "./types";
 
 const CATEGORY_PALETTE = [
@@ -89,21 +88,16 @@ const createCategory: AITool = {
       throw new Error("`name` is required and must be a non-empty string.");
     }
 
-    // Reject duplicate names case-insensitively. The user can have a
-    // "Coffee" category and not see a confusing "Coffee" / "coffee"
-    // pair after the assistant's call. Better to surface the collision
-    // as a tool error so the model can decide what to do (mention the
-    // existing category, suggest a different name, etc.) than silently
-    // create a parallel one. Check both DB-backed categories AND the
-    // hardcoded DEFAULT_CATEGORIES — `Subscriptions` may not be in the
-    // user's DB yet but it's a real category nonetheless.
-    const existingDbHit = ctx.categories.find(
+    // Reject duplicate names case-insensitively. Use the merged live
+    // category list so we catch BOTH persisted DB rows AND
+    // DEFAULT_CATEGORIES that aren't yet seeded — the latter is still
+    // a real category in the regex categoriser, so a parallel
+    // "Subscriptions" would still produce duplicates in pickers.
+    // Live getter so a category created earlier in the same agentic
+    // loop is visible here.
+    const existing = ctx.getAllCategories().find(
       (c) => c.name.toLowerCase() === name.toLowerCase()
     );
-    const existingDefaultHit = DEFAULT_CATEGORIES.find(
-      (c) => c.name.toLowerCase() === name.toLowerCase()
-    );
-    const existing = existingDbHit ?? existingDefaultHit;
     if (existing) {
       throw new Error(
         `A category named "${existing.name}" already exists. The user can move transactions into it without creating a new one.`
@@ -167,13 +161,15 @@ const applyCategoryOverride: AITool = {
       throw new Error("`categoryId` is required.");
     }
 
-    // Validate the categoryId resolves — either to a DB category or a
-    // default. A bogus id silently writes a dangling override and the
+    // Validate the categoryId resolves against the merged live list.
+    // A bogus id silently writes a dangling override and the
     // categorizer's defensive fallback hides the bug. Surface as a
-    // tool error so the model corrects itself.
-    const targetDb = ctx.categories.find((c) => c.id === categoryId);
-    const targetDefault = DEFAULT_CATEGORIES.find((c) => c.id === categoryId);
-    const target = targetDb ?? targetDefault;
+    // tool error so the model corrects itself. Live getter so a
+    // category created EARLIER IN THE SAME AGENTIC LOOP is visible
+    // here — without that, "create Coffee shops" + "move Skola to
+    // Coffee shops" in one assistant turn would fail validation on
+    // the second call.
+    const target = ctx.getAllCategories().find((c) => c.id === categoryId);
     if (!target) {
       throw new Error(
         `No category with id "${categoryId}". Call list_categories first to see the valid ids.`
@@ -182,10 +178,9 @@ const applyCategoryOverride: AITool = {
 
     // Reuse the existing override row if there is one — keeps the
     // createdAt timestamp stable AND avoids the unique-merchant
-    // constraint failing on a fresh id() write. ctx.overrides is
-    // populated from useMerchantOverrides() so it reflects the live
-    // DB state without needing a queryOnce round-trip.
-    const existing = ctx.overrides.find(
+    // constraint failing on a fresh id() write. Live getter so an
+    // override applied earlier in the same agentic loop is visible.
+    const existing = ctx.getOverrides().find(
       (o) => o.merchant.toLowerCase() === merchant.toLowerCase()
     );
 

--- a/client/src/lib/ai/tools/write.ts
+++ b/client/src/lib/ai/tools/write.ts
@@ -1,0 +1,210 @@
+// Write tools the assistant can call to mutate the user's data.
+// Unlike the readonly tools, these have side effects in InstantDB.
+//
+// Auto-apply policy (from issue #29):
+//   - CREATE  → executes immediately (reversible via /categories × button
+//               or CategoryPicker's "Clear override" button)
+//   - EDIT    → would require confirm. Not in this PR — see issue #29
+//               for the discussion. Replacing an existing override is
+//               technically an EDIT but the blast radius is small (at
+//               most one merchant's category) and the user can clear it
+//               in /transactions, so apply_category_override permits
+//               the replace case.
+//   - DELETE  → not exposed as tools. /categories has a × button for
+//               categories; /transactions' CategoryPicker has a Clear
+//               Override button. Both are 1-click UI actions, so the
+//               assistant tells the user to use them rather than
+//               carrying confirm-card UX in chat.
+//
+// Tools call `db.transact()` directly via the imported singleton
+// (matches the pattern in client/src/hooks/useCategories.ts and
+// useMerchantOverrides.ts). The singleton handles the demo-mode swap
+// in dev, so writes against `?demo=1` mutate the in-memory store and
+// never touch the user's real InstantDB app.
+
+import { id } from "@instantdb/react";
+import { db } from "../../instant";
+import { DEFAULT_CATEGORIES } from "../../utils";
+import type { AITool } from "./types";
+
+const CATEGORY_PALETTE = [
+  "#FF5A3A", // coral
+  "#4BD9A2", // emerald
+  "#6AA3FF", // azure
+  "#E8A05A", // amber
+  "#B38DF7", // violet
+  "#FF7A9E", // rose
+  "#F1B84A", // gold
+  "#6b7280", // slate (matches Other)
+];
+
+const CATEGORY_ICONS = ["◐", "◆", "◉", "✦", "✧", "◇", "✶", "◈"];
+
+/** Pick a deterministic-but-varied default for color/icon when the model
+ *  doesn't supply them. The hash is derived from the category name so
+ *  re-running create_category with the same name returns the same
+ *  visual identity. */
+function pickDefaults(name: string): { color: string; icon: string } {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+  }
+  return {
+    color: CATEGORY_PALETTE[hash % CATEGORY_PALETTE.length],
+    icon: CATEGORY_ICONS[hash % CATEGORY_ICONS.length],
+  };
+}
+
+const createCategory: AITool = {
+  definition: {
+    name: "create_category",
+    description:
+      "Creates a new spending category. AUTO-APPLIES — the new category appears immediately in the user's category list with no confirmation step. Returns the new category's id and name. The user can rename or delete the category at /categories. Call this when the user asks to make, add, or create a new category, or when they ask to organize transactions in a way that needs a category that doesn't exist yet.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description:
+            "Display name for the new category (e.g. 'Coffee shops', 'Pet care', 'Side hustle expenses'). Required.",
+        },
+        color: {
+          type: "string",
+          description:
+            "Optional hex color for the category dot (e.g. '#FF5A3A'). If omitted, a default is picked deterministically from the name.",
+        },
+        icon: {
+          type: "string",
+          description:
+            "Optional one-character glyph rendered next to the category name. If omitted, a default is picked deterministically from the name.",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  statusText: "Creating the category…",
+  executor: async (input, ctx) => {
+    const name = typeof input.name === "string" ? input.name.trim() : "";
+    if (!name) {
+      throw new Error("`name` is required and must be a non-empty string.");
+    }
+
+    // Reject duplicate names case-insensitively. The user can have a
+    // "Coffee" category and not see a confusing "Coffee" / "coffee"
+    // pair after the assistant's call. Better to surface the collision
+    // as a tool error so the model can decide what to do (mention the
+    // existing category, suggest a different name, etc.) than silently
+    // create a parallel one. Check both DB-backed categories AND the
+    // hardcoded DEFAULT_CATEGORIES — `Subscriptions` may not be in the
+    // user's DB yet but it's a real category nonetheless.
+    const existingDbHit = ctx.categories.find(
+      (c) => c.name.toLowerCase() === name.toLowerCase()
+    );
+    const existingDefaultHit = DEFAULT_CATEGORIES.find(
+      (c) => c.name.toLowerCase() === name.toLowerCase()
+    );
+    const existing = existingDbHit ?? existingDefaultHit;
+    if (existing) {
+      throw new Error(
+        `A category named "${existing.name}" already exists. The user can move transactions into it without creating a new one.`
+      );
+    }
+
+    const defaults = pickDefaults(name);
+    const color = typeof input.color === "string" ? input.color : defaults.color;
+    const icon = typeof input.icon === "string" ? input.icon : defaults.icon;
+
+    const newId = id();
+    await db.transact(
+      db.tx.categories[newId].update({
+        name,
+        color,
+        icon,
+        isDefault: false,
+      })
+    );
+
+    return {
+      id: newId,
+      name,
+      color,
+      icon,
+      created: true,
+    };
+  },
+};
+
+const applyCategoryOverride: AITool = {
+  definition: {
+    name: "apply_category_override",
+    description:
+      "Maps a merchant to a specific category — every transaction (past and future) from that merchant will categorise under the chosen category instead of the auto-detected one. AUTO-APPLIES (no confirm). Use this when the user asks to move a merchant's transactions to a different category, e.g. 'put all Skola transactions in Coffee shops' or 'move Starbucks to Dining.' If the user wants multiple merchants moved to the same category, call this tool once per merchant. The user can clear the override anytime by clicking the merchant's category badge in /transactions and choosing 'Clear override.'",
+    inputSchema: {
+      type: "object",
+      properties: {
+        merchant: {
+          type: "string",
+          description:
+            "The merchant string to map (case-insensitive in matching, but stored as the user wrote it for display). Required.",
+        },
+        categoryId: {
+          type: "string",
+          description:
+            "The id of the category to map the merchant to. Use list_categories first if you don't already know the id. Required.",
+        },
+      },
+      required: ["merchant", "categoryId"],
+    },
+  },
+  statusText: "Applying the category override…",
+  executor: async (input, ctx) => {
+    const merchant = typeof input.merchant === "string" ? input.merchant.trim() : "";
+    const categoryId = typeof input.categoryId === "string" ? input.categoryId : "";
+    if (!merchant) {
+      throw new Error("`merchant` is required and must be a non-empty string.");
+    }
+    if (!categoryId) {
+      throw new Error("`categoryId` is required.");
+    }
+
+    // Validate the categoryId resolves — either to a DB category or a
+    // default. A bogus id silently writes a dangling override and the
+    // categorizer's defensive fallback hides the bug. Surface as a
+    // tool error so the model corrects itself.
+    const targetDb = ctx.categories.find((c) => c.id === categoryId);
+    const targetDefault = DEFAULT_CATEGORIES.find((c) => c.id === categoryId);
+    const target = targetDb ?? targetDefault;
+    if (!target) {
+      throw new Error(
+        `No category with id "${categoryId}". Call list_categories first to see the valid ids.`
+      );
+    }
+
+    // Reuse the existing override row if there is one — keeps the
+    // createdAt timestamp stable AND avoids the unique-merchant
+    // constraint failing on a fresh id() write. ctx.overrides is
+    // populated from useMerchantOverrides() so it reflects the live
+    // DB state without needing a queryOnce round-trip.
+    const existing = ctx.overrides.find(
+      (o) => o.merchant.toLowerCase() === merchant.toLowerCase()
+    );
+
+    const opId = existing?.id ?? id();
+    await db.transact(
+      db.tx.merchantCategoryOverrides[opId].update({
+        merchant,
+        categoryId,
+        createdAt: existing?.createdAt ?? Date.now(),
+      })
+    );
+
+    return {
+      merchant,
+      categoryId,
+      categoryName: target.name,
+      replacedExistingOverride: !!existing,
+    };
+  },
+};
+
+export const WRITE_TOOLS: AITool[] = [createCategory, applyCategoryOverride];

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -6,7 +6,7 @@ import { AreaChart, Donut, HBar } from "../ink/charts";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedPayments } from "../hooks/useTransactions";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
-import { DEFAULT_CATEGORIES, type InkCategory } from "../lib/utils";
+import { type InkCategory } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { useRangeState } from "../hooks/useRangeState";
 import { isInRange, rangeToDateParams } from "../lib/dateRange";
@@ -27,7 +27,7 @@ export function Categories() {
   const now = new Date();
 
   const { payments } = useConvertedPayments();
-  const { getCategory, categorize: categorizeId } = useCategorizer();
+  const { getCategory, categorize: categorizeId, allCategories } = useCategorizer();
   const trend = useMonthlyTrend(6);
   const { range, props: rangeProps } = useRangeState("Month");
 
@@ -61,13 +61,13 @@ export function Categories() {
   }, [cats, selected]);
 
   const selectedId = selected || cats[0]?.cat;
-  const selCat = DEFAULT_CATEGORIES.find((c) => c.id === selectedId);
+  const selCat = allCategories.find((c) => c.id === selectedId);
   const selData = cats.find((c) => c.cat === selectedId);
 
   const catTrend = useMemo(() => {
     const keys = trend.map((m) => m.key);
     const perCat: Record<string, { key: string; value: number }[]> = {};
-    for (const c of DEFAULT_CATEGORIES) {
+    for (const c of allCategories) {
       perCat[c.id] = keys.map((k) => ({ key: k, value: 0 }));
     }
     for (const p of payments) {
@@ -79,7 +79,7 @@ export function Categories() {
       if (perCat[catId]) perCat[catId][idx].value += p.gelAmount;
     }
     return { keys, perCat, labels: trend.map((m) => m.label.slice(0, 3)) };
-  }, [payments, trend]);
+  }, [payments, trend, allCategories, categorizeId]);
 
   const selMerchants = useMemo(() => {
     const map: Record<string, { merchant: string; total: number; count: number }> = {};

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -8,6 +8,7 @@ import { useConvertedPayments } from "../hooks/useTransactions";
 import { useMonthlyTrend } from "../hooks/useMonthlyTrend";
 import { type InkCategory } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
+import { useCategories, useCategoryActions } from "../hooks/useCategories";
 import { useRangeState } from "../hooks/useRangeState";
 import { isInRange, rangeToDateParams } from "../lib/dateRange";
 import { formatCompact, formatLocalDay, monthKey } from "../ink/format";
@@ -28,8 +29,36 @@ export function Categories() {
 
   const { payments } = useConvertedPayments();
   const { getCategory, categorize: categorizeId, allCategories } = useCategorizer();
+  const { categories: dbCategories } = useCategories();
+  const { deleteCategory } = useCategoryActions();
   const trend = useMonthlyTrend(6);
   const { range, props: rangeProps } = useRangeState("Month");
+
+  // A category row is deletable when there's a DB row with isDefault: false.
+  // Hard-coded DEFAULT_CATEGORIES that haven't been seeded into the DB
+  // are never deletable (they'd just re-appear from the regex
+  // categoriser's id list). Default-bucket categories (from
+  // initializeDefaultCategories) are likewise not deletable to preserve
+  // the spending mix invariant.
+  const deletableIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const c of dbCategories) {
+      if (!c.isDefault) set.add(c.id);
+    }
+    return set;
+  }, [dbCategories]);
+
+  const handleDelete = async (catId: string, catName: string) => {
+    const txCount = payments.filter(
+      (p) => p.gelAmount !== null && categorizeId(p.merchant, p.rawMessage) === catId
+    ).length;
+    const message = txCount === 0
+      ? `Delete "${catName}"? This category has no transactions assigned to it.`
+      : `Delete "${catName}"? ${txCount} transaction${txCount === 1 ? "" : "s"} currently categorise here and will fall back to the auto category. Any merchant-overrides pointing at this category will be removed.`;
+    if (!window.confirm(message)) return;
+    if (selected === catId) setSelected(null);
+    await deleteCategory(catId);
+  };
 
   const monthPayments = useMemo(
     () => payments.filter((p) => isInRange(p.transactionDate, range)),
@@ -159,20 +188,20 @@ export function Categories() {
             {cats.map((c) => {
               const pct = (c.total / total) * 100;
               const active = c.cat === selectedId;
+              const deletable = deletableIds.has(c.cat);
               return (
-                <button
+                <div
                   key={c.cat}
+                  className="category-row"
                   onClick={() => setSelected(c.cat)}
                   style={{
                     display: "flex",
                     alignItems: "center",
                     gap: 10,
                     padding: "10px 12px",
-                    border: "none",
                     cursor: "pointer",
                     borderRadius: 10,
                     background: active ? T.panelAlt : "transparent",
-                    textAlign: "left",
                   }}
                 >
                   <span style={{ width: 8, height: 8, borderRadius: 4, background: c.meta.color }} />
@@ -195,7 +224,34 @@ export function Categories() {
                   >
                     ₾{Math.round(c.total)}
                   </span>
-                </button>
+                  {deletable && (
+                    <button
+                      type="button"
+                      title={`Delete "${c.meta.name}"`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(c.cat, c.meta.name);
+                      }}
+                      style={{
+                        width: 22,
+                        height: 22,
+                        borderRadius: 11,
+                        border: `1px solid ${T.line}`,
+                        background: "transparent",
+                        color: T.dim,
+                        fontSize: 12,
+                        lineHeight: 1,
+                        cursor: "pointer",
+                        flexShrink: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
               );
             })}
           </div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -11,7 +11,7 @@ import { useCredits, useRangeCredits } from "../hooks/useCredits";
 import { useRangeState } from "../hooks/useRangeState";
 import { previousRange, rangeToDateParams } from "../lib/dateRange";
 import { formatCompact, formatLocalDay } from "../ink/format";
-import { DEFAULT_CATEGORIES } from "../lib/utils";
+import { type InkCategory } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { isWithinInterval, endOfMonth, differenceInCalendarDays } from "date-fns";
 
@@ -54,7 +54,7 @@ export function Dashboard() {
   // isWithinInterval the aggregator hooks use so the donut total
   // always reconciles with stats.total.
   const byCategory = useMemo(() => {
-    const map: Record<string, { total: number; count: number; meta: typeof DEFAULT_CATEGORIES[number] }> = {};
+    const map: Record<string, { total: number; count: number; meta: InkCategory }> = {};
     for (const p of payments) {
       if (p.gelAmount === null) continue;
       if (!isWithinInterval(new Date(p.transactionDate), { start: range.start, end: range.end })) continue;

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -7,7 +7,6 @@ import { useConvertedPayments, useFailedPayments } from "../hooks/useTransaction
 import { useBankSenders } from "../hooks/useBankSenders";
 import { useRangeState } from "../hooks/useRangeState";
 import { isInRange, isValidIsoDateRange } from "../lib/dateRange";
-import { DEFAULT_CATEGORIES } from "../lib/utils";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { currencySymbol, formatLocalDay, parseLocalDay } from "../ink/format";
 
@@ -19,7 +18,7 @@ export function Transactions() {
   const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
   const { senders } = useBankSenders();
-  const { getCategory, categorize: categorizeId } = useCategorizer();
+  const { getCategory, categorize: categorizeId, allCategories } = useCategorizer();
   // Drill-down search params accepted on first paint. Anything that doesn't
   // match falls through to the unfiltered default — chart drill-downs can
   // freely add params without breaking the page if a future link mistypes
@@ -32,7 +31,7 @@ export function Transactions() {
   const initialCat = (() => {
     const raw = searchParams.get("category");
     if (!raw) return "all";
-    return DEFAULT_CATEGORIES.some((c) => c.id === raw) ? raw : "all";
+    return allCategories.some((c) => c.id === raw) ? raw : "all";
   })();
   const initialMerchant = searchParams.get("merchant") || "";
   const initialCustom = (() => {
@@ -246,7 +245,7 @@ export function Transactions() {
             }}
           >
             <option value="all">All categories</option>
-            {DEFAULT_CATEGORIES.map((c) => (
+            {allCategories.map((c) => (
               <option key={c.id} value={c.id}>
                 {c.name}
               </option>

--- a/docs/e2e/assistant.md
+++ b/docs/e2e/assistant.md
@@ -99,6 +99,98 @@ Open `http://localhost:5173/assistant`.
 
 ---
 
+## Write tools (issue #29)
+
+These tests cover the assistant's write-tool surface. v1 ships two CREATE-type
+tools (`create_category`, `apply_category_override`), both auto-apply. EDIT
+and DELETE happen via UI affordances (the × button on `/categories` and the
+"Clear override" button in `CategoryPicker` on `/transactions`).
+
+### T-AI-07 — `create_category` auto-applies and renders end-to-end
+
+**Steps**
+1. Start a fresh assistant conversation.
+2. Send: `"Make a new category called Coffee shops."`
+3. After the response, navigate to `/categories`.
+4. After that, navigate to `/transactions` and open the category dropdown filter.
+
+**Expected**
+- Chat shows a `TOOL CALL create_category` pill (sub-second).
+- Assistant's text response confirms the category was created (exact wording drifts).
+- `/categories` left list shows `Coffee shops` with a small × delete button next to its row (it's deletable because `isDefault: false`).
+- `/transactions` category dropdown includes `Coffee shops` as a filter option.
+- The category persists across page reloads.
+
+### T-AI-08 — `create_category` rejects duplicate names
+
+**Steps**
+1. After T-AI-07 (or with `Coffee shops` already created), send: `"Make a coffee shops category."`
+
+**Expected**
+- The tool errors. The model surfaces the existing category instead of creating a parallel one (e.g. "You already have a Coffee shops category — want me to move transactions into it instead?").
+- Duplicate detection is case-insensitive: `"Coffee Shops"`, `"coffee shops"`, `"COFFEE SHOPS"` all collide with `"Coffee shops"`.
+- Default categories also collide: `"Make a Groceries category"` should fail with the same response.
+
+### T-AI-09 — `apply_category_override` moves a merchant
+
+**Pre:** at least one `Coffee shops` category exists (run T-AI-07 first if not).
+
+**Steps**
+1. Send: `"Move all my Carrefour transactions to Coffee shops."` (substitute any merchant present in your demo data — Carrefour, Spotify, IKEA, etc.)
+2. Wait for the response.
+3. Navigate to `/transactions`.
+4. Filter by category = Coffee shops.
+
+**Expected**
+- The model calls `apply_category_override` once with `merchant=Carrefour, categoryId=<coffee-shops-id>`.
+- The tool result includes `categoryName: "Coffee shops"` and `replacedExistingOverride: false`.
+- `/transactions` filtered by Coffee shops shows all the Carrefour rows that previously categorised as Groceries.
+- Spending mix on `/` (Dashboard) re-allocates: Coffee shops now has the Carrefour total, Groceries has correspondingly less.
+
+### T-AI-10 — `apply_category_override` is reversible via the UI
+
+**Pre:** T-AI-09 just ran (Carrefour is overridden to Coffee shops).
+
+**Steps**
+1. Open `/transactions`. Find any Carrefour row.
+2. Click the merchant's category badge.
+3. Click "Clear override · use the auto category".
+4. Refresh.
+
+**Expected**
+- The CategoryPicker dropdown now lists `Coffee shops` alongside the default categories (the picker uses `allCategories` per the foundation commit).
+- After clicking "Clear override", every Carrefour row reverts to "Groceries" (the auto-detected category).
+- Spending mix on `/` matches what it was before T-AI-09.
+
+### T-AI-11 — Delete a category from `/categories`
+
+**Pre:** at least one user-created category exists (run T-AI-07 if not). Bonus: an override targeting that category exists (run T-AI-09 first).
+
+**Steps**
+1. Open `/categories`.
+2. Click the × button on the user-created category row.
+3. Confirm the dialog.
+
+**Expected**
+- The category disappears from the left list.
+- Any merchant overrides pointing at the deleted category are also cleaned up — the affected merchants revert to their auto-detected category in `/transactions`.
+- The dialog message reflects what's about to happen: empty category vs. N transactions affected.
+- Default categories (those with `isDefault: true` in DB or hardcoded in `DEFAULT_CATEGORIES`) do NOT show a × button.
+
+### T-AI-12 — Multi-write turn (multiple `apply_category_override` in one response)
+
+**Pre:** `Coffee shops` exists.
+
+**Steps**
+1. Send: `"Move my Starbucks, Coffee LAB, and Skola transactions to Coffee shops."` (substitute three merchants present in your data).
+
+**Expected**
+- The assistant emits 3 `TOOL CALL apply_category_override` pills in sequence.
+- All three merchants now show "Coffee shops" in `/transactions`.
+- If a merchant doesn't exist in the data, the tool still succeeds (it creates an override row even if no transactions currently match) — the model should tell the user how many transactions are now mapped (0 if the merchant has no transactions yet).
+
+---
+
 ## T-AI-06 — Side-panel scrolling works (Layout-overflow regression guard)
 
 **Why this exists:** PR #20 set Layout's `<main>` to `overflow: auto` to give the chat a bounded viewport, then PR #27 reverted that to keep document scroll working everywhere else, and instead wrapped only the assistant page in `calc(100vh - 56px)`. This test confirms both the chat scroller AND the input row layout still work after the rewrap.


### PR DESCRIPTION
**Phase 1 of [#29](https://github.com/tornikegomareli/Xarji/issues/29).** Replaces the closed PR #31 with a wider scope that addresses Codex's two findings: custom categories now flow through the rest of the app, and a delete UI on \`/categories\` provides the rollback path the auto-apply policy depended on.

## What ships

Two write tools the assistant can call:

| Tool | Effect | Apply policy |
|---|---|---|
| \`create_category\` | Adds a new category | Auto |
| \`apply_category_override\` | Maps merchant → category (creates or replaces the per-merchant override) | Auto |

EDIT and DELETE happen via UI affordances:
- **Delete a category**: × button on each non-default row in \`/categories\`. Cleans up dangling overrides in the same transact call.
- **Clear an override**: existing CategoryPicker on \`/transactions\` (open the merchant's category badge → \"Clear override\").

The assistant's system prompt is updated to describe both tools AND to point users at the UI for actions that aren't exposed as tools (so it stops saying \"I can't do that\" with no follow-up).

## Why \"auto-apply\" is now actually safe

PR #31 was closed because Codex correctly flagged that:
1. \`create_category\` wrote rows the rest of the app couldn't use (categorizer, picker, dropdowns all hardcoded \`DEFAULT_CATEGORIES\`).
2. \"Auto-apply because reversible\" was a hollow claim — no UI consumed \`useCategoryActions.deleteCategory\`.

Both fixed:
1. **Foundation commit (\`63285b1\`)**: \`useCategorizer()\` now exposes \`allCategories\` — DB rows merged with \`DEFAULT_CATEGORIES\`. CategoryPicker, Transactions filter dropdown, Categories per-cat trend, Dashboard donut type all read from it. Defensive: dangling overrides (target deleted) fall back to the regex result instead of returning broken records.
2. **Delete UI commit (\`85c6478\`)**: × button on non-default category rows; confirm dialog message reflects whether the category has transactions; \`useCategoryActions.deleteCategory\` reads live overrides and includes deletes for dangling rows in the same transact call. Default categories don't show the × button.

## Why no chat-side confirm UX

Original issue framed EDIT and DELETE as needing in-chat confirm cards. Pragmatic call for v1:

- Chat-side confirm cards add real complexity (state machine, persistence shape, handler wiring, accessibility).
- Both EDIT and DELETE have 1-click UI paths that already exist (or that this PR adds).
- The assistant gracefully tells the user how to do it in the UI — verified live in the user's screenshot before this PR landed.

If user feedback is \"editing/deleting in the UI is too much friction,\" follow-up PR adds chat-side confirm cards. For now: simpler, shippable, gets the main use case (\"create a Coffee shops category and move my Starbucks/Coffee LAB/Skola transactions there\") working end-to-end.

## Verification

- Foundation typechecks across every call site (Dashboard / Transactions / Categories / CategoryPicker / Categories.tsx).
- 193 service tests pass.
- Live test (in dev with demo mode):
  - \"Make a Coffee shops category\" → category appears in \`/categories\`, in \`/transactions\` filter dropdown, with × button.
  - \"Move all my Carrefour transactions to Coffee shops\" → override applies, spending mix re-allocates.
  - \"Now delete Coffee shops\" → assistant correctly tells user to click × on \`/categories\`. User clicks × → category deleted, dangling Carrefour override cleaned up.

## E2E coverage

T-AI-07 through T-AI-12 added to \`docs/e2e/assistant.md\` (6 new tests).

## Replaces

- Closes #31 (which was closed in favor of this consolidated PR).
- Implements #29.
- Issue #28 (preserve tool_use/tool_result pairs across turns) is still open as a follow-up but not blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI assistant can now create custom categories and apply merchant-specific category overrides with persistent storage.
  * Users can delete custom categories from the Categories page.
  * Dynamic category lists throughout the app reflect both default and user-created categories.

* **Documentation**
  * Added comprehensive end-to-end test documentation for assistant write operations, category creation, overrides, and deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->