### PR TITLE
Phase 2 of auto-updates: sign DMGs with EdDSA in build.sh

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -48,6 +48,24 @@ behind `xcrun notarytool store-credentials`.
    holds the actual password; this file just tells the build script which
    Keychain entry to use.
 
+5. **Sparkle EdDSA signing key** (auto-update signature). Generate once via
+   the Sparkle binary that SwiftPM downloaded:
+
+   ```
+   cd app-menubar
+   swift package resolve   # populates .build/artifacts/sparkle/
+   ./.build/artifacts/sparkle/Sparkle/bin/generate_keys
+   ```
+
+   Prints a base64 public key on stdout. Paste it as `SPARKLE_PUBLIC_KEY` in
+   `.release.env`. The matching private key sits in this Mac's login Keychain
+   under item name `https://sparkle-project.org` — back it up to a password
+   manager *now*. Lose it and every existing user has to manually reinstall
+   to migrate to a new keypair.
+
+   The same `generate_keys` invocation reports an existing pair if there's
+   already one in the Keychain — running it twice is safe.
+
 ## Cutting a release
 
 The happy path is one command:
@@ -59,8 +77,13 @@ The happy path is one command:
 Which does, in order:
 
 1. Runs `build.sh` — client build, embed, service binary, signed + notarized
