### PR TITLE
Phase A of #33: detail-panel category picker + inline new-category create

### DIFF
--- a/client/src/components/CategoryPicker.tsx
+++ b/client/src/components/CategoryPicker.tsx
@@ -10,6 +10,8 @@ import { useTheme, type InkTheme } from "../ink/theme";
 import { type InkCategory } from "../lib/utils";
 import { useMerchantOverrides } from "../hooks/useMerchantOverrides";
 import { useCategorizer } from "../hooks/useCategorizer";
+import { useCategoryActions } from "../hooks/useCategories";
+import { pickCategoryDefaults } from "../lib/categoryDefaults";
 
 export function CategoryPicker({
   merchant,
@@ -24,7 +26,17 @@ export function CategoryPicker({
   const ref = useRef<HTMLDivElement | null>(null);
   const { byMerchant, setOverride, clearOverride } = useMerchantOverrides();
   const { allCategories } = useCategorizer();
+  const { addCategory } = useCategoryActions();
   const [busy, setBusy] = useState(false);
+  // "creating mode" — user clicked "+ New category" and we render the
+  // inline name input instead of the category list. Keeps the picker
+  // self-contained: no modal, no separate component, no navigation
+  // away from the row the user is editing.
+  const [creating, setCreating] = useState(false);
+  const [draftName, setDraftName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const draftInputRef = useRef<HTMLInputElement | null>(null);
+
   const hasOverride = !!byMerchant.get(merchant.trim().toLowerCase());
 
   useEffect(() => {
@@ -32,7 +44,16 @@ export function CategoryPicker({
       if (!ref.current?.contains(e.target as Node)) onClose();
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        if (creating) {
+          // First Escape exits create mode; second Escape closes the picker.
+          setCreating(false);
+          setDraftName("");
+          setError(null);
+        } else {
+          onClose();
+        }
+      }
     };
     document.addEventListener("mousedown", onDoc);
     document.addEventListener("keydown", onKey);
@@ -40,7 +61,13 @@ export function CategoryPicker({
       document.removeEventListener("mousedown", onDoc);
       document.removeEventListener("keydown", onKey);
     };
-  }, [onClose]);
+  }, [onClose, creating]);
+
+  // Auto-focus the draft input when entering creating mode so the user
+  // can type the category name without an extra click.
+  useEffect(() => {
+    if (creating) draftInputRef.current?.focus();
+  }, [creating]);
 
   const pick = async (cat: InkCategory) => {
     if (busy) return;
@@ -64,6 +91,46 @@ export function CategoryPicker({
     }
   };
 
+  const submitNew = async () => {
+    const name = draftName.trim();
+    if (!name) {
+      setError("Name is required.");
+      return;
+    }
+    // Case-insensitive duplicate check against the merged live category
+    // list (DEFAULT_CATEGORIES + DB rows). Mirrors the AI tool's
+    // duplicate handling so the user gets the same constraint
+    // regardless of which channel they came from.
+    const existing = allCategories.find(
+      (c) => c.name.toLowerCase() === name.toLowerCase()
+    );
+    if (existing) {
+      setError(`"${existing.name}" already exists.`);
+      return;
+    }
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const defaults = pickCategoryDefaults(name);
+      const newId = await addCategory({
+        name,
+        color: defaults.color,
+        icon: defaults.icon,
+        isDefault: false,
+      });
+      // Apply the new category as the merchant's override immediately
+      // — that's what the user clicked in for, otherwise they'd have
+      // to do a second pick after creating.
+      await setOverride(merchant, newId);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <div
       ref={ref}
@@ -72,7 +139,7 @@ export function CategoryPicker({
         top: "calc(100% + 6px)",
         left: 0,
         zIndex: 100,
-        minWidth: 240,
+        minWidth: 260,
         background: T.panel,
         border: `1px solid ${T.lineStrong}`,
         borderRadius: 12,
@@ -83,48 +150,163 @@ export function CategoryPicker({
         gap: 2,
       }}
     >
-      <div
-        style={{
-          padding: "6px 10px 4px",
-          fontSize: 10,
-          color: T.dim,
-          fontFamily: T.mono,
-          letterSpacing: 0.6,
-          textTransform: "uppercase",
-        }}
-      >
-        Move {merchant} to
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", maxHeight: 280, overflowY: "auto" }}>
-        {allCategories.map((cat) => (
-          <CategoryRow
-            key={cat.id}
-            T={T}
-            cat={cat}
-            active={cat.id === current.id}
-            onPick={pick}
+      {creating ? (
+        <div style={{ padding: 4, display: "flex", flexDirection: "column", gap: 8 }}>
+          <div
+            style={{
+              fontSize: 10,
+              color: T.dim,
+              fontFamily: T.mono,
+              letterSpacing: 0.6,
+              textTransform: "uppercase",
+              padding: "0 6px",
+            }}
+          >
+            New category for {merchant}
+          </div>
+          <input
+            ref={draftInputRef}
+            value={draftName}
+            onChange={(e) => {
+              setDraftName(e.target.value);
+              if (error) setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                submitNew();
+              }
+            }}
+            placeholder="e.g. Coffee shops"
+            disabled={busy}
+            style={{
+              padding: "8px 12px",
+              background: T.panelAlt,
+              border: `1px solid ${T.line}`,
+              borderRadius: 8,
+              color: T.text,
+              fontSize: 13,
+              fontFamily: T.sans,
+              outline: "none",
+            }}
           />
-        ))}
-      </div>
-      {hasOverride && (
-        <button
-          onClick={reset}
-          disabled={busy}
-          style={{
-            marginTop: 6,
-            padding: "8px 10px",
-            background: "transparent",
-            border: `1px solid ${T.line}`,
-            borderRadius: 8,
-            color: T.muted,
-            fontSize: 11.5,
-            fontFamily: T.sans,
-            cursor: busy ? "not-allowed" : "pointer",
-            textAlign: "left",
-          }}
-        >
-          Clear override · use the auto category
-        </button>
+          {error && (
+            <div
+              style={{
+                fontSize: 11,
+                color: T.accent,
+                fontFamily: T.sans,
+                padding: "0 6px",
+              }}
+            >
+              {error}
+            </div>
+          )}
+          <div style={{ display: "flex", gap: 6, marginTop: 2 }}>
+            <button
+              onClick={submitNew}
+              disabled={busy || !draftName.trim()}
+              style={{
+                flex: 1,
+                padding: "8px 12px",
+                background: busy || !draftName.trim() ? T.panelAlt : T.accent,
+                color: busy || !draftName.trim() ? T.dim : "#fff",
+                border: "none",
+                borderRadius: 8,
+                fontSize: 12,
+                fontWeight: 600,
+                fontFamily: T.sans,
+                cursor: busy || !draftName.trim() ? "not-allowed" : "pointer",
+              }}
+            >
+              {busy ? "Creating…" : "Create + apply"}
+            </button>
+            <button
+              onClick={() => {
+                setCreating(false);
+                setDraftName("");
+                setError(null);
+              }}
+              disabled={busy}
+              style={{
+                padding: "8px 12px",
+                background: "transparent",
+                color: T.muted,
+                border: `1px solid ${T.line}`,
+                borderRadius: 8,
+                fontSize: 12,
+                fontFamily: T.sans,
+                cursor: busy ? "not-allowed" : "pointer",
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div
+            style={{
+              padding: "6px 10px 4px",
+              fontSize: 10,
+              color: T.dim,
+              fontFamily: T.mono,
+              letterSpacing: 0.6,
+              textTransform: "uppercase",
+            }}
+          >
+            Move {merchant} to
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", maxHeight: 280, overflowY: "auto" }}>
+            {allCategories.map((cat) => (
+              <CategoryRow
+                key={cat.id}
+                T={T}
+                cat={cat}
+                active={cat.id === current.id}
+                onPick={pick}
+              />
+            ))}
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 6 }}>
+            <button
+              onClick={() => setCreating(true)}
+              disabled={busy}
+              style={{
+                padding: "8px 10px",
+                background: "transparent",
+                border: `1px solid ${T.line}`,
+                borderRadius: 8,
+                color: T.text,
+                fontSize: 11.5,
+                fontFamily: T.sans,
+                cursor: busy ? "not-allowed" : "pointer",
+                textAlign: "left",
+              }}
+            >
+              + New category…
+            </button>
+            {hasOverride && (
+              <button
+                onClick={reset}
+                disabled={busy}
+                style={{
+                  padding: "8px 10px",
+                  background: "transparent",
+                  border: `1px solid ${T.line}`,
+                  borderRadius: 8,
+                  color: T.muted,
+                  fontSize: 11.5,
+                  fontFamily: T.sans,
+                  cursor: busy ? "not-allowed" : "pointer",
+                  textAlign: "left",
+                }}
+              >
+                Clear override · use the auto category
+              </button>
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/client/src/components/CategoryPicker.tsx
+++ b/client/src/components/CategoryPicker.tsx
@@ -17,10 +17,17 @@ export function CategoryPicker({
   merchant,
   current,
   onClose,
+  anchor = "left",
 }: {
   merchant: string;
   current: InkCategory;
   onClose: () => void;
+  /** Which side of the trigger the picker aligns to. "left" (default)
+   *  matches the inline use on TxRow's category badge; "right" is for
+   *  the Transactions detail panel where the trigger is on the right
+   *  edge of a narrow column and a left-anchored picker would clip
+   *  off-screen. */
+  anchor?: "left" | "right";
 }) {
   const T = useTheme();
   const ref = useRef<HTMLDivElement | null>(null);
@@ -137,7 +144,7 @@ export function CategoryPicker({
       style={{
         position: "absolute",
         top: "calc(100% + 6px)",
-        left: 0,
+        ...(anchor === "right" ? { right: 0 } : { left: 0 }),
         zIndex: 100,
         minWidth: 260,
         background: T.panel,

--- a/client/src/lib/ai/tools/write.ts
+++ b/client/src/lib/ai/tools/write.ts
@@ -24,35 +24,8 @@
 
 import { id } from "@instantdb/react";
 import { db } from "../../instant";
+import { pickCategoryDefaults } from "../../categoryDefaults";
 import type { AITool } from "./types";
-
-const CATEGORY_PALETTE = [
-  "#FF5A3A", // coral
-  "#4BD9A2", // emerald
-  "#6AA3FF", // azure
-  "#E8A05A", // amber
-  "#B38DF7", // violet
-  "#FF7A9E", // rose
-  "#F1B84A", // gold
-  "#6b7280", // slate (matches Other)
-];
-
-const CATEGORY_ICONS = ["◐", "◆", "◉", "✦", "✧", "◇", "✶", "◈"];
-
-/** Pick a deterministic-but-varied default for color/icon when the model
- *  doesn't supply them. The hash is derived from the category name so
- *  re-running create_category with the same name returns the same
- *  visual identity. */
-function pickDefaults(name: string): { color: string; icon: string } {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) {
-    hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
-  }
-  return {
-    color: CATEGORY_PALETTE[hash % CATEGORY_PALETTE.length],
-    icon: CATEGORY_ICONS[hash % CATEGORY_ICONS.length],
-  };
-}
 
 const createCategory: AITool = {
   definition: {
@@ -104,7 +77,7 @@ const createCategory: AITool = {
       );
     }
 
-    const defaults = pickDefaults(name);
+    const defaults = pickCategoryDefaults(name);
     const color = typeof input.color === "string" ? input.color : defaults.color;
     const icon = typeof input.icon === "string" ? input.icon : defaults.icon;
 

--- a/client/src/lib/categoryDefaults.ts
+++ b/client/src/lib/categoryDefaults.ts
@@ -1,0 +1,29 @@
+// Deterministic color + icon defaults for categories created without
+// explicit visual identity. Re-running with the same name returns the
+// same colors/glyph so a user-created category looks stable across
+// recreations (and so the AI tool and the manual UI picker pick the
+// same defaults — no drift between channels).
+
+const CATEGORY_PALETTE = [
+  "#FF5A3A", // coral
+  "#4BD9A2", // emerald
+  "#6AA3FF", // azure
+  "#E8A05A", // amber
+  "#B38DF7", // violet
+  "#FF7A9E", // rose
+  "#F1B84A", // gold
+  "#6b7280", // slate (matches Other)
+];
+
+const CATEGORY_ICONS = ["◐", "◆", "◉", "✦", "✧", "◇", "✶", "◈"];
+
+export function pickCategoryDefaults(name: string): { color: string; icon: string } {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+  }
+  return {
+    color: CATEGORY_PALETTE[hash % CATEGORY_PALETTE.length],
+    icon: CATEGORY_ICONS[hash % CATEGORY_ICONS.length],
+  };
+}

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { useTheme, useViewport } from "../ink/theme";
+import { useTheme, useViewport, type InkTheme } from "../ink/theme";
 import { Card, CardLabel, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
+import { CategoryPicker } from "../components/CategoryPicker";
 import { useConvertedPayments, useFailedPayments } from "../hooks/useTransactions";
 import { useBankSenders } from "../hooks/useBankSenders";
 import { useRangeState } from "../hooks/useRangeState";
@@ -18,7 +19,7 @@ export function Transactions() {
   const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
   const { senders } = useBankSenders();
-  const { getCategory, categorize: categorizeId, allCategories } = useCategorizer();
+  const { categorize: categorizeId, allCategories } = useCategorizer();
   // Drill-down search params accepted on first paint. Anything that doesn't
   // match falls through to the unfiltered default — chart drill-downs can
   // freely add params without breaking the page if a future link mistypes
@@ -371,20 +372,15 @@ export function Transactions() {
                 : `${currencySymbol(selected.currency)}${(selected.amount ?? 0).toFixed(2)}`}
             </div>
             <div style={{ marginTop: 20, display: "flex", flexDirection: "column", gap: 10 }}>
-              {[
-                ["When", new Date(selected.transactionDate).toLocaleString("en-US", { weekday: "short", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false })],
-                ["Card", selected.cardLastDigits ? `··${selected.cardLastDigits}` : "—"],
-                ["Bank", selected.bankSenderId],
-                ["Category", getCategory(selected.merchant, selected.rawMerchant).name],
-                selected.kind === "failed"
-                  ? ["Reason", selected.failureReason || "—"]
-                  : ["Points", selected.plusEarned ? `+${selected.plusEarned}` : "—"],
-              ].map(([k, v], i) => (
-                <div key={i} style={{ display: "flex", justifyContent: "space-between", padding: "8px 0", borderBottom: `1px solid ${T.line}` }}>
-                  <span style={{ fontSize: 12, color: T.muted, fontFamily: T.sans }}>{k}</span>
-                  <span style={{ fontSize: 12.5, color: T.text, fontFamily: T.sans, fontWeight: 600 }}>{v}</span>
-                </div>
-              ))}
+              <DetailRow T={T} k="When" v={new Date(selected.transactionDate).toLocaleString("en-US", { weekday: "short", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false })} />
+              <DetailRow T={T} k="Card" v={selected.cardLastDigits ? `··${selected.cardLastDigits}` : "—"} />
+              <DetailRow T={T} k="Bank" v={selected.bankSenderId} />
+              <CategoryDetailRow T={T} merchant={selected.merchant} rawMerchant={selected.rawMerchant} />
+              {selected.kind === "failed" ? (
+                <DetailRow T={T} k="Reason" v={selected.failureReason || "—"} />
+              ) : (
+                <DetailRow T={T} k="Points" v={selected.plusEarned ? `+${selected.plusEarned}` : "—"} />
+              )}
             </div>
             <div style={{ marginTop: 18 }}>
               <CardLabel>Raw SMS</CardLabel>
@@ -409,6 +405,80 @@ export function Transactions() {
           </Card>
         )}
       </div>
+    </div>
+  );
+}
+
+function DetailRow({ T, k, v }: { T: InkTheme; k: string; v: string }) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", padding: "8px 0", borderBottom: `1px solid ${T.line}` }}>
+      <span style={{ fontSize: 12, color: T.muted, fontFamily: T.sans }}>{k}</span>
+      <span style={{ fontSize: 12.5, color: T.text, fontFamily: T.sans, fontWeight: 600 }}>{v}</span>
+    </div>
+  );
+}
+
+/**
+ * Special-cased detail-panel row for Category — clicking the value
+ * opens the CategoryPicker anchored to this row, with a "+ Create new
+ * category" inline option. Persists as a per-merchant override (same
+ * model the inline picker uses on the row's category badge).
+ */
+function CategoryDetailRow({
+  T,
+  merchant,
+  rawMerchant,
+}: {
+  T: InkTheme;
+  merchant: string;
+  rawMerchant?: string;
+}) {
+  const { getCategory } = useCategorizer();
+  const [open, setOpen] = useState(false);
+  const cat = getCategory(merchant, rawMerchant);
+  const pickerMerchant = (merchant || rawMerchant || "").trim();
+  const canEdit = pickerMerchant.length > 0;
+
+  return (
+    <div style={{ position: "relative", borderBottom: `1px solid ${T.line}`, paddingBottom: 8 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 0 0" }}>
+        <span style={{ fontSize: 12, color: T.muted, fontFamily: T.sans }}>Category</span>
+        <button
+          type="button"
+          onClick={() => canEdit && setOpen((o) => !o)}
+          disabled={!canEdit}
+          title={canEdit ? "Change category for all transactions from this merchant" : "Merchant unknown"}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "4px 8px",
+            border: `1px solid ${T.line}`,
+            borderRadius: 8,
+            background: open ? T.panelAlt : "transparent",
+            color: T.text,
+            fontFamily: T.sans,
+            fontSize: 12.5,
+            fontWeight: 600,
+            cursor: canEdit ? "pointer" : "not-allowed",
+          }}
+        >
+          <span style={{ width: 8, height: 8, borderRadius: 4, background: cat.color }} />
+          {cat.name}
+          {canEdit && (
+            <span style={{ fontSize: 9, color: T.dim, marginLeft: 4 }}>{open ? "▴" : "▾"}</span>
+          )}
+        </button>
+      </div>
+      {open && canEdit && (
+        <div style={{ position: "absolute", right: 0, top: "100%", zIndex: 50 }}>
+          <CategoryPicker
+            merchant={pickerMerchant}
+            current={cat}
+            onClose={() => setOpen(false)}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -471,13 +471,12 @@ function CategoryDetailRow({
         </button>
       </div>
       {open && canEdit && (
-        <div style={{ position: "absolute", right: 0, top: "100%", zIndex: 50 }}>
-          <CategoryPicker
-            merchant={pickerMerchant}
-            current={cat}
-            onClose={() => setOpen(false)}
-          />
-        </div>
+        <CategoryPicker
+          merchant={pickerMerchant}
+          current={cat}
+          onClose={() => setOpen(false)}
+          anchor="right"
+        />
       )}
     </div>
   );


### PR DESCRIPTION
**Phase A of [#33](https://github.com/tornikegomareli/Xarji/issues/33).** The first half-session of the categories-v2 work — pure UX, no schema changes, no AI tools touched (other than de-duping a helper).

## What ships

- CategoryPicker gains a **\"+ New category…\"** button at the bottom of the dropdown. Click toggles the picker into a small inline form (auto-focused name input, deterministic color/icon defaults from a hash of the name, case-insensitive duplicate-name validation, Create + apply / Cancel). On submit, the picker creates the category AND applies it as the merchant override in one step.
- The Transactions **detail panel's Category row** is now a clickable button (color dot + name + ▾ chevron) instead of static text. Click anchors a CategoryPicker below it. Reuses the same dropdown the inline-row picker uses, so the new \"+ New category…\" works there too.

## What this does not do (from #33's open questions)

- **Per-transaction overrides** (vs. per-merchant) — deferred. The detail-panel picker still writes a merchant-level override, same as the inline picker on each transaction row. If user feedback says \"I need to mark THIS Carrefour as Other without affecting the rest,\" we add a \`payments.categoryOverride\` schema field in Phase A.1.
- **Full /categories CRUD UI + AI edit/delete tools** — Phase B.
- **Exclude-from-analytics** — Phase C.

## Implementation notes

- \`pickCategoryDefaults(name)\` extracted from \`lib/ai/tools/write.ts\` to a new \`lib/categoryDefaults.ts\` so the manual UI picker and the AI tool produce identical color/icon for the same name. No drift between channels.
- Detail panel's metadata rows refactored: the generic \`[k, v].map\` was uniform-only; pulling the Category row out as a special case made the rest of the rows cleaner via a small \`DetailRow\` helper.
- Picker's Escape behaviour: first press exits create mode, second press closes the picker. So a typo-then-recover doesn't accidentally close the picker entirely.

## Verification

- \`bun run build\` clean.
- 193 service tests pass.
- Live: open /transactions, select a row, click the Category badge in the detail panel, hit \"+ New category…\", type a name, Enter — category created, applied as merchant override, picker closes.

## E2E coverage

Not added in this PR — the existing T-AI-09 (apply_category_override moves a merchant) covers the underlying override behaviour. New picker UX is small enough to not warrant a separate E2E test before Phase B/C consolidate the surface.