### PR TITLE
feat: per-transaction category overrides with scope picker

### DIFF
--- a/client/src/components/CategoryPicker.tsx
+++ b/client/src/components/CategoryPicker.tsx
@@ -1,14 +1,9 @@
-// Inline dropdown that lets the user move a transaction's merchant
-// into a different category. Persists the choice via the
-// useMerchantOverrides hook (writes a row to InstantDB's
-// merchantCategoryOverrides table). The choice applies to *every*
-// transaction from that merchant — past and future — because the
-// override is per-merchant, not per-transaction.
-
-import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTheme, type InkTheme } from "../ink/theme";
 import { type InkCategory } from "../lib/utils";
 import { useMerchantOverrides } from "../hooks/useMerchantOverrides";
+import { useTransactionOverrides } from "../hooks/useTransactionOverrides";
 import { useCategorizer } from "../hooks/useCategorizer";
 import { useCategoryActions } from "../hooks/useCategories";
 import { pickCategoryDefaults } from "../lib/categoryDefaults";
@@ -18,6 +13,7 @@ export function CategoryPicker({
   current,
   onClose,
   anchor = "left",
+  paymentId,
 }: {
   merchant: string;
   current: InkCategory;
@@ -28,13 +24,23 @@ export function CategoryPicker({
    *  edge of a narrow column and a left-anchored picker would clip
    *  off-screen. */
   anchor?: "left" | "right";
+  /** When provided, the picker offers a scope toggle: "This transaction"
+   *  (per-transaction override) vs "All [merchant]" (per-merchant override).
+   *  Defaults to transaction scope when set. Omit for merchant-only behaviour. */
+  paymentId?: string;
 }) {
   const T = useTheme();
   const ref = useRef<HTMLDivElement | null>(null);
-  const { byMerchant, setOverride, clearOverride } = useMerchantOverrides();
+  const anchorRef = useRef<HTMLSpanElement | null>(null);
+  const [dropdownPos, setDropdownPos] = useState<{ top?: number; bottom?: number; left?: number; right?: number } | null>(null);
+  const { byMerchant, setOverride: setMerchantOverride, clearOverride: clearMerchantOverride } = useMerchantOverrides();
+  const { byPaymentId, setOverride: setTxOverride, clearOverride: clearTxOverride } = useTransactionOverrides();
   const { allCategories } = useCategorizer();
   const { addCategory } = useCategoryActions();
   const [busy, setBusy] = useState(false);
+  const [scope, setScope] = useState<"transaction" | "merchant">(
+    paymentId ? "transaction" : "merchant"
+  );
   // "creating mode" — user clicked "+ New category" and we render the
   // inline name input instead of the category list. Keeps the picker
   // self-contained: no modal, no separate component, no navigation
@@ -44,7 +50,10 @@ export function CategoryPicker({
   const [error, setError] = useState<string | null>(null);
   const draftInputRef = useRef<HTMLInputElement | null>(null);
 
-  const hasOverride = !!byMerchant.get(merchant.trim().toLowerCase());
+  const hasOverride =
+    scope === "transaction"
+      ? !!paymentId && !!byPaymentId.get(paymentId)
+      : !!byMerchant.get(merchant.trim().toLowerCase());
 
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {
@@ -76,11 +85,34 @@ export function CategoryPicker({
     if (creating) draftInputRef.current?.focus();
   }, [creating]);
 
+  // Compute fixed position from the trigger's bounding rect so the
+  // portal dropdown renders below the badge regardless of scroll
+  // containers or Card's overflow: hidden.
+  useLayoutEffect(() => {
+    const parent = anchorRef.current?.parentElement;
+    if (!parent) return;
+    const rect = parent.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const flipUp = spaceBelow < 320;
+    const hPos = anchor === "right"
+      ? { right: window.innerWidth - rect.right }
+      : { left: rect.left };
+    if (flipUp) {
+      setDropdownPos({ ...hPos, bottom: window.innerHeight - rect.top + 6 });
+    } else {
+      setDropdownPos({ ...hPos, top: rect.bottom + 6 });
+    }
+  }, [anchor]);
+
   const pick = async (cat: InkCategory) => {
     if (busy) return;
     setBusy(true);
     try {
-      await setOverride(merchant, cat.id);
+      if (scope === "transaction" && paymentId) {
+        await setTxOverride(paymentId, cat.id);
+      } else {
+        await setMerchantOverride(merchant, cat.id);
+      }
       onClose();
     } finally {
       setBusy(false);
@@ -91,7 +123,11 @@ export function CategoryPicker({
     if (busy) return;
     setBusy(true);
     try {
-      await clearOverride(merchant);
+      if (scope === "transaction" && paymentId) {
+        await clearTxOverride(paymentId);
+      } else {
+        await clearMerchantOverride(merchant);
+      }
       onClose();
     } finally {
       setBusy(false);
@@ -126,10 +162,11 @@ export function CategoryPicker({
         icon: defaults.icon,
         isDefault: false,
       });
-      // Apply the new category as the merchant's override immediately
-      // — that's what the user clicked in for, otherwise they'd have
-      // to do a second pick after creating.
-      await setOverride(merchant, newId);
+      if (scope === "transaction" && paymentId) {
+        await setTxOverride(paymentId, newId);
+      } else {
+        await setMerchantOverride(merchant, newId);
+      }
       onClose();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -138,15 +175,18 @@ export function CategoryPicker({
     }
   };
 
-  return (
+  const dropdown = dropdownPos && (
     <div
       ref={ref}
+      onClick={(e) => e.stopPropagation()}
       style={{
-        position: "absolute",
-        top: "calc(100% + 6px)",
-        ...(anchor === "right" ? { right: 0 } : { left: 0 }),
-        zIndex: 100,
-        minWidth: 260,
+        position: "fixed",
+        top: dropdownPos.top,
+        bottom: dropdownPos.bottom,
+        left: dropdownPos.left,
+        right: dropdownPos.right,
+        zIndex: 1000,
+        minWidth: 300,
         background: T.panel,
         border: `1px solid ${T.lineStrong}`,
         borderRadius: 12,
@@ -264,6 +304,22 @@ export function CategoryPicker({
           >
             Move {merchant} to
           </div>
+          {paymentId && (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 3,
+                padding: "2px 4px 4px",
+                background: T.panelAlt,
+                borderRadius: 8,
+                margin: "0 4px 2px",
+              }}
+            >
+              <ScopeBtn T={T} label="Just this one" active={scope === "transaction"} onClick={() => setScope("transaction")} />
+              <ScopeBtn T={T} label={`All ${merchant.slice(0, 10)}${merchant.length > 10 ? "…" : ""} transactions`} active={scope === "merchant"} onClick={() => setScope("merchant")} />
+            </div>
+          )}
           <div style={{ display: "flex", flexDirection: "column", maxHeight: 280, overflowY: "auto" }}>
             {allCategories.map((cat) => (
               <CategoryRow
@@ -316,6 +372,47 @@ export function CategoryPicker({
         </>
       )}
     </div>
+  );
+
+  return (
+    <>
+      <span ref={anchorRef} style={{ position: "absolute", inset: 0, pointerEvents: "none" }} />
+      {createPortal(dropdown, document.body)}
+    </>
+  );
+}
+
+function ScopeBtn({
+  T,
+  label,
+  active,
+  onClick,
+}: {
+  T: InkTheme;
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        flex: 1,
+        padding: "5px 8px",
+        borderRadius: 6,
+        border: "none",
+        background: active ? T.panel : "transparent",
+        color: active ? T.text : T.muted,
+        fontSize: 11,
+        fontFamily: T.sans,
+        fontWeight: active ? 600 : 400,
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+        minWidth: 0,
+      }}
+    >
+      {label}
+    </button>
   );
 }
 

--- a/client/src/hooks/useCategorizer.ts
+++ b/client/src/hooks/useCategorizer.ts
@@ -16,13 +16,16 @@ import {
   type InkCategory,
 } from "../lib/utils";
 import { useMerchantOverrides } from "./useMerchantOverrides";
+import { useTransactionOverrides } from "./useTransactionOverrides";
 import { useCategories } from "./useCategories";
 
 export interface Categorizer {
-  /** Returns the category id (e.g. "groceries") for a merchant. */
-  categorize: (merchant: string | null | undefined, raw?: string | null) => string;
-  /** Returns the full InkCategory record with name + color + icon. */
-  getCategory: (merchant: string | null | undefined, raw?: string | null) => InkCategory;
+  /** Returns the category id (e.g. "groceries") for a merchant.
+   *  Pass paymentId to honour per-transaction overrides (higher priority). */
+  categorize: (merchant: string | null | undefined, raw?: string | null, paymentId?: string | null) => string;
+  /** Returns the full InkCategory record with name + color + icon.
+   *  Pass paymentId to honour per-transaction overrides (higher priority). */
+  getCategory: (merchant: string | null | undefined, raw?: string | null, paymentId?: string | null) => InkCategory;
   /** Convenience for places that historically called `autoCategorize`
    *  to get the human-facing category name (e.g. "Groceries"). */
   categorizeName: (merchant: string | null | undefined) => string;
@@ -36,6 +39,7 @@ export interface Categorizer {
 
 export function useCategorizer(): Categorizer {
   const { byMerchant } = useMerchantOverrides();
+  const { byPaymentId } = useTransactionOverrides();
   const { categories: dbCategories } = useCategories();
 
   // Merge DB categories with DEFAULT_CATEGORIES, deduping by *name*
@@ -89,7 +93,15 @@ export function useCategorizer(): Categorizer {
   }, [allCategories]);
 
   const getCategory = useCallback(
-    (merchant: string | null | undefined, raw?: string | null): InkCategory => {
+    (merchant: string | null | undefined, raw?: string | null, paymentId?: string | null): InkCategory => {
+      // Per-transaction override wins over everything.
+      if (paymentId) {
+        const txOverride = byPaymentId.get(paymentId);
+        if (txOverride) {
+          const hit = allCategories.find((c) => c.id === txOverride.categoryId);
+          if (hit) return hit;
+        }
+      }
       if (merchant) {
         const override = byMerchant.get(merchant.trim().toLowerCase());
         if (override) {
@@ -107,11 +119,17 @@ export function useCategorizer(): Categorizer {
       const id = categorizeId(merchant, raw);
       return byCanonicalId.get(id) ?? defaultGetCategory(merchant, raw);
     },
-    [byMerchant, allCategories, byCanonicalId]
+    [byPaymentId, byMerchant, allCategories, byCanonicalId]
   );
 
   const categorize = useCallback(
-    (merchant: string | null | undefined, raw?: string | null): string => {
+    (merchant: string | null | undefined, raw?: string | null, paymentId?: string | null): string => {
+      if (paymentId) {
+        const txOverride = byPaymentId.get(paymentId);
+        if (txOverride && allCategories.some((c) => c.id === txOverride.categoryId)) {
+          return txOverride.categoryId;
+        }
+      }
       if (merchant) {
         const override = byMerchant.get(merchant.trim().toLowerCase());
         // Only honour an override if the target still exists. Dangling
@@ -126,7 +144,7 @@ export function useCategorizer(): Categorizer {
       const canonicalId = categorizeId(merchant, raw);
       return byCanonicalId.get(canonicalId)?.id ?? canonicalId;
     },
-    [byMerchant, allCategories, byCanonicalId]
+    [byPaymentId, byMerchant, allCategories, byCanonicalId]
   );
 
   const categorizeName = useCallback(

--- a/client/src/hooks/useTransactionOverrides.ts
+++ b/client/src/hooks/useTransactionOverrides.ts
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+import { id as instantId } from "@instantdb/react";
+import { db, type TransactionCategoryOverride } from "../lib/instant";
+
+export function useTransactionOverrides() {
+  const { data } = db.useQuery({ transactionCategoryOverrides: {} });
+
+  const overrides = useMemo<TransactionCategoryOverride[]>(
+    () => data?.transactionCategoryOverrides ?? [],
+    [data?.transactionCategoryOverrides]
+  );
+
+  const byPaymentId = useMemo(() => {
+    const m = new Map<string, TransactionCategoryOverride>();
+    for (const o of overrides) m.set(o.paymentId, o);
+    return m;
+  }, [overrides]);
+
+  const setOverride = async (paymentId: string, categoryId: string): Promise<void> => {
+    if (!paymentId) return;
+    const existing = byPaymentId.get(paymentId);
+    const opId = existing?.id ?? instantId();
+    await db.transact(
+      db.tx.transactionCategoryOverrides[opId].update({
+        paymentId,
+        categoryId,
+        createdAt: existing?.createdAt ?? Date.now(),
+      })
+    );
+  };
+
+  const clearOverride = async (paymentId: string): Promise<void> => {
+    const existing = byPaymentId.get(paymentId);
+    if (!existing) return;
+    await db.transact(db.tx.transactionCategoryOverrides[existing.id].delete());
+  };
+
+  return { overrides, byPaymentId, setOverride, clearOverride };
+}

--- a/client/src/ink/TxRow.tsx
+++ b/client/src/ink/TxRow.tsx
@@ -41,7 +41,7 @@ export function TxRow({
   const T = useTheme();
   const vp = useViewport();
   const { getCategory } = useCategorizer();
-  const cat = getCategory(t.merchant, t.rawMerchant);
+  const cat = getCategory(t.merchant, t.rawMerchant, t.id);
   const failed = t.kind === "failed";
   const credit = t.kind === "credit";
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -191,6 +191,7 @@ export function TxRow({
               merchant={t.merchant}
               current={cat}
               onClose={() => setPickerOpen(false)}
+              paymentId={t.id}
             />
           )}
         </div>

--- a/client/src/lib/instant.ts
+++ b/client/src/lib/instant.ts
@@ -60,6 +60,11 @@ const schema = i.schema({
       categoryId: i.string(),
       createdAt: i.number(),
     }),
+    transactionCategoryOverrides: i.entity({
+      paymentId: i.string().unique(),
+      categoryId: i.string(),
+      createdAt: i.number(),
+    }),
     credits: i.entity({
       transactionId: i.string().unique(),
       transactionType: i.string(),
@@ -189,6 +194,13 @@ export type BankSender = {
 export type MerchantCategoryOverride = {
   id: string;
   merchant: string;
+  categoryId: string;
+  createdAt: number;
+};
+
+export type TransactionCategoryOverride = {
+  id: string;
+  paymentId: string;
   categoryId: string;
   createdAt: number;
 };

--- a/client/src/pages/Categories.tsx
+++ b/client/src/pages/Categories.tsx
@@ -67,7 +67,7 @@ export function Categories() {
 
   const handleDelete = async (catId: string, catName: string) => {
     const txCount = payments.filter(
-      (p) => p.gelAmount !== null && categorizeId(p.merchant, p.rawMessage) === catId
+      (p) => p.gelAmount !== null && categorizeId(p.merchant, p.rawMessage, p.id) === catId
     ).length;
     const message = txCount === 0
       ? `Delete "${catName}"? This category has no transactions assigned to it.`
@@ -87,7 +87,7 @@ export function Categories() {
     for (const p of monthPayments) {
       if (p.excludedFromAnalytics) continue;
       if (p.gelAmount === null) continue;
-      const cat = getCategory(p.merchant, p.rawMessage);
+      const cat = getCategory(p.merchant, p.rawMessage, p.id);
       if (!map[cat.id]) map[cat.id] = { cat: cat.id, total: 0, count: 0, meta: cat };
       map[cat.id].total += p.gelAmount;
       map[cat.id].count += 1;
@@ -145,7 +145,7 @@ export function Categories() {
       const k = monthKey(p.transactionDate);
       const idx = keys.indexOf(k);
       if (idx === -1) continue;
-      const catId = categorizeId(p.merchant, p.rawMessage);
+      const catId = categorizeId(p.merchant, p.rawMessage, p.id);
       if (perCat[catId]) perCat[catId][idx].value += p.gelAmount;
     }
     return { keys, perCat, labels: trend.map((m) => m.label.slice(0, 3)) };
@@ -156,7 +156,7 @@ export function Categories() {
     for (const p of monthPayments) {
       if (p.excludedFromAnalytics) continue;
       if (p.gelAmount === null) continue;
-      const cid = categorizeId(p.merchant, p.rawMessage);
+      const cid = categorizeId(p.merchant, p.rawMessage, p.id);
       if (cid !== selectedId) continue;
       const m = p.merchant || "Unknown";
       if (!map[m]) map[m] = { merchant: m, total: 0, count: 0 };
@@ -164,11 +164,11 @@ export function Categories() {
       map[m].count += 1;
     }
     return Object.values(map).sort((a, b) => b.total - a.total);
-  }, [monthPayments, selectedId]);
+  }, [monthPayments, selectedId, categorizeId]);
 
   const selTx: InkTx[] = useMemo(() => {
     return monthPayments
-      .filter((p) => categorizeId(p.merchant, p.rawMessage) === selectedId)
+      .filter((p) => categorizeId(p.merchant, p.rawMessage, p.id) === selectedId)
       .slice(0, 20)
       .map((p) => ({
         id: p.id,
@@ -184,7 +184,7 @@ export function Categories() {
         rawMessage: p.rawMessage,
         excludedFromAnalytics: p.excludedFromAnalytics,
       }));
-  }, [monthPayments, selectedId]);
+  }, [monthPayments, selectedId, categorizeId]);
 
   const eyebrow = `Where your money went · ${format(now, "MMMM")}`;
 

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -63,7 +63,7 @@ export function Transactions() {
         cardLastDigits: p.cardLastDigits,
         transactionDate: p.transactionDate,
         bankSenderId: p.bankSenderId,
-        category: categorizeId(p.merchant, p.rawMessage),
+        category: categorizeId(p.merchant, p.rawMessage, p.id),
         rawMessage: p.rawMessage,
         plusEarned: p.plusEarned,
         excludedFromAnalytics: p.excludedFromAnalytics,
@@ -381,7 +381,7 @@ export function Transactions() {
               <DetailRow T={T} k="When" v={new Date(selected.transactionDate).toLocaleString("en-US", { weekday: "short", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false })} />
               <DetailRow T={T} k="Card" v={selected.cardLastDigits ? `··${selected.cardLastDigits}` : "—"} />
               <DetailRow T={T} k="Bank" v={selected.bankSenderId} />
-              <CategoryDetailRow T={T} merchant={selected.merchant} rawMerchant={selected.rawMerchant} />
+              <CategoryDetailRow T={T} merchant={selected.merchant} rawMerchant={selected.rawMerchant} paymentId={selected.kind === "payment" ? selected.id : undefined} />
               {selected.kind === "failed" ? (
                 <DetailRow T={T} k="Reason" v={selected.failureReason || "—"} />
               ) : (
@@ -499,14 +499,16 @@ function CategoryDetailRow({
   T,
   merchant,
   rawMerchant,
+  paymentId,
 }: {
   T: InkTheme;
   merchant: string;
   rawMerchant?: string;
+  paymentId?: string;
 }) {
   const { getCategory } = useCategorizer();
   const [open, setOpen] = useState(false);
-  const cat = getCategory(merchant, rawMerchant);
+  const cat = getCategory(merchant, rawMerchant, paymentId);
   const pickerMerchant = (merchant || rawMerchant || "").trim();
   const canEdit = pickerMerchant.length > 0;
 
@@ -547,6 +549,7 @@ function CategoryDetailRow({
           current={cat}
           onClose={() => setOpen(false)}
           anchor="right"
+          paymentId={paymentId}
         />
       )}
     </div>

--- a/service/src/instant-schema.ts
+++ b/service/src/instant-schema.ts
@@ -97,6 +97,15 @@ const schema = i.schema({
       categoryId: i.string(),
       createdAt: i.number(),
     }),
+
+    // Per-transaction category overrides. Takes priority over the
+    // per-merchant override. paymentId is the InstantDB entity id of
+    // the payments row — stable, unique, never changes after creation.
+    transactionCategoryOverrides: i.entity({
+      paymentId: i.string().unique(),
+      categoryId: i.string(),
+      createdAt: i.number(),
+    }),
   },
   links: {},
 });


### PR DESCRIPTION
What changed                                                                                                                                               
                                                                                                                                                             
  Previously, picking a category on a transaction applied it to every transaction from that merchant. This PR adds a second layer: overrides can now be      
  scoped to a single transaction.                                                                                                                            
                                                                                                                                                             
  New data layer  

  - New transactionCategoryOverrides table in InstantDB (both service and client schemas), keyed by the payment's entity id                                  
  - New useTransactionOverrides hook mirroring useMerchantOverrides
  - useCategorizer — getCategory and categorize now accept an optional paymentId; lookup priority is transaction override → merchant override → regex        
  fallback                                                                                                                                                   
                                                                                                                                                             
  CategoryPicker UX                                                                                                                                          
                  
  - New paymentId prop; when present a scope toggle appears: "Just this one" vs "All [merchant…] transactions"                                               
  - Defaults to "Just this one" — the more precise choice
  - Picker rendered via createPortal to document.body with position: fixed, so Card's overflow: hidden can no longer clip it                                 
  - Automatically flips upward when less than 320px of space remains below the trigger                                                                       
  - Click propagation stopped on the picker root so opening it doesn't select the transaction detail panel                                                   
                                                                                                                                                             
  Consistency fixes                                                                                                                                          
                                                                                                                                                             
  - All categorization call sites in Transactions.tsx and Categories.tsx (donut, trend, merchant breakdown, filter, transaction list) now pass p.id so       
  transaction-level overrides are reflected everywhere — not just in the badge

<img width="357" height="497" alt="image" src="https://github.com/user-attachments/assets/5446c5c7-c3aa-48ad-ac0f-c6396c1ad0d1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-transaction category overrides: set custom categories for individual payments, not just merchants
  * Category scope toggle: choose whether your override applies to a single transaction or all transactions from that merchant

* **Improvements**
  * Enhanced category picker dropdown positioning and rendering for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->