### PR TITLE
Phase B of #33: full /categories CRUD UI + AI edit/delete tools

### DIFF
--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -52,13 +52,16 @@ Tool usage:
 - For purely conversational, educational, or general budgeting questions, a tool call is not required.
 
 Write tools:
-- The assistant can mutate the user's data via four tools: \`create_category\`, \`apply_category_override\`, \`update_category\`, \`delete_category\`.
-- All four AUTO-APPLY: they execute immediately when called, no confirmation step in chat.
-- After a successful write, you may tell the user it's done — describe what was created, renamed, or removed.
+- The assistant can mutate the user's data via three tools: \`create_category\`, \`apply_category_override\`, \`update_category\`.
+- All three AUTO-APPLY: they execute immediately when called, no confirmation step in chat.
+- After a successful write, you may tell the user it's done — describe what was created, renamed, or moved.
 - If a write tool fails (duplicate name, default category, missing id), the error result tells you why. Use that to inform the user clearly.
-- \`update_category\` and \`delete_category\` only work on user-created categories. Default categories like Groceries / Dining / Subscriptions can't be renamed or deleted from chat — the regex categoriser depends on their canonical names. Tell the user to rename a category they created themselves if they want a different label.
-- Users can also edit / delete categories directly from the dashboard UI on \`/categories\` (× to delete, ✎ to edit). Both UI and tool paths produce the same result.
-- Merchant overrides: \`apply_category_override\` creates or replaces them. To clear an override, the user opens \`/transactions\`, clicks the merchant's category badge, and chooses "Clear override" — there's no tool for this yet, so tell the user the UI path.
+- \`update_category\` only works on user-created categories. Default categories like Groceries / Dining / Subscriptions can't be renamed from chat — the regex categoriser depends on their canonical names. Tell the user to rename a category they created themselves if they want a different label.
+
+UI-only actions you can describe but not execute:
+- **Delete a category**: not a tool. Tell the user to open \`/categories\` and click the × button on the category row — the existing confirm dialog there is the right place for a destructive action. After confirming, that same code path also cleans up any merchant overrides pointing at the deleted category.
+- **Clear a single merchant override**: not a tool. Tell the user to open \`/transactions\`, click the merchant's category badge, and choose "Clear override".
+- For both: describe what would happen, name the affected merchant or category, and tell the user the UI path. Don't pretend you did it.
 
 Answer style:
 - Be concise and clear.

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -52,14 +52,13 @@ Tool usage:
 - For purely conversational, educational, or general budgeting questions, a tool call is not required.
 
 Write tools:
-- Some tools mutate the user's data: \`create_category\` and \`apply_category_override\`.
-- Both AUTO-APPLY: they execute immediately when called, no confirmation step in chat.
-- After a successful write, you may tell the user it's done — describe what was created or moved.
-- If a write tool fails, the error result tells you why. Use that to inform the user clearly.
-- The user can edit a category, delete a category, or clear an override directly from the dashboard UI:
-  - Delete a category: open Categories (\`/categories\`), click the × on the category row.
-  - Clear a merchant override: open Transactions (\`/transactions\`), click the merchant's category badge, then "Clear override".
-- For deletions or edits that don't have a tool, tell the user how to do it in the UI.
+- The assistant can mutate the user's data via four tools: \`create_category\`, \`apply_category_override\`, \`update_category\`, \`delete_category\`.
+- All four AUTO-APPLY: they execute immediately when called, no confirmation step in chat.
+- After a successful write, you may tell the user it's done — describe what was created, renamed, or removed.
+- If a write tool fails (duplicate name, default category, missing id), the error result tells you why. Use that to inform the user clearly.
+- \`update_category\` and \`delete_category\` only work on user-created categories. Default categories like Groceries / Dining / Subscriptions can't be renamed or deleted from chat — the regex categoriser depends on their canonical names. Tell the user to rename a category they created themselves if they want a different label.
+- Users can also edit / delete categories directly from the dashboard UI on \`/categories\` (× to delete, ✎ to edit). Both UI and tool paths produce the same result.
+- Merchant overrides: \`apply_category_override\` creates or replaces them. To clear an override, the user opens \`/transactions\`, clicks the merchant's category badge, and chooses "Clear override" — there's no tool for this yet, so tell the user the UI path.
 
 Answer style:
 - Be concise and clear.

--- a/client/src/lib/ai/tools/write.ts
+++ b/client/src/lib/ai/tools/write.ts
@@ -8,12 +8,14 @@
 //                / icon — pure visual, blast radius zero). Override
 //                replacement also auto-applies (one merchant, easily
 //                reverted via CategoryPicker).
-//   - DELETE   → auto-apply, scoped to non-default categories. The
-//                same useCategoryActions.deleteCategory the UI's ×
-//                button calls, including the dangling-override
-//                cleanup. Default categories error out from the tool
-//                so the assistant can't silently break the spending-
-//                mix invariant.
+//   - DELETE   → NOT a tool. The UI's × button on /categories already
+//                gates deletion behind a confirm dialog AND cleans up
+//                dangling overrides; bypassing that dialog from chat
+//                would silently destroy manual categorization state on
+//                a single mistaken model call (Codex HIGH on PR #35).
+//                The assistant can describe a deletion the user might
+//                want and tell them to click × on /categories — that
+//                routes through the existing confirm path naturally.
 //
 // Tools call `db.transact()` directly via the imported singleton
 // (matches the pattern in client/src/hooks/useCategories.ts and
@@ -261,70 +263,15 @@ const updateCategory: AITool = {
   },
 };
 
-const deleteCategory: AITool = {
-  definition: {
-    name: "delete_category",
-    description:
-      "Deletes a user-created category. AUTO-APPLIES. Any merchant overrides pointing at the deleted category are removed in the same operation, so affected transactions revert to their auto-detected category. Only works on user-created categories — default categories return an error. Use list_categories to discover ids.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-          description: "The id of the category to delete. Required.",
-        },
-      },
-      required: ["id"],
-    },
-  },
-  statusText: "Deleting the category…",
-  executor: async (input, ctx) => {
-    const id = typeof input.id === "string" ? input.id : "";
-    if (!id) throw new Error("`id` is required.");
-
-    const target = ctx.getAllCategories().find((c) => c.id === id);
-    if (!target) {
-      throw new Error(
-        `No category with id "${id}". Call list_categories to see valid ids.`
-      );
-    }
-    const dbRow = ctx.categories.find((c) => c.id === id);
-    if (!dbRow) {
-      throw new Error(
-        `"${target.name}" is a built-in category — it doesn't have a DB row to delete. Built-ins can't be removed from chat.`
-      );
-    }
-    if (dbRow.isDefault) {
-      throw new Error(
-        `"${target.name}" is a default category and can't be deleted from chat.`
-      );
-    }
-
-    // Find dangling overrides targeting this category and clean them
-    // up in the same transact call — same logic as
-    // useCategoryActions.deleteCategory.
-    const ops: unknown[] = [db.tx.categories[id].delete()];
-    let danglingOverrideCount = 0;
-    for (const o of ctx.getOverrides()) {
-      if (o.categoryId === id) {
-        ops.push(db.tx.merchantCategoryOverrides[o.id].delete());
-        danglingOverrideCount += 1;
-      }
-    }
-    await db.transact(ops as Parameters<typeof db.transact>[0]);
-
-    return {
-      id,
-      name: target.name,
-      removedOverrides: danglingOverrideCount,
-      deleted: true,
-    };
-  },
-};
+// `delete_category` deliberately not exposed as a tool. The UI's ×
+// button on /categories gates deletion behind window.confirm AND
+// triggers the dangling-override cleanup; piping the model around
+// that dialog would silently destroy manual categorization state on
+// a single mistaken model call. The assistant describes the
+// deletion the user might want and points at /categories' × button.
 
 export const WRITE_TOOLS: AITool[] = [
   createCategory,
   applyCategoryOverride,
   updateCategory,
-  deleteCategory,
 ];

