### PR TITLE
Fix CategoryPicker viewport clamping and scroll dismiss  

### DIFF
--- a/client/src/components/CategoryPicker.tsx
+++ b/client/src/components/CategoryPicker.tsx
@@ -32,7 +32,7 @@ export function CategoryPicker({
   const T = useTheme();
   const ref = useRef<HTMLDivElement | null>(null);
   const anchorRef = useRef<HTMLSpanElement | null>(null);
-  const [dropdownPos, setDropdownPos] = useState<{ top?: number; bottom?: number; left?: number; right?: number } | null>(null);
+  const [dropdownPos, setDropdownPos] = useState<{ top?: number; bottom?: number; left?: number; right?: number; maxHeight: number } | null>(null);
   const { byMerchant, setOverride: setMerchantOverride, clearOverride: clearMerchantOverride } = useMerchantOverrides();
   const { byPaymentId, setOverride: setTxOverride, clearOverride: clearTxOverride } = useTransactionOverrides();
   const { allCategories } = useCategorizer();
@@ -59,6 +59,8 @@ export function CategoryPicker({
     const onDoc = (e: MouseEvent) => {
       if (!ref.current?.contains(e.target as Node)) onClose();
     };
+    const onScroll = () => onClose();
+    window.addEventListener("scroll", onScroll, { capture: true, passive: true });
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         if (creating) {
@@ -76,6 +78,7 @@ export function CategoryPicker({
     return () => {
       document.removeEventListener("mousedown", onDoc);
       document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", onScroll, { capture: true });
     };
   }, [onClose, creating]);
 
@@ -92,15 +95,17 @@ export function CategoryPicker({
     const parent = anchorRef.current?.parentElement;
     if (!parent) return;
     const rect = parent.getBoundingClientRect();
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const flipUp = spaceBelow < 320;
+    const margin = 12;
+    const spaceBelow = window.innerHeight - rect.bottom - margin;
+    const spaceAbove = rect.top - margin;
+    const flipUp = spaceBelow < 320 && spaceAbove > spaceBelow;
     const hPos = anchor === "right"
       ? { right: window.innerWidth - rect.right }
       : { left: rect.left };
     if (flipUp) {
-      setDropdownPos({ ...hPos, bottom: window.innerHeight - rect.top + 6 });
+      setDropdownPos({ ...hPos, bottom: window.innerHeight - rect.top + 6, maxHeight: spaceAbove });
     } else {
-      setDropdownPos({ ...hPos, top: rect.bottom + 6 });
+      setDropdownPos({ ...hPos, top: rect.bottom + 6, maxHeight: spaceBelow });
     }
   }, [anchor]);
 
@@ -187,6 +192,7 @@ export function CategoryPicker({
         right: dropdownPos.right,
         zIndex: 1000,
         minWidth: 300,
+        maxHeight: dropdownPos.maxHeight,
         background: T.panel,
         border: `1px solid ${T.lineStrong}`,
         borderRadius: 12,
@@ -195,6 +201,7 @@ export function CategoryPicker({
         display: "flex",
         flexDirection: "column",
         gap: 2,
+        overflow: "hidden",
       }}
     >
       {creating ? (
@@ -320,7 +327,7 @@ export function CategoryPicker({
               <ScopeBtn T={T} label={`All ${merchant.slice(0, 10)}${merchant.length > 10 ? "…" : ""} transactions`} active={scope === "merchant"} onClick={() => setScope("merchant")} />
             </div>
           )}
-          <div style={{ display: "flex", flexDirection: "column", maxHeight: 280, overflowY: "auto" }}>
+          <div style={{ display: "flex", flexDirection: "column", flex: 1, overflowY: "auto", minHeight: 0 }}>
             {allCategories.map((cat) => (
               <CategoryRow
                 key={cat.id}

--- a/client/src/ink/TxRow.tsx
+++ b/client/src/ink/TxRow.tsx
@@ -31,11 +31,13 @@ export function TxRow({
   t,
   isLast,
   compact,
+  selected,
   onClick,
 }: {
   t: InkTx;
   isLast?: boolean;
   compact?: boolean;
+  selected?: boolean;
   onClick?: () => void;
 }) {
   const T = useTheme();
@@ -49,8 +51,9 @@ export function TxRow({
   // user-meaningful category, and overriding a declined transaction's
   // categorisation has no downstream effect either.
   const canChangeCategory = t.kind === "payment" && !!t.merchant;
-  const pad = compact ? "10px 0" : T.density.rowPad;
-  const isFx = (t.kind === "payment" || t.kind === "credit") && t.currency !== "GEL";
+  const pad = compact ? "10px 5px" : T.density.rowPad;
+  const isFx =
+    (t.kind === "payment" || t.kind === "credit") && t.currency !== "GEL";
   const cols = vp.narrow ? "32px 1fr 90px" : "36px 1fr 110px 110px 90px";
   const symbol = currencySymbol(t.currency);
 
@@ -78,6 +81,9 @@ export function TxRow({
         alignItems: "center",
         cursor: onClick ? "pointer" : "default",
         position: "relative",
+        background: selected ? T.accentSoft : "transparent",
+        borderRadius: selected ? 8 : 0,
+        transition: "background 0.15s ease",
       }}
     >
       <div
@@ -88,10 +94,10 @@ export function TxRow({
           background: credit
             ? "rgba(75,217,162,0.18)"
             : failed
-            ? T.accentSoft
-            : cat
-            ? `${cat.color}22`
-            : T.panelAlt,
+              ? T.accentSoft
+              : cat
+                ? `${cat.color}22`
+                : T.panelAlt,
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
@@ -115,13 +121,32 @@ export function TxRow({
             gap: 8,
           }}
         >
-          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: vp.narrow ? 180 : 240 }}>
+          <span
+            style={{
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              maxWidth: vp.narrow ? 180 : 240,
+            }}
+          >
             {t.merchant || t.counterparty || "—"}
           </span>
           {failed && <Pill>Declined</Pill>}
-          {credit && <Pill bg="rgba(75,217,162,0.15)" color={T.green}>Income</Pill>}
-          {isFx && <Pill bg={T.panelAlt} color={T.muted}>{t.currency}</Pill>}
-          {t.excludedFromAnalytics && <Pill bg={T.panelAlt} color={T.dim}>Excluded</Pill>}
+          {credit && (
+            <Pill bg="rgba(75,217,162,0.15)" color={T.green}>
+              Income
+            </Pill>
+          )}
+          {isFx && (
+            <Pill bg={T.panelAlt} color={T.muted}>
+              {t.currency}
+            </Pill>
+          )}
+          {t.excludedFromAnalytics && (
+            <Pill bg={T.panelAlt} color={T.dim}>
+              Excluded
+            </Pill>
+          )}
         </div>
         <div
           style={{
@@ -143,7 +168,14 @@ export function TxRow({
         </div>
       </div>
       {!vp.narrow && (
-        <div style={{ fontFamily: T.sans, fontSize: 12, fontWeight: 500, position: "relative" }}>
+        <div
+          style={{
+            fontFamily: T.sans,
+            fontSize: 12,
+            fontWeight: 500,
+            position: "relative",
+          }}
+        >
           {canChangeCategory ? (
             <button
               onClick={(e) => {
@@ -167,10 +199,14 @@ export function TxRow({
                 transition: "background .12s ease",
               }}
               onMouseEnter={(e) => {
-                if (!pickerOpen) (e.currentTarget as HTMLButtonElement).style.background = T.panelAlt;
+                if (!pickerOpen)
+                  (e.currentTarget as HTMLButtonElement).style.background =
+                    T.panelAlt;
               }}
               onMouseLeave={(e) => {
-                if (!pickerOpen) (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+                if (!pickerOpen)
+                  (e.currentTarget as HTMLButtonElement).style.background =
+                    "transparent";
               }}
             >
               <span
@@ -184,7 +220,9 @@ export function TxRow({
               {cat?.name}
             </button>
           ) : (
-            <span style={{ color: T.muted }}>{credit ? "Income" : cat?.name}</span>
+            <span style={{ color: T.muted }}>
+              {credit ? "Income" : cat?.name}
+            </span>
           )}
           {pickerOpen && cat && (
             <CategoryPicker
@@ -197,13 +235,32 @@ export function TxRow({
         </div>
       )}
       {!vp.narrow && (
-        <div style={{ fontFamily: T.mono, fontSize: 10, color: T.dim, letterSpacing: 0.3 }}>
-          {new Date(t.transactionDate).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+        <div
+          style={{
+            fontFamily: T.mono,
+            fontSize: 10,
+            color: T.dim,
+            letterSpacing: 0.3,
+          }}
+        >
+          {new Date(t.transactionDate).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+          })}
         </div>
       )}
       <div style={{ textAlign: "right" }}>
         {failed ? (
-          <span style={{ fontFamily: T.sans, fontSize: 15, color: T.accent, fontWeight: 600 }}>—</span>
+          <span
+            style={{
+              fontFamily: T.sans,
+              fontSize: 15,
+              color: T.accent,
+              fontWeight: 600,
+            }}
+          >
+            —
+          </span>
         ) : (
           <span
             style={{
@@ -216,7 +273,9 @@ export function TxRow({
               // Dim the amount on excluded rows so the user can tell
               // at a glance the row isn't part of any total.
               opacity: t.excludedFromAnalytics ? 0.5 : 1,
-              textDecoration: t.excludedFromAnalytics ? "line-through" : undefined,
+              textDecoration: t.excludedFromAnalytics
+                ? "line-through"
+                : undefined,
             }}
           >
             {credit ? "+" : "−"}

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -336,7 +336,7 @@ export function Transactions() {
                       </span>
                     </div>
                     {items.map((t, i) => (
-                      <TxRow key={t.id} t={t} isLast={i === items.length - 1} onClick={() => setSelectedId(t.id)} />
+                      <TxRow key={t.id} t={t} isLast={i === items.length - 1} selected={t.id === selectedId} onClick={() => setSelectedId(t.id === selectedId ? null : t.id)} />
                     ))}
                   </div>
                 );
@@ -346,7 +346,7 @@ export function Transactions() {
         </Card>
 
         {selected && (
-          <Card pad="22px 24px" style={{ display: "flex", flexDirection: "column" }}>
+          <Card pad="22px 24px" style={{ display: "flex", flexDirection: "column", position: "sticky", top: 28, alignSelf: "start", maxHeight: "calc(100vh - 56px)", overflowY: "auto" }}>
             <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 14 }}>
               <CardLabel>{selected.kind === "failed" ? "Declined payment" : "Payment"}</CardLabel>
               <button


### PR DESCRIPTION
## Summary      
  - Clamp dropdown height to available viewport space (above or below trigger) so the category list is never cut off
  - Category list scrolls within the clamped space instead of overflowing                                                                                       
  - Close the picker on any scroll event (window or inner scroll containers)  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added transaction selection with visual highlighting for selected rows
  * Category picker now auto-dismisses when scrolling the window
  * Improved dropdown positioning with dynamic height calculation based on available space
  * Transaction detail panel now uses sticky positioning and supports independent scrolling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->