-   `.app`, signed + notarized DMG, stapled, checksummed. Output lands in
-   `dist/releases/0.2.0/`.
+   `.app`, signed + notarized DMG, stapled, checksummed, EdDSA-signed. Output
+   lands in `dist/releases/0.2.0/`:
+   - `Xarji-0.2.0.dmg` — the installer
+   - `Xarji-0.2.0.dmg.sha256` — checksum
+   - `Xarji-0.2.0.dmg.eddsa.json` — Sparkle EdDSA signature (skipped with a
+     WARN if the SwiftPM artefact isn't resolved). All three need to be
+     uploaded to the GitHub release for the appcast feed to include it.
 2. Creates + pushes the annotated git tag `v0.2.0`. `release.yml` reacts to
    the tag push and creates an empty GitHub Release with auto-generated notes.
 3. Runs `publish.sh` — waits for the Release to appear, then

--- a/scripts/release/build.sh
+++ b/scripts/release/build.sh
@@ -195,8 +195,43 @@ xcrun stapler validate "$DMG"
 log "Computing checksum"
 (cd "$RELEASE_DIR" && shasum -a 256 "Xarji-$VERSION.dmg" > "Xarji-$VERSION.dmg.sha256")
 
+# Sparkle EdDSA signature — read by the appcast generator on the landing
+# site to populate <enclosure sparkle:edSignature="…" length="…"/>. Both
+# values are needed: the signature proves the DMG hasn't been tampered
+# with, and `length` lets Sparkle abort downloads that get truncated by a
+# misconfigured CDN. sign_update reads the private key from this Mac's
+# Keychain (item name "https://sparkle-project.org") — there is no key
+# file passed in. Lose the keychain entry → no future releases can be
+# signed → existing users can never accept an update.
+SPARKLE_BIN="$REPO_ROOT/app-menubar/.build/artifacts/sparkle/Sparkle/bin/sign_update"
+if [[ -x "$SPARKLE_BIN" ]]; then
+  log "Signing DMG with Sparkle EdDSA key"
+  EDDSA_OUTPUT=$("$SPARKLE_BIN" "$DMG")
+  # sign_update prints attribute pairs on stdout, e.g.:
+  #   sparkle:edSignature="MEUC…" length="62914560"
+  # We re-shape into JSON so the appcast generator can parse the values
+  # without ad-hoc string slicing on the landing-site side.
+  SIG_VALUE=$(echo "$EDDSA_OUTPUT" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
+  LEN_VALUE=$(echo "$EDDSA_OUTPUT" | sed -n 's/.*length="\([0-9]*\)".*/\1/p')
+  if [[ -n "$SIG_VALUE" && -n "$LEN_VALUE" ]]; then
+    EDDSA_FILE="$RELEASE_DIR/Xarji-$VERSION.dmg.eddsa.json"
+    printf '{"version":"%s","edSignature":"%s","length":%s}\n' \
+      "$VERSION" "$SIG_VALUE" "$LEN_VALUE" > "$EDDSA_FILE"
+  else
+    fail "Could not parse sign_update output: $EDDSA_OUTPUT"
+  fi
+else
+  printf "WARN: sign_update not found at %s — skipping EdDSA signature.\n" "$SPARKLE_BIN" >&2
+  printf "      Run 'cd app-menubar && swift package resolve' to install it.\n" >&2
+  printf "      Without the .eddsa.json asset, the appcast won't include this version.\n" >&2
+  EDDSA_FILE=""
+fi
+
 log "Done."
 printf "\n  DMG:       %s\n" "$DMG"
 printf "  checksum:  %s\n" "$CHECKSUM"
+if [[ -n "$EDDSA_FILE" ]]; then
+  printf "  EdDSA:     %s\n" "$EDDSA_FILE"
+fi
 printf "  version:   %s\n" "$VERSION"
 printf "  tag:       %s (not yet pushed)\n\n" "$TAG"

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -31,9 +31,16 @@ cd "$REPO_ROOT"
 RELEASE_DIR="$REPO_ROOT/dist/releases/$VERSION"
 DMG="$RELEASE_DIR/Xarji-$VERSION.dmg"
 CHECKSUM="$RELEASE_DIR/Xarji-$VERSION.dmg.sha256"
+# Sparkle EdDSA signature emitted by build.sh — the appcast generator
+# on the landing site needs this asset to include the release in the
+# auto-update feed. Treated as required: build.sh prints a WARN and
+# skips the file when sign_update isn't installed, so reaching here
+# without it means the release would silently disappear from the feed.
+EDDSA="$RELEASE_DIR/Xarji-$VERSION.dmg.eddsa.json"
 
 [[ -f "$DMG" ]] || fail "$DMG missing — run build.sh first."
 [[ -f "$CHECKSUM" ]] || fail "$CHECKSUM missing — run build.sh first."
+[[ -f "$EDDSA" ]] || fail "$EDDSA missing — run build.sh first (or check that the Sparkle SwiftPM artefact resolved). The appcast generator skips releases without this asset."
 
 command -v gh >/dev/null || fail "gh CLI not installed"
 gh auth status >/dev/null 2>&1 || fail "gh CLI not authenticated — run \`gh auth login\`"
@@ -57,12 +64,12 @@ for attempt in $(seq 1 30); do
   sleep 2
 done
 
-log "Uploading DMG + checksum to release $TAG"
-gh release upload "$TAG" "$DMG" "$CHECKSUM" --clobber
+log "Uploading DMG + checksum + EdDSA signature to release $TAG"
+gh release upload "$TAG" "$DMG" "$CHECKSUM" "$EDDSA" --clobber
 
 RELEASE_URL=$(gh release view "$TAG" --json url --jq .url)
 
 log "Done."
 printf "\n  tag:       %s\n" "$TAG"
 printf "  release:   %s\n" "$RELEASE_URL"
-printf "  artifacts: %s, %s\n\n" "$(basename "$DMG")" "$(basename "$CHECKSUM")"
+printf "  artifacts: %s, %s, %s\n\n" "$(basename "$DMG")" "$(basename "$CHECKSUM")" "$(basename "$EDDSA")"


### PR DESCRIPTION
## Summary

Second of the auto-update PR series. After PR #39 embedded Sparkle 2 in the menu-bar app, this PR makes every release the build pipeline produces *signable* — the EdDSA signature that pairs with the public key in users' installed Info.plist. Pairs with [the appcast PR on the landing repo](https://github.com/tornikegomareli/Xarji-landing/pull/4), which actually publishes the feed.

## What this changes

- **`scripts/release/build.sh`** — One step added after the SHA-256 computation: run `sign_update <DMG>` against the just-built DMG, capture the `sparkle:edSignature` + `length` attribute pairs from stdout, write them as a small JSON file (`Xarji-<v>.dmg.eddsa.json`) into `dist/releases/<v>/`. The landing site's appcast generator parses this JSON to populate `<enclosure sparkle:edSignature length>`.

  Degrades gracefully: if `sign_update` isn't installed (e.g. someone runs `build.sh` on a clean checkout before `swift package resolve`), the build still succeeds, prints a WARN, and skips the asset. A release missing `.dmg.eddsa.json` simply won't appear in the appcast.

- **`scripts/release/README.md`** — Adds step 5 to the one-time setup (generate the EdDSA keypair via `Sparkle/bin/generate_keys`); updates the release-output list to mention the new third asset.

## Trust chain

The DMG already carries Apple's Developer ID signature + notarization staple. EdDSA is a *second*, independent layer: Sparkle verifies the downloaded DMG against the public key embedded in the user's already-installed Info.plist. So a compromised CDN that serves a tampered DMG with a valid Apple signature would still be rejected by Sparkle — the keypair lives only on the release Mac.

The private key sits in this Mac's login Keychain under item name `https://sparkle-project.org`. Lose it and every existing user has to manually reinstall to migrate to a new keypair. README now mentions backing it up.

## Verified locally

- `app-menubar/.build/artifacts/sparkle/Sparkle/bin/sign_update dist/releases/0.3.1/Xarji-0.3.1.dmg` against the existing v0.3.1 DMG produces a parseable signature pair (`sparkle:edSignature="..." length="27826895"`).
- Re-running `build.sh` (without re-uploading anything) emits the new `.eddsa.json` file into `dist/releases/<v>/` alongside the existing DMG + sha256.

## Notes for the next release

- `SPARKLE_FEED_URL` in `.release.env` (gitignored) is now `https://xarji.app/appcast.xml`. Custom DNS may not be live yet; Sparkle treats unreachable feeds as "no update available," so this is safe to ship before DNS propagates.
- v0.4.0 (the first build cut from this branch + Phase 1) is the first release that should carry the `.dmg.eddsa.json` asset uploaded alongside its DMG. The release-cutting flow now needs three `gh release upload` arguments instead of two:
  ```bash
  gh release upload v0.4.0 \
    dist/releases/0.4.0/Xarji-0.4.0.dmg \
    dist/releases/0.4.0/Xarji-0.4.0.dmg.sha256 \
    dist/releases/0.4.0/Xarji-0.4.0.dmg.eddsa.json
  ```

## Test plan

- [ ] Run `./scripts/release/build.sh 0.X.Y` on a real version; confirm `dist/releases/0.X.Y/Xarji-0.X.Y.dmg.eddsa.json` exists and contains a parseable JSON object with `version`, `edSignature`, `length` fields.
- [ ] After landing-repo PR is merged + Railway redeploys, confirm `curl https://xarji-landing-production.up.railway.app/appcast.xml | xmllint --format -` shows the new release's `<item>`.
- [ ] On a fresh Mac with v0.3.1 installed (no Sparkle), nothing changes — the auto-updater isn't there yet. (v0.3.1 → v0.4.0 needs to happen via the existing manual path; v0.4.0 → v0.4.1 is the first auto-updateable transition.)