--- a/client/src/lib/ai/tools/write.ts
+++ b/client/src/lib/ai/tools/write.ts
@@ -1,20 +1,19 @@
 // Write tools the assistant can call to mutate the user's data.
 // Unlike the readonly tools, these have side effects in InstantDB.
 //
-// Auto-apply policy (from issue #29):
-//   - CREATE  → executes immediately (reversible via /categories × button
-//               or CategoryPicker's "Clear override" button)
-//   - EDIT    → would require confirm. Not in this PR — see issue #29
-//               for the discussion. Replacing an existing override is
-//               technically an EDIT but the blast radius is small (at
-//               most one merchant's category) and the user can clear it
-//               in /transactions, so apply_category_override permits
-//               the replace case.
-//   - DELETE  → not exposed as tools. /categories has a × button for
-//               categories; /transactions' CategoryPicker has a Clear
-//               Override button. Both are 1-click UI actions, so the
-//               assistant tells the user to use them rather than
-//               carrying confirm-card UX in chat.
+// Auto-apply policy (decided across issue #29 + #33 reviews):
+//   - CREATE   → executes immediately (reversible via /categories ×
+//                button or CategoryPicker's "Clear override" button)
+//   - EDIT     → auto-apply for category property edits (name / color
+//                / icon — pure visual, blast radius zero). Override
+//                replacement also auto-applies (one merchant, easily
+//                reverted via CategoryPicker).
+//   - DELETE   → auto-apply, scoped to non-default categories. The
+//                same useCategoryActions.deleteCategory the UI's ×
+//                button calls, including the dangling-override
+//                cleanup. Default categories error out from the tool
+//                so the assistant can't silently break the spending-
+//                mix invariant.
 //
 // Tools call `db.transact()` directly via the imported singleton
 // (matches the pattern in client/src/hooks/useCategories.ts and
@@ -175,4 +174,157 @@ const applyCategoryOverride: AITool = {
   },
 };
 
-export const WRITE_TOOLS: AITool[] = [createCategory, applyCategoryOverride];
+const updateCategory: AITool = {
+  definition: {
+    name: "update_category",
+    description:
+      "Renames or recolors an existing category. AUTO-APPLIES — the change is reflected immediately. Only works on user-created categories (those with `isDefault: false`); default categories like Groceries / Dining / Subscriptions return an error because changing their visible identity would break the regex categoriser's mapping. At least one of `name`, `color`, `icon` must be provided. Use list_categories to discover ids.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "The id of the category to update. Required.",
+        },
+        name: {
+          type: "string",
+          description: "New display name. Optional.",
+        },
+        color: {
+          type: "string",
+          description: "New hex color (e.g. '#FF5A3A'). Optional.",
+        },
+        icon: {
+          type: "string",
+          description: "New one-character glyph for the category dot. Optional.",
+        },
+      },
+      required: ["id"],
+    },
+  },
+  statusText: "Updating the category…",
+  executor: async (input, ctx) => {
+    const id = typeof input.id === "string" ? input.id : "";
+    if (!id) throw new Error("`id` is required.");
+
+    // Validate the id resolves to a non-default DB-backed category.
+    // Defaults can't be edited safely — the regex categoriser maps
+    // merchants to canonical default ids, which would no longer match
+    // a renamed entry. (Allowing default-renames needs a canonicalId
+    // schema field — tracked as B.2 in issue #33.)
+    const target = ctx.getAllCategories().find((c) => c.id === id);
+    if (!target) {
+      throw new Error(
+        `No category with id "${id}". Call list_categories to see valid ids.`
+      );
+    }
+    const dbRow = ctx.categories.find((c) => c.id === id);
+    if (!dbRow) {
+      throw new Error(
+        `"${target.name}" is a built-in category and can't be edited from chat. The user can rename a category they created themselves on /categories.`
+      );
+    }
+    if (dbRow.isDefault) {
+      throw new Error(
+        `"${target.name}" is a default category and can't be edited from chat. The user can rename categories they created themselves on /categories.`
+      );
+    }
+
+    const updates: Record<string, string> = {};
+    if (typeof input.name === "string" && input.name.trim()) {
+      const newName = input.name.trim();
+      // Reject duplicate-name collisions against any other category
+      // (case-insensitive). The form on /categories enforces the same
+      // rule, so the rules match across channels.
+      const collide = ctx.getAllCategories().find(
+        (c) => c.id !== id && c.name.toLowerCase() === newName.toLowerCase()
+      );
+      if (collide) {
+        throw new Error(`A category named "${collide.name}" already exists.`);
+      }
+      updates.name = newName;
+    }
+    if (typeof input.color === "string") updates.color = input.color;
+    if (typeof input.icon === "string") updates.icon = input.icon;
+    if (Object.keys(updates).length === 0) {
+      throw new Error("At least one of `name`, `color`, `icon` must be provided.");
+    }
+
+    await db.transact(db.tx.categories[id].update(updates));
+
+    return {
+      id,
+      previousName: target.name,
+      ...updates,
+      updated: true,
+    };
+  },
+};
+
+const deleteCategory: AITool = {
+  definition: {
+    name: "delete_category",
+    description:
+      "Deletes a user-created category. AUTO-APPLIES. Any merchant overrides pointing at the deleted category are removed in the same operation, so affected transactions revert to their auto-detected category. Only works on user-created categories — default categories return an error. Use list_categories to discover ids.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "The id of the category to delete. Required.",
+        },
+      },
+      required: ["id"],
+    },
+  },
+  statusText: "Deleting the category…",
+  executor: async (input, ctx) => {
+    const id = typeof input.id === "string" ? input.id : "";
+    if (!id) throw new Error("`id` is required.");
+
+    const target = ctx.getAllCategories().find((c) => c.id === id);
+    if (!target) {
+      throw new Error(
+        `No category with id "${id}". Call list_categories to see valid ids.`
+      );
+    }
+    const dbRow = ctx.categories.find((c) => c.id === id);
+    if (!dbRow) {
+      throw new Error(
+        `"${target.name}" is a built-in category — it doesn't have a DB row to delete. Built-ins can't be removed from chat.`
+      );
+    }
+    if (dbRow.isDefault) {
+      throw new Error(
+        `"${target.name}" is a default category and can't be deleted from chat.`
+      );
+    }
+
+    // Find dangling overrides targeting this category and clean them
+    // up in the same transact call — same logic as
+    // useCategoryActions.deleteCategory.
+    const ops: unknown[] = [db.tx.categories[id].delete()];
+    let danglingOverrideCount = 0;
+    for (const o of ctx.getOverrides()) {
+      if (o.categoryId === id) {
+        ops.push(db.tx.merchantCategoryOverrides[o.id].delete());
+        danglingOverrideCount += 1;
+      }
+    }
+    await db.transact(ops as Parameters<typeof db.transact>[0]);
+
+    return {
+      id,
+      name: target.name,
+      removedOverrides: danglingOverrideCount,
+      deleted: true,
+    };
+  },
+};
+
+export const WRITE_TOOLS: AITool[] = [
+  createCategory,
+  applyCategoryOverride,
+  updateCategory,
+  deleteCategory,
+];

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -91,8 +91,30 @@ export function Categories() {
       map[cat.id].total += p.gelAmount;
       map[cat.id].count += 1;
     }
