### PR TITLE
PR Title: Fix Sparkle dyld crash — add @loader_path/../Frameworks rpath

### DIFF
--- a/app-menubar/Scripts/package_app.sh
+++ b/app-menubar/Scripts/package_app.sh
@@ -140,6 +140,7 @@ if [[ ! -x "$SWIFT_BIN" ]]; then
 fi
 cp "$SWIFT_BIN" "$APP/Contents/MacOS/XarjiMenuBar"
 chmod +x "$APP/Contents/MacOS/XarjiMenuBar"
+install_name_tool -add_rpath "@loader_path/../Frameworks" "$APP/Contents/MacOS/XarjiMenuBar"
 
 # Drop the compiled Bun service alongside. The menu-bar app Process-
 # spawns this on launch; see CoreProcess.swift resolveCoreBinary().


### PR DESCRIPTION
## Summary                                                                                                                                                    
  - SwiftPM only embeds `@loader_path` in the binary's LC_RPATH, which resolves                                                                                 
    to `Contents/MacOS/`. Sparkle.framework lives in `Contents/Frameworks/`, so
    dyld couldn't find it at launch and aborted with "Library not loaded".                                                                                      
  - Added `install_name_tool -add_rpath "@loader_path/../Frameworks"` in                                                                                        
    `package_app.sh` after copying the binary, before codesign.   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS app packaging configuration for improved framework resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->