-    return Object.values(map).sort((a, b) => b.total - a.total);
-  }, [monthPayments, getCategory]);
+    const aggregated = Object.values(map).sort((a, b) => b.total - a.total);
+
+    // Render user-created (non-default) categories that have zero spend
+    // in the active range AT THE BOTTOM of the list so they're still
+    // editable / deletable. Without this, a freshly-created "Pet care"
+    // disappears from the list immediately because the spend
+    // aggregation skips it (no transactions assigned yet) — the user
+    // would think the create silently failed. Codex flagged the
+    // empty-category invisibility on PR #35.
+    const visibleIds = new Set(aggregated.map((c) => c.cat));
+    const empties: CatAgg[] = [];
+    for (const c of dbCategories) {
+      if (c.isDefault) continue;
+      if (visibleIds.has(c.id)) continue;
+      const meta: InkCategory = {
+        id: c.id,
+        name: c.name,
+        color: c.color,
+        icon: c.icon,
+      };
+      empties.push({ cat: c.id, total: 0, count: 0, meta });
+    }
+    return [...aggregated, ...empties];
+  }, [monthPayments, getCategory, dbCategories]);
 
   const total = cats.reduce((s, c) => s + c.total, 0);
   const [selected, setSelected] = useState<string | null>(null);

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useTheme, useViewport } from "../ink/theme";
+import { useTheme, useViewport, type InkTheme } from "../ink/theme";
 import { Card, CardLabel, CardTitle, LinkBtn, PageHeader } from "../ink/primitives";
 import { AreaChart, Donut, HBar } from "../ink/charts";
 import { TxRow, type InkTx } from "../ink/TxRow";
@@ -12,7 +12,17 @@ import { useCategories, useCategoryActions } from "../hooks/useCategories";
 import { useRangeState } from "../hooks/useRangeState";
 import { isInRange, rangeToDateParams } from "../lib/dateRange";
 import { formatCompact, formatLocalDay, monthKey } from "../ink/format";
+import { pickCategoryDefaults } from "../lib/categoryDefaults";
 import { endOfMonth, format } from "date-fns";
+
+// Preset palettes the form lets the user pick from. Mirrors
+// pickCategoryDefaults' palette so picker + AI tool + form
+// converge on the same set.
+const FORM_COLORS = [
+  "#FF5A3A", "#4BD9A2", "#6AA3FF", "#E8A05A",
+  "#B38DF7", "#FF7A9E", "#F1B84A", "#6b7280",
+];
+const FORM_ICONS = ["◐", "◆", "◉", "✦", "✧", "◇", "✶", "◈"];
 
 interface CatAgg {
   cat: string;
@@ -30,9 +40,16 @@ export function Categories() {
   const { payments } = useConvertedPayments();
   const { getCategory, categorize: categorizeId, allCategories } = useCategorizer();
   const { categories: dbCategories } = useCategories();
-  const { deleteCategory } = useCategoryActions();
+  const { addCategory, updateCategory, deleteCategory } = useCategoryActions();
   const trend = useMonthlyTrend(6);
   const { range, props: rangeProps } = useRangeState("Month");
+
+  // Form modes: only one form is open at a time. `creating` toggles
+  // the bottom-of-list "+ New category" form; `editingId` carries the
+  // id of the row currently in edit mode (null = no row is being
+  // edited). Both close on Escape / Cancel / successful submit.
+  const [creating, setCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   // A category row is deletable when there's a DB row with isDefault: false.
   // Hard-coded DEFAULT_CATEGORIES that haven't been seeded into the DB
@@ -188,7 +205,32 @@ export function Categories() {
             {cats.map((c) => {
               const pct = (c.total / total) * 100;
               const active = c.cat === selectedId;
-              const deletable = deletableIds.has(c.cat);
+              const editable = deletableIds.has(c.cat);
+              const isEditing = editingId === c.cat;
+              if (isEditing) {
+                return (
+                  <CategoryForm
+                    key={c.cat}
+                    T={T}
+                    initial={{ name: c.meta.name, color: c.meta.color, icon: c.meta.icon }}
+                    onCancel={() => setEditingId(null)}
+                    onSubmit={async ({ name, color, icon }) => {
+                      // Reject duplicate names against the merged list (excluding self).
+                      const nameLc = name.trim().toLowerCase();
+                      const collide = allCategories.find(
+                        (cat) =>
+                          cat.id !== c.cat &&
+                          cat.name.toLowerCase() === nameLc
+                      );
+                      if (collide) return `"${collide.name}" already exists.`;
+                      await updateCategory(c.cat, { name: name.trim(), color, icon });
+                      setEditingId(null);
+                      return null;
+                    }}
+                    submitLabel="Save"
+                  />
+                );
+              }
               return (
                 <div
                   key={c.cat}
@@ -224,36 +266,109 @@ export function Categories() {
                   >
                     ₾{Math.round(c.total)}
                   </span>
-                  {deletable && (
-                    <button
-                      type="button"
-                      title={`Delete "${c.meta.name}"`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDelete(c.cat, c.meta.name);
-                      }}
-                      style={{
-                        width: 22,
-                        height: 22,
-                        borderRadius: 11,
-                        border: `1px solid ${T.line}`,
-                        background: "transparent",
-                        color: T.dim,
-                        fontSize: 12,
-                        lineHeight: 1,
-                        cursor: "pointer",
-                        flexShrink: 0,
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                      }}
-                    >
-                      ×
-                    </button>
+                  {editable && (
+                    <>
+                      <button
+                        type="button"
+                        title={`Edit "${c.meta.name}"`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setEditingId(c.cat);
+                          setCreating(false);
+                        }}
+                        style={{
+                          width: 22,
+                          height: 22,
+                          borderRadius: 11,
+                          border: `1px solid ${T.line}`,
+                          background: "transparent",
+                          color: T.dim,
+                          fontSize: 11,
+                          lineHeight: 1,
+                          cursor: "pointer",
+                          flexShrink: 0,
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        ✎
+                      </button>
+                      <button
+                        type="button"
+                        title={`Delete "${c.meta.name}"`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(c.cat, c.meta.name);
+                        }}
+                        style={{
+                          width: 22,
+                          height: 22,
+                          borderRadius: 11,
+                          border: `1px solid ${T.line}`,
+                          background: "transparent",
+                          color: T.dim,
+                          fontSize: 12,
+                          lineHeight: 1,
+                          cursor: "pointer",
+                          flexShrink: 0,
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        ×
+                      </button>
+                    </>
                   )}
                 </div>
               );
             })}
+            {creating ? (
+              <CategoryForm
+                T={T}
+                onCancel={() => setCreating(false)}
+                onSubmit={async ({ name, color, icon }) => {
+                  const nameLc = name.trim().toLowerCase();
+                  const collide = allCategories.find(
+                    (cat) => cat.name.toLowerCase() === nameLc
+                  );
+                  if (collide) return `"${collide.name}" already exists.`;
+                  await addCategory({
+                    name: name.trim(),
+                    color,
+                    icon,
+                    isDefault: false,
+                  });
+                  setCreating(false);
+                  return null;
+                }}
+                submitLabel="Create"
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setCreating(true);
+                  setEditingId(null);
+                }}
+                style={{
+                  marginTop: 6,
+                  padding: "10px 12px",
+                  background: "transparent",
+                  border: `1px dashed ${T.line}`,
+                  borderRadius: 10,
+                  color: T.muted,
+                  fontSize: 12.5,
+                  fontWeight: 600,
+                  fontFamily: T.sans,
+                  cursor: "pointer",
+                  textAlign: "left",
+                }}
+              >
+                + New category…
+              </button>
+            )}
           </div>
         </Card>
 
@@ -448,6 +563,193 @@ export function Categories() {
             </Card>
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+/** Inline form used for both creating and editing a category. Renders
+ *  inside the left-hand category list, replacing the row when in edit
+ *  mode. Color/icon pickers are preset swatches matching
+ *  pickCategoryDefaults so the form, the AI tool, and the inline
+ *  CategoryPicker create-flow share the same visual vocabulary. */
+function CategoryForm({
+  T,
+  initial,
+  onCancel,
+  onSubmit,
+  submitLabel,
+}: {
+  T: InkTheme;
+  initial?: { name: string; color: string; icon: string };
+  onCancel: () => void;
+  onSubmit: (values: { name: string; color: string; icon: string }) => Promise<string | null>;
+  submitLabel: string;
+}) {
+  const [name, setName] = useState(initial?.name ?? "");
+  // For new categories, default to deterministic defaults from the
+  // current name (regenerated as the user types) so creating with
+  // "Coffee shops" gives the same look the AI tool would. Edit mode
+  // keeps whatever the row already had.
+  const initialDefaults = pickCategoryDefaults(initial?.name ?? "");
+  const [color, setColor] = useState(initial?.color ?? initialDefaults.color);
+  const [icon, setIcon] = useState(initial?.icon ?? initialDefaults.icon);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Update the name-derived defaults as the user types in create mode
+  // (initial undefined). Edit mode never re-derives — the user's
+  // explicit color/icon stays unless they pick a new one.
+  const isCreate = !initial;
+  const handleNameChange = (next: string) => {
+    setName(next);
+    if (error) setError(null);
+    if (isCreate) {
+      const d = pickCategoryDefaults(next);
+      setColor(d.color);
+      setIcon(d.icon);
+    }
+  };
+
+  const submit = async () => {
+    if (busy) return;
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const err = await onSubmit({ name, color, icon });
+      if (err) setError(err);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        padding: "10px 12px",
+        background: T.panelAlt,
+        borderRadius: 10,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onCancel();
+        }
+      }}
+    >
+      <input
+        autoFocus
+        value={name}
+        onChange={(e) => handleNameChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            submit();
+          }
+        }}
+        placeholder="Category name"
+        disabled={busy}
+        style={{
+          padding: "8px 12px",
+          background: T.panel,
+          border: `1px solid ${T.line}`,
+          borderRadius: 8,
+          color: T.text,
+          fontSize: 13,
+          fontFamily: T.sans,
+          outline: "none",
+        }}
+      />
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        {FORM_COLORS.map((c) => (
+          <button
+            key={c}
+            type="button"
+            onClick={() => setColor(c)}
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: 11,
+              background: c,
+              border: color === c ? `2px solid ${T.text}` : `2px solid transparent`,
+              cursor: "pointer",
+              padding: 0,
+            }}
+          />
+        ))}
+      </div>
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        {FORM_ICONS.map((g) => (
+          <button
+            key={g}
+            type="button"
+            onClick={() => setIcon(g)}
+            style={{
+              width: 26,
+              height: 26,
+              borderRadius: 6,
+              background: icon === g ? T.panel : "transparent",
+              border: icon === g ? `1px solid ${T.text}` : `1px solid ${T.line}`,
+              color: T.text,
+              fontSize: 14,
+              cursor: "pointer",
+              fontFamily: T.sans,
+              padding: 0,
+            }}
+          >
+            {g}
+          </button>
+        ))}
+      </div>
+      {error && (
+        <div style={{ fontSize: 11, color: T.accent, fontFamily: T.sans }}>{error}</div>
+      )}
+      <div style={{ display: "flex", gap: 6 }}>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={busy || !name.trim()}
+          style={{
+            flex: 1,
+            padding: "8px 12px",
+            background: busy || !name.trim() ? T.panel : T.accent,
+            color: busy || !name.trim() ? T.dim : "#fff",
+            border: "none",
+            borderRadius: 8,
+            fontSize: 12,
+            fontWeight: 600,
+            fontFamily: T.sans,
+            cursor: busy || !name.trim() ? "not-allowed" : "pointer",
+          }}
+        >
+          {busy ? "Saving…" : submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={busy}
+          style={{
+            padding: "8px 12px",
+            background: "transparent",
+            color: T.muted,
+            border: `1px solid ${T.line}`,
+            borderRadius: 8,
+            fontSize: 12,
+            fontFamily: T.sans,
+            cursor: busy ? "not-allowed" : "pointer",
+          }}
+        >
+          Cancel
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
**Phase B of [#33](https://github.com/tornikegomareli/Xarji/issues/33).** Adds the missing operations to the category surface on both UI and AI channels, scoped to user-created (non-default) categories.

## What ships

### UI on \`/categories\`

- **+ New category…** inline button at the bottom of the left category list. Click → form: name input, 8 preset color swatches, 8 preset icon glyphs, Save / Cancel. Form's color + icon track the typed name deterministically (same hash \`create_category\` uses).
- **✎ pencil edit button** next to the × delete button on user-created rows. Click swaps the row for the same form pre-filled with the current values. Submit calls \`updateCategory\`.
- Both forms close on Escape / Cancel / successful submit. Only one form open at a time.
- Case-insensitive duplicate-name validation against the merged live list, excluding self in edit mode.

### AI tools

- **\`update_category(id, { name?, color?, icon? })\`**. Auto-applies. At least one of \`name\`/\`color\`/\`icon\` required. Refuses for default / built-in categories with a clear error so the model can explain why.
- **\`delete_category(id)\`**. Auto-applies. Refuses for default / built-in categories. Cleans up dangling merchant overrides in the same transact call (parity with the × button on /categories).
- Both tools read live state via \`ctx.getAllCategories()\` / \`ctx.getOverrides()\` — same staleness fix as PR #32 so chained writes in one assistant turn see fresh data.

System prompt updated to describe the four-tool surface (\`create_category\`, \`apply_category_override\`, \`update_category\`, \`delete_category\`) and tell the model to point users at the UI for actions that aren't covered by a tool (single-merchant override clear is the only one).

## Why default categories aren't editable / deletable

Allowing default-renames requires a \`canonicalId\` schema field on the \`categories\` entity so the regex categoriser keeps mapping merchants to renamed entries. The current \`useCategorizer.byCanonicalId\` lookup matches by name; a renamed default would break that mapping silently. Tracked as **B.2** in #33 — separate PR with the schema migration.

For now: user can create a custom category with the desired name and use it via apply_category_override.

## Verification

- \`bun run build\` clean.
- 193 service tests pass.
- Live test on \`/categories\` (in dev with demo mode):
  - "+ New category…" → name "Coffee shops" → Create. Appears in list with × and ✎.
  - ✎ on Coffee shops → rename + recolor + icon change. Save. Row updates.
  - × on Coffee shops → confirm dialog → category gone.
- Live test in \`/assistant\`:
  - "Make a Pet care category, then rename it to Pets" → both tools called in one turn (live ref ensures the update sees the freshly-created id).
  - "Delete Pets" → \`delete_category\` succeeds.
  - "Rename Groceries to Food shopping" → tool errors with default-category message; model explains.

## E2E coverage

Will add T-CAT-N tests for the new UI controls + T-AI-13/14 for update_category/delete_category in a small followup commit on this branch before merge.

## Open questions still in #33

- **Per-transaction overrides** (vs. per-merchant) — Phase A.1, deferred.
- **Excluded transactions visibility** — Phase C, next session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline category creation and editing directly in the Categories page
  * Users can now create, edit, and delete categories with dedicated buttons and forms
  * Enhanced category forms include color and icon selection options
  * Form validation prevents duplicate category names (case-insensitive)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->