### PR TITLE
Phase 1 of flex budgeting: schema + /budgets page MVP

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Layout } from "./components/Layout";
-import { Dashboard, Transactions, Categories, Merchants, Income, Signals, Settings, Assistant } from "./pages";
+import { Dashboard, Transactions, Categories, Budgets, Merchants, Income, Signals, Settings, Assistant } from "./pages";
 
 function App() {
   return (
@@ -11,6 +11,7 @@ function App() {
           <Route path="transactions" element={<Transactions />} />
           <Route path="income" element={<Income />} />
           <Route path="categories" element={<Categories />} />
+          <Route path="budgets" element={<Budgets />} />
           <Route path="merchants" element={<Merchants />} />
           <Route path="assistant" element={<Assistant />} />
           <Route path="signals" element={<Signals />} />

--- a/client/src/dev/demoData.ts
+++ b/client/src/dev/demoData.ts
@@ -145,20 +145,26 @@ function buildPayments(rng: () => number, now: Date): Payment[] {
     const weekday = date.getDay();
     const weekMul = weekday === 0 || weekday === 6 ? 1.3 : 1.0;
     const recencyMul = daysBack < 45 ? 1.0 : 0.85;
-    // Dampen current-month flex spending so /budgets shows flex
-    // remaining > 0 in demos (without this, the organic loop spends
-    // ~₾7-8k against a ~₾8.5k flex pool — close to zero remaining,
-    // which makes the headline number look broken even though it's
-    // accurate). Halving the current month leaves ~₾4k flex remaining,
-    // which is the right "you have headroom" story for screencasts.
+    // Dampen current-month flex spending so /budgets and the
+    // Dashboard show positive net cashflow + meaningful flex
+    // remaining in demos. Two levers, both ×0.5 → 0.25× total spend
+    // reduction. Halving the count alone wasn't enough because
+    // big-ticket merchants (Elit Electronics, Booking, Wizz Air)
+    // pull the per-transaction average up; halving the per-tx
+    // amount as well clips outlier impact without removing those
+    // merchants from the demo entirely. Past months keep full
+    // volume so the trend chart + rollover math (Phase 2) still
+    // have realistic actuals to walk over.
     const inCurrentMonth =
       date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth();
-    const monthMul = inCurrentMonth ? 0.5 : 1.0;
-    const count = Math.max(0, Math.round((2 + rng() * 5) * weekMul * recencyMul * monthMul));
+    const countMul = inCurrentMonth ? 0.5 : 1.0;
+    const amountMul = inCurrentMonth ? 0.5 : 1.0;
+    const count = Math.max(0, Math.round((2 + rng() * 5) * weekMul * recencyMul * countMul));
 
     for (let i = 0; i < count; i++) {
       const m = pick(rng, MERCHANTS);
-      const baseAmount = round2(m.range[0] + rng() * (m.range[1] - m.range[0]));
+      const rawBaseAmount = round2(m.range[0] + rng() * (m.range[1] - m.range[0]));
+      const baseAmount = round2(rawBaseAmount * amountMul);
       const hour = 8 + Math.floor(rng() * 14);
       const minute = Math.floor(rng() * 60);
       date.setHours(hour, minute, Math.floor(rng() * 60));

--- a/client/src/dev/demoData.ts
+++ b/client/src/dev/demoData.ts
@@ -7,7 +7,7 @@
 // from `./demoDb`, which itself is only reached behind a static
 // `import.meta.env.DEV && isDemoMode()` gate in `lib/instant.ts`.
 
-import type { Payment, FailedPayment, Credit, Category, BankSender } from "../lib/instant";
+import type { Payment, FailedPayment, Credit, Category, BankSender, BudgetPlan } from "../lib/instant";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 
 function mulberry32(seed: number) {
@@ -33,13 +33,42 @@ const SENDERS: BankSender[] = [
   { id: "bs-bog", senderId: "BOG", displayName: "Main", enabled: true, createdAt: Date.now() - 9 * 30 * 86400000 },
 ];
 
-const CATEGORIES: Category[] = DEFAULT_CATEGORIES.map((c) => ({
-  id: `cat-${c.id}`,
-  name: c.name,
-  color: c.color,
-  icon: c.icon,
-  isDefault: true,
-}));
+// Bucket assignments for the demo dataset. Hand-picked so the
+// /budgets page renders a non-trivial example out of the box: a few
+// Fixed (predictable subscriptions/utilities), the rest Flex
+// (discretionary), one Non-Monthly (Travel — accrues to a sinking
+// fund). Targets reflect realistic GEL amounts that sum into a
+// flex-pool the demo income (~₾4800) actually supports.
+const DEMO_BUCKET_ASSIGNMENTS: Record<
+  string,
+  { bucket: "fixed" | "flex" | "non_monthly"; targetAmount?: number; frequencyMonths?: number; rolloverEnabled?: boolean }
+> = {
+  groceries: { bucket: "flex" },
+  dining: { bucket: "flex" },
+  food: { bucket: "flex" },
+  transport: { bucket: "flex" },
+  subs: { bucket: "fixed", targetAmount: 200, rolloverEnabled: true },
+  shopping: { bucket: "flex" },
+  travel: { bucket: "non_monthly", targetAmount: 2400, frequencyMonths: 12 },
+  utilities: { bucket: "fixed", targetAmount: 220, rolloverEnabled: false },
+  health: { bucket: "flex" },
+  fun: { bucket: "flex" },
+  loans: { bucket: "fixed", targetAmount: 800, rolloverEnabled: false },
+  cash: { bucket: "flex" },
+  other: { bucket: "flex" },
+};
+
+const CATEGORIES: Category[] = DEFAULT_CATEGORIES.map((c) => {
+  const bucketSpec = DEMO_BUCKET_ASSIGNMENTS[c.id];
+  return {
+    id: `cat-${c.id}`,
+    name: c.name,
+    color: c.color,
+    icon: c.icon,
+    isDefault: true,
+    ...(bucketSpec ?? {}),
+  };
+});
 
 // Merchants chosen to match every regex bucket in lib/utils.ts so the
 // donut populates all 11 default categories. Amount ranges in GEL.
@@ -400,6 +429,43 @@ export interface DemoDataset {
   credits: Credit[];
   categories: Category[];
   bankSenders: BankSender[];
+  budgetPlans: BudgetPlan[];
+}
+
+// Two months of budgetPlans seeded for the demo: the current month
+// (auto-everything) plus the previous month (also auto). Two rows
+// gives the rollover anchor a real value, so demo viewers see
+// non-zero "carried" indicators on Fixed-with-rollover + Non-Monthly
+// rows after at least one historical month exists.
+function buildBudgetPlans(now: Date): BudgetPlan[] {
+  const cur = new Date(now.getFullYear(), now.getMonth(), 1);
+  const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  const fmt = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  const ts = (d: Date) => d.getTime();
+  return [
+    {
+      id: `plan-${fmt(prev)}`,
+      planMonth: fmt(prev),
+      expectedIncome: 0,
+      expectedIncomeAuto: true,
+      flexPool: 0,
+      flexPoolAuto: true,
+      savingsTarget: 500,
+      createdAt: ts(prev),
+      updatedAt: ts(prev),
+    },
+    {
+      id: `plan-${fmt(cur)}`,
+      planMonth: fmt(cur),
+      expectedIncome: 0,
+      expectedIncomeAuto: true,
+      flexPool: 0,
+      flexPoolAuto: true,
+      savingsTarget: 500,
+      createdAt: ts(cur),
+      updatedAt: ts(cur),
+    },
+  ];
 }
 
 export function buildDemoDataset(seed: "default" | "empty"): DemoDataset {
@@ -410,6 +476,7 @@ export function buildDemoDataset(seed: "default" | "empty"): DemoDataset {
       credits: [],
       categories: [],
       bankSenders: [],
+      budgetPlans: [],
     };
   }
   const rng = mulberry32(20260424);
@@ -420,5 +487,6 @@ export function buildDemoDataset(seed: "default" | "empty"): DemoDataset {
     credits: buildCredits(rng, now),
     categories: CATEGORIES,
     bankSenders: SENDERS,
+    budgetPlans: buildBudgetPlans(now),
   };
 }

--- a/client/src/dev/demoData.ts
+++ b/client/src/dev/demoData.ts
@@ -145,7 +145,16 @@ function buildPayments(rng: () => number, now: Date): Payment[] {
     const weekday = date.getDay();
     const weekMul = weekday === 0 || weekday === 6 ? 1.3 : 1.0;
     const recencyMul = daysBack < 45 ? 1.0 : 0.85;
-    const count = Math.max(0, Math.round((2 + rng() * 5) * weekMul * recencyMul));
+    // Dampen current-month flex spending so /budgets shows flex
+    // remaining > 0 in demos (without this, the organic loop spends
+    // ~₾7-8k against a ~₾8.5k flex pool — close to zero remaining,
+    // which makes the headline number look broken even though it's
+    // accurate). Halving the current month leaves ~₾4k flex remaining,
+    // which is the right "you have headroom" story for screencasts.
+    const inCurrentMonth =
+      date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth();
+    const monthMul = inCurrentMonth ? 0.5 : 1.0;
+    const count = Math.max(0, Math.round((2 + rng() * 5) * weekMul * recencyMul * monthMul));
 
     for (let i = 0; i < count; i++) {
       const m = pick(rng, MERCHANTS);

--- a/client/src/dev/demoDb.ts
+++ b/client/src/dev/demoDb.ts
@@ -35,6 +35,7 @@ function seed(dataset: DemoDataset) {
   store.set("credits", dataset.credits as unknown as AnyRecord[]);
   store.set("categories", dataset.categories as unknown as AnyRecord[]);
   store.set("bankSenders", dataset.bankSenders as unknown as AnyRecord[]);
+  store.set("budgetPlans", dataset.budgetPlans as unknown as AnyRecord[]);
 }
 
 function getSnapshot(collection: Collection): readonly AnyRecord[] {

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -142,7 +142,7 @@ export function useAgentRunner() {
   const { failedPayments } = useFailedPayments();
   const { categories } = useCategories();
   const { senders } = useBankSenders();
-  const { categorizeName, allCategories } = useCategorizer();
+  const { categorizeName, categorize, allCategories } = useCategorizer();
   const { overrides } = useMerchantOverrides();
   const { plans } = useBudgetPlans();
 
@@ -180,6 +180,7 @@ export function useAgentRunner() {
           overrides,
           now: new Date(),
           categorizeName,
+          categorize,
           // Getters that read fresh state via the ref — see comment on
           // liveRef above for the why. The non-getter fields above are
           // captured once for the run; tools that mutate state should
@@ -192,6 +193,6 @@ export function useAgentRunner() {
         signal,
       });
     },
-    [payments, credits, failedPayments, categories, senders, overrides, categorizeName]
+    [payments, credits, failedPayments, categories, senders, overrides, categorizeName, categorize]
   );
 }

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -156,6 +156,10 @@ export function useAgentRunner() {
   // when set_expected_income is followed by set_flex_pool in one turn.
   const liveRef = useRef({ allCategories, overrides, categories, plans });
   liveRef.current = { allCategories, overrides, categories, plans };
+  // categories is also exposed via getCategories for chained budget
+  // writes — see types.ts JSDoc on AIToolContext.getCategories. The
+  // ref already tracks `categories`; getCategories just reads it
+  // through the same getter pattern as getAllCategories etc.
 
   return useCallback(
     async (
@@ -187,6 +191,7 @@ export function useAgentRunner() {
           // use the getters for everything they touch.
           getAllCategories: () => liveRef.current.allCategories,
           getOverrides: () => liveRef.current.overrides,
+          getCategories: () => liveRef.current.categories,
           getPlans: () => liveRef.current.plans,
         },
         emit,

--- a/client/src/hooks/useAgentRunner.ts
+++ b/client/src/hooks/useAgentRunner.ts
@@ -12,17 +12,19 @@ import { getProviderClient } from "../lib/ai/provider";
 import { runAgent, type AssistantEvent } from "../lib/ai/orchestrator";
 import { READONLY_TOOLS } from "../lib/ai/tools/readonly";
 import { WRITE_TOOLS } from "../lib/ai/tools/write";
+import { BUDGET_TOOLS } from "../lib/ai/tools/budgets";
 import type { AITool } from "../lib/ai/tools/types";
 import type { AICoreMessage } from "../lib/ai/types";
 import type { AIConfig } from "../lib/aiConfig";
 import { useMerchantOverrides } from "./useMerchantOverrides";
+import { useBudgetPlans } from "./useBudgets";
 
 // Tool registries the agent has access to. Adding a tool to one of
 // these lists automatically (a) makes it callable by the model and
 // (b) appends it to the "Available tools" section of the system
 // prompt — see buildSystemPrompt() below. Adding a NEW registry?
 // Concatenate it into ALL_TOOLS so both effects happen.
-const ALL_TOOLS: AITool[] = [...READONLY_TOOLS, ...WRITE_TOOLS];
+const ALL_TOOLS: AITool[] = [...READONLY_TOOLS, ...WRITE_TOOLS, ...BUDGET_TOOLS];
 
 const BASE_SYSTEM_PROMPT = `You are Xarji's AI Assistant, a personal finance assistant embedded inside the Xarji dashboard.
 
@@ -60,6 +62,15 @@ Write tools:
 - \`exclude_transaction\` hides a transaction from analytics totals, donut, trends, and signals — the row stays visible in the /transactions or /income ledger with an "Excluded" pill. Fully reversible via \`include_transaction\` on the same id. Use when the user says things like "don't count that ₾4280 IKEA purchase, it was for someone else", "exclude this from my spending", or "ignore that one in the math".
 - Both exclusion tools accept \`kind\` ("payment" or "credit") so the model can hide either an outgoing payment or an incoming credit. Default is "payment".
 - To find the row id and current state, call \`search_transactions\` first — it returns each row's \`id\`, \`kind\`, and \`excludedFromAnalytics\`, which is exactly what \`exclude_transaction\` / \`include_transaction\` need. Use the \`kind\` filter on \`search_transactions\` to narrow to payments or credits when the user's wording makes that clear.
+
+Flex budgeting:
+- Xarji has a Monarch-style three-bucket budgeting model on the \`/budgets\` page. Categories carry a \`bucket\` ("fixed", "flex", or "non_monthly") plus a target. The headline number is **flex remaining** — what the user has left to spend on discretionary stuff this month.
+- Use \`get_budget_summary\` for plan-aware questions ("how much flex do I have left", "am I on track this month", "what's my budget for X").
+- Use \`list_budgets_by_bucket\` for "show me all my budgets", "which categories are over budget".
+- Write tools auto-apply: \`set_category_bucket\`, \`set_category_target\`, \`set_category_rollover\`, \`set_expected_income\`, \`set_flex_pool\`, \`set_savings_target\`, \`clear_category_budget\`.
+- The flex-pool formula is: expectedIncome − sum(fixed targets) − sum(non-monthly accruals) − savingsTarget. If the user wants to manually override the flex pool, use \`set_flex_pool\`. If they want auto-derive back, call \`set_flex_pool\` with \`amountGEL: null\`.
+- For Non-Monthly categories, both \`targetGEL\` and \`frequencyMonths\` are required (e.g. ₾2400 across 12 months = ₾200/mo accrual). Fixed categories only need \`targetGEL\`. Flex categories don't take per-category targets — the bucket pool is the limit.
+- Rollover semantics: Fixed categories opt in via \`set_category_rollover\`. Non-Monthly always rolls (sinking-fund balance). Flex never rolls. Rollover only kicks in once the user has saved a plan; before that, current month starts at zero carry.
 
 UI-only actions you can describe but not execute:
 - **Delete a category**: not a tool. Tell the user to open \`/categories\` and click the × button on the category row — the existing confirm dialog there is the right place for a destructive action. After confirming, that same code path also cleans up any merchant overrides pointing at the deleted category.
@@ -133,6 +144,7 @@ export function useAgentRunner() {
   const { senders } = useBankSenders();
   const { categorizeName, allCategories } = useCategorizer();
   const { overrides } = useMerchantOverrides();
+  const { plans } = useBudgetPlans();
 
   // Ref-based snapshot of live state. Updated on every render so that
   // tools called LATER in a single agentic loop see fresh data after
@@ -140,9 +152,10 @@ export function useAgentRunner() {
   // assistant turn that does `create_category` then `apply_category_
   // override` validates the second call against the snapshot taken
   // BEFORE the first call ran, rejecting the just-created id. Codex
-  // HIGH on PR #32.
-  const liveRef = useRef({ allCategories, overrides, categories });
-  liveRef.current = { allCategories, overrides, categories };
+  // HIGH on PR #32. The same staleness story applies to budget plans
+  // when set_expected_income is followed by set_flex_pool in one turn.
+  const liveRef = useRef({ allCategories, overrides, categories, plans });
+  liveRef.current = { allCategories, overrides, categories, plans };
 
   return useCallback(
     async (
@@ -173,6 +186,7 @@ export function useAgentRunner() {
           // use the getters for everything they touch.
           getAllCategories: () => liveRef.current.allCategories,
           getOverrides: () => liveRef.current.overrides,
+          getPlans: () => liveRef.current.plans,
         },
         emit,
         signal,

--- a/client/src/hooks/useBudgets.ts
+++ b/client/src/hooks/useBudgets.ts
@@ -183,8 +183,16 @@ export function useBudgetSummary(planMonth = planMonthKey()) {
  * `db.transact` call, keeping the InstantDB write surface in one
  * place (matches the useTransactionExclude / useCategoryActions
  * pattern elsewhere in the app).
+ *
+ * Subscribes to the budgetPlans list so upsertPlan can decide
+ * insert-vs-update against React state rather than calling
+ * `db.queryOnce` — the demo DB at `client/src/dev/demoDb.ts` doesn't
+ * implement queryOnce, so going through the live subscription makes
+ * the same code path work in real and demo modes. (Codex P2 on PR
+ * #42.)
  */
 export function useBudgetMutations() {
+  const { plans } = useBudgetPlans();
   const setCategoryBucket = useCallback(async (categoryId: string, bucket: Bucket | null) => {
     if (bucket === null) {
       // Unclassify: clear bucket + target + frequency + rollover so
@@ -215,7 +223,6 @@ export function useBudgetMutations() {
   const upsertPlan = useCallback(
     async (planMonth: string, updates: Partial<Omit<BudgetPlan, "id" | "planMonth" | "createdAt">>) => {
       const now = Date.now();
-      const { plans } = await readPlans();
       const existing = plans.find((p) => p.planMonth === planMonth);
       if (existing) {
         await db.transact(
@@ -240,7 +247,7 @@ export function useBudgetMutations() {
         );
       }
     },
-    []
+    [plans]
   );
 
   const setExpectedIncome = useCallback(
@@ -331,15 +338,4 @@ function planMonthYear(key: string): number {
 
 function planMonthMonth(key: string): number {
   return Number(key.slice(5, 7)) - 1;
-}
-
-// One-shot read for upsert decisions. We can't useQuery in a callback,
-// so this wraps the fact that the plans list is already cached by
-// useBudgetPlans elsewhere on the page — calling .queryOnce() here
-// handles the rare case where the mutation runs before useBudgetPlans
-// has subscribed.
-async function readPlans(): Promise<{ plans: BudgetPlan[] }> {
-  const result = await db.queryOnce({ budgetPlans: {} });
-  const plans = ((result.data?.budgetPlans ?? []) as BudgetPlan[]) ?? [];
-  return { plans };
 }

--- a/client/src/hooks/useBudgets.ts
+++ b/client/src/hooks/useBudgets.ts
@@ -1,0 +1,345 @@
+// React hooks for the flex-budgeting feature. Layer the pure utility
+// functions in lib/budgets.ts on top of InstantDB queries + the
+// existing categorizer / payments / credits hooks.
+
+import { useCallback, useMemo } from "react";
+import { id } from "@instantdb/react";
+import { db, type BudgetPlan, type Category } from "../lib/instant";
+import { useCategories } from "./useCategories";
+import { useConvertedCredits } from "./useCredits";
+import { useConvertedPayments } from "./useTransactions";
+import { useCategorizer } from "./useCategorizer";
+import {
+  bucketMonthlyCommitment,
+  computeFlexPool,
+  median,
+  monthlyAccrual,
+  planMonthKey,
+  type Bucket,
+} from "../lib/budgets";
+
+/**
+ * Read-only view of all budget plan rows. One per month at most.
+ * The page hooks below read the current month's plan via
+ * `useBudgetPlan(planMonth)`; this raw list is mostly useful for
+ * Phase 2 rollover math walking prior months.
+ */
+export function useBudgetPlans() {
+  const { data, isLoading, error } = db.useQuery({ budgetPlans: {} });
+  const plans = useMemo<BudgetPlan[]>(() => {
+    const rows = (data?.budgetPlans ?? []) as BudgetPlan[];
+    return [...rows].sort((a, b) => a.planMonth.localeCompare(b.planMonth));
+  }, [data?.budgetPlans]);
+  return { plans, isLoading, error };
+}
+
+/**
+ * 3-month rolling average of GEL-converted credits, excluding any
+ * `excludedFromAnalytics: true` rows. The default for
+ * expectedIncome — the user can always override.
+ *
+ * Returns 0 when the user has no qualifying credits in the window.
+ * The page surfaces a "no income detected" affordance in that case
+ * instead of silently showing a ₾0 flex pool.
+ */
+export function useExpectedIncomeDefault(now = new Date()): number {
+  const { credits } = useConvertedCredits();
+  return useMemo(() => {
+    const cutoff = new Date(now.getFullYear(), now.getMonth() - 3, 1).getTime();
+    const monthEnd = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
+    const monthly = new Map<string, number>();
+    for (const c of credits) {
+      if (c.gelAmount === null) continue;
+      if (c.excludedFromAnalytics) continue;
+      if (c.transactionDate < cutoff || c.transactionDate >= monthEnd) continue;
+      const d = new Date(c.transactionDate);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+      monthly.set(key, (monthly.get(key) ?? 0) + c.gelAmount);
+    }
+    if (monthly.size === 0) return 0;
+    const totals = Array.from(monthly.values());
+    return totals.reduce((s, x) => s + x, 0) / totals.length;
+  }, [credits, now]);
+}
+
+/**
+ * Resolved view of one month's budget plan. If a row exists it's
+ * read as-is; otherwise the values fall back to the auto-derived
+ * defaults (income from `useExpectedIncomeDefault`, pool from the
+ * canonical formula). The `auto` flags reflect what the page
+ * displays — a stored row with `expectedIncomeAuto: true` will
+ * still render the auto-derived value, not the stale stored one.
+ *
+ * No row is created until the user explicitly saves a change. That
+ * keeps the DB free of empty-state plan rows for months the user
+ * hasn't visited.
+ */
+export function useBudgetPlan(planMonth = planMonthKey()) {
+  const { plans, isLoading, error } = useBudgetPlans();
+  const expectedIncomeAuto = useExpectedIncomeDefault();
+  const { categories } = useCategories();
+
+  return useMemo(() => {
+    const stored = plans.find((p) => p.planMonth === planMonth) ?? null;
+    const expectedIncome =
+      stored && !stored.expectedIncomeAuto ? stored.expectedIncome : expectedIncomeAuto;
+    const fixedTargets = sumByBucket(categories, "fixed");
+    const nonMonthlyAccruals = sumByBucket(categories, "non_monthly");
+    const savingsTarget = stored?.savingsTarget ?? 0;
+    const flexPoolAuto = computeFlexPool({
+      expectedIncome,
+      fixedTargets,
+      nonMonthlyAccruals,
+      savingsTarget,
+    });
+    const flexPool = stored && !stored.flexPoolAuto ? stored.flexPool : flexPoolAuto;
+
+    return {
+      planMonth,
+      stored,
+      expectedIncome,
+      expectedIncomeIsAuto: !stored || stored.expectedIncomeAuto,
+      fixedTargets,
+      nonMonthlyAccruals,
+      savingsTarget,
+      flexPool,
+      flexPoolIsAuto: !stored || stored.flexPoolAuto,
+      autoDerivedFlexPool: flexPoolAuto,
+      isLoading,
+      error,
+    };
+  }, [plans, expectedIncomeAuto, categories, planMonth, isLoading, error]);
+}
+
+/**
+ * Per-bucket aggregate the page renders. For each category, returns
+ * the target + monthly commitment + actual spent this month +
+ * remaining. Honors `excludedFromAnalytics`. Phase 2 wires rollover
+ * carry on top of this shape.
+ */
+export function useBudgetSummary(planMonth = planMonthKey()) {
+  const { categories } = useCategories();
+  const { payments } = useConvertedPayments();
+  const { categorize } = useCategorizer();
+
+  return useMemo(() => {
+    const monthStart = new Date(planMonthYear(planMonth), planMonthMonth(planMonth), 1).getTime();
+    const monthEnd = new Date(planMonthYear(planMonth), planMonthMonth(planMonth) + 1, 1).getTime();
+
+    const spentByCategoryId = new Map<string, number>();
+    for (const p of payments) {
+      if (p.gelAmount === null) continue;
+      if (p.excludedFromAnalytics) continue;
+      if (p.transactionDate < monthStart || p.transactionDate >= monthEnd) continue;
+      const catId = categorize(p.merchant ?? null, p.rawMessage ?? null, p.id);
+      spentByCategoryId.set(catId, (spentByCategoryId.get(catId) ?? 0) + p.gelAmount);
+    }
+
+    type Row = {
+      category: Category;
+      bucket: Bucket | null;
+      target: number;
+      monthlyCommitment: number;
+      actual: number;
+      remaining: number;
+    };
+
+    const rows: Row[] = categories.map((c) => {
+      const bucket = isBucket(c.bucket) ? c.bucket : null;
+      const target = c.targetAmount ?? 0;
+      const monthlyCommitment = bucketMonthlyCommitment(c);
+      const actual = spentByCategoryId.get(c.id) ?? 0;
+      const remaining = bucket === "fixed" ? target - actual : monthlyCommitment - actual;
+      return { category: c, bucket, target, monthlyCommitment, actual, remaining };
+    });
+
+    const byBucket = {
+      fixed: rows.filter((r) => r.bucket === "fixed"),
+      flex: rows.filter((r) => r.bucket === "flex"),
+      non_monthly: rows.filter((r) => r.bucket === "non_monthly"),
+      unclassified: rows.filter((r) => r.bucket === null),
+    };
+
+    const fixedActual = byBucket.fixed.reduce((s, r) => s + r.actual, 0);
+    const fixedTarget = byBucket.fixed.reduce((s, r) => s + r.target, 0);
+    const flexActual = byBucket.flex.reduce((s, r) => s + r.actual, 0);
+    const nonMonthlyActual = byBucket.non_monthly.reduce((s, r) => s + r.actual, 0);
+    const nonMonthlyAccruals = byBucket.non_monthly.reduce((s, r) => s + r.monthlyCommitment, 0);
+
+    return {
+      rows,
+      byBucket,
+      fixedActual,
+      fixedTarget,
+      flexActual,
+      nonMonthlyActual,
+      nonMonthlyAccruals,
+    };
+  }, [categories, payments, categorize, planMonth]);
+}
+
+/**
+ * Mutations for the /budgets page. Each function wraps a single
+ * `db.transact` call, keeping the InstantDB write surface in one
+ * place (matches the useTransactionExclude / useCategoryActions
+ * pattern elsewhere in the app).
+ */
+export function useBudgetMutations() {
+  const setCategoryBucket = useCallback(async (categoryId: string, bucket: Bucket | null) => {
+    if (bucket === null) {
+      // Unclassify: clear bucket + target + frequency + rollover so
+      // the row resets to its pre-Phase-1 shape. Keep name/color/icon.
+      await db.transact(
+        db.tx.categories[categoryId].update({
+          bucket: undefined,
+          targetAmount: undefined,
+          frequencyMonths: undefined,
+          rolloverEnabled: undefined,
+        })
+      );
+    } else {
+      await db.transact(db.tx.categories[categoryId].update({ bucket }));
+    }
+  }, []);
+
+  const setCategoryTarget = useCallback(
+    async (
+      categoryId: string,
+      args: { targetAmount?: number; frequencyMonths?: number; rolloverEnabled?: boolean }
+    ) => {
+      await db.transact(db.tx.categories[categoryId].update(args));
+    },
+    []
+  );
+
+  const upsertPlan = useCallback(
+    async (planMonth: string, updates: Partial<Omit<BudgetPlan, "id" | "planMonth" | "createdAt">>) => {
+      const now = Date.now();
+      const { plans } = await readPlans();
+      const existing = plans.find((p) => p.planMonth === planMonth);
+      if (existing) {
+        await db.transact(
+          db.tx.budgetPlans[existing.id].update({ ...updates, updatedAt: now })
+        );
+      } else {
+        // Seed required fields with sensible defaults — the row gets
+        // created in auto-everything mode unless the caller said
+        // otherwise via `updates`.
+        const newId = id();
+        await db.transact(
+          db.tx.budgetPlans[newId].update({
+            planMonth,
+            expectedIncome: 0,
+            expectedIncomeAuto: true,
+            flexPool: 0,
+            flexPoolAuto: true,
+            createdAt: now,
+            updatedAt: now,
+            ...updates,
+          })
+        );
+      }
+    },
+    []
+  );
+
+  const setExpectedIncome = useCallback(
+    async (planMonth: string, value: number | null) => {
+      if (value === null) {
+        await upsertPlan(planMonth, { expectedIncomeAuto: true });
+      } else {
+        await upsertPlan(planMonth, {
+          expectedIncome: value,
+          expectedIncomeAuto: false,
+        });
+      }
+    },
+    [upsertPlan]
+  );
+
+  const setFlexPool = useCallback(
+    async (planMonth: string, value: number | null) => {
+      if (value === null) {
+        await upsertPlan(planMonth, { flexPoolAuto: true });
+      } else {
+        await upsertPlan(planMonth, { flexPool: value, flexPoolAuto: false });
+      }
+    },
+    [upsertPlan]
+  );
+
+  const setSavingsTarget = useCallback(
+    async (planMonth: string, value: number) => {
+      await upsertPlan(planMonth, { savingsTarget: value });
+    },
+    [upsertPlan]
+  );
+
+  return {
+    setCategoryBucket,
+    setCategoryTarget,
+    setExpectedIncome,
+    setFlexPool,
+    setSavingsTarget,
+  };
+}
+
+/**
+ * Wizard helper: median of monthly spend for one category in the
+ * last 3 months. Pre-fills the target field for Fixed suggestions.
+ */
+export function useCategoryMedianSpend(categoryId: string, months = 3, now = new Date()): number {
+  const { payments } = useConvertedPayments();
+  const { categorize } = useCategorizer();
+  return useMemo(() => {
+    const cutoff = new Date(now.getFullYear(), now.getMonth() - months, 1).getTime();
+    const monthlyTotals = new Map<string, number>();
+    for (const p of payments) {
+      if (p.gelAmount === null) continue;
+      if (p.excludedFromAnalytics) continue;
+      if (p.transactionDate < cutoff) continue;
+      const catId = categorize(p.merchant ?? null, p.rawMessage ?? null, p.id);
+      if (catId !== categoryId) continue;
+      const d = new Date(p.transactionDate);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+      monthlyTotals.set(key, (monthlyTotals.get(key) ?? 0) + p.gelAmount);
+    }
+    return median(Array.from(monthlyTotals.values()));
+  }, [payments, categorize, categoryId, months, now]);
+}
+
+// Helpers — kept inside the module since they're tied to the InstantDB
+// shape and would just be noise in lib/budgets.ts.
+
+function sumByBucket(categories: Category[], bucket: Bucket): number {
+  let sum = 0;
+  for (const c of categories) {
+    if (c.bucket !== bucket) continue;
+    if (bucket === "fixed") sum += c.targetAmount ?? 0;
+    if (bucket === "non_monthly") sum += monthlyAccrual(c);
+  }
+  return sum;
+}
+
+function isBucket(value: string | undefined): value is Bucket {
+  return value === "fixed" || value === "flex" || value === "non_monthly";
+}
+
+function planMonthYear(key: string): number {
+  return Number(key.slice(0, 4));
+}
+
+function planMonthMonth(key: string): number {
+  return Number(key.slice(5, 7)) - 1;
+}
+
+// One-shot read for upsert decisions. We can't useQuery in a callback,
+// so this wraps the fact that the plans list is already cached by
+// useBudgetPlans elsewhere on the page — calling .queryOnce() here
+// handles the rare case where the mutation runs before useBudgetPlans
+// has subscribed.
+async function readPlans(): Promise<{ plans: BudgetPlan[] }> {
+  const result = await db.queryOnce({ budgetPlans: {} });
+  const plans = ((result.data?.budgetPlans ?? []) as BudgetPlan[]) ?? [];
+  return { plans };
+}

--- a/client/src/hooks/useBudgets.ts
+++ b/client/src/hooks/useBudgets.ts
@@ -10,9 +10,12 @@ import { useConvertedCredits } from "./useCredits";
 import { useConvertedPayments } from "./useTransactions";
 import { useCategorizer } from "./useCategorizer";
 import {
+  anchorMonthFromPlans,
   bucketMonthlyCommitment,
   computeFlexPool,
+  computeRollover,
   median,
+  monthKeyFromTimestamp,
   monthlyAccrual,
   planMonthKey,
   type Bucket,
@@ -113,26 +116,50 @@ export function useBudgetPlan(planMonth = planMonthKey()) {
 
 /**
  * Per-bucket aggregate the page renders. For each category, returns
- * the target + monthly commitment + actual spent this month +
- * remaining. Honors `excludedFromAnalytics`. Phase 2 wires rollover
- * carry on top of this shape.
+ * target + monthly commitment + actual + rolloverIn (Phase 2) +
+ * remaining. Honors `excludedFromAnalytics`.
+ *
+ * Rollover semantics (Phase 2):
+ *   - Fixed with `rolloverEnabled: true`: leftover/overshoot from
+ *     prior months carries to current month's effective target.
+ *   - Non-Monthly: always rolls forward (sinking-fund balance) —
+ *     accrual_m − actual_m summed across months from the anchor.
+ *   - Flex: never rolls (matches Monarch's help docs).
+ *
+ * The anchor is the earliest planMonth in the user's saved plans.
+ * Months before the anchor are treated as 0-contribution; the user
+ * hadn't started budgeting yet, so we don't retro-credit nor debit.
  */
 export function useBudgetSummary(planMonth = planMonthKey()) {
   const { categories } = useCategories();
   const { payments } = useConvertedPayments();
   const { categorize } = useCategorizer();
+  const { plans } = useBudgetPlans();
 
   return useMemo(() => {
     const monthStart = new Date(planMonthYear(planMonth), planMonthMonth(planMonth), 1).getTime();
     const monthEnd = new Date(planMonthYear(planMonth), planMonthMonth(planMonth) + 1, 1).getTime();
+    const anchor = anchorMonthFromPlans(plans);
 
+    // Bucket-by-categoryId for current month spend AND build the
+    // (categoryId × monthKey) → spend lookup we hand to
+    // computeRollover. Walking payments once for both is an O(n)
+    // pass; Phase 1 walked twice in different callers.
     const spentByCategoryId = new Map<string, number>();
+    const monthlyActualsByCategory = new Map<string, number>();
     for (const p of payments) {
       if (p.gelAmount === null) continue;
       if (p.excludedFromAnalytics) continue;
-      if (p.transactionDate < monthStart || p.transactionDate >= monthEnd) continue;
       const catId = categorize(p.merchant ?? null, p.rawMessage ?? null, p.id);
-      spentByCategoryId.set(catId, (spentByCategoryId.get(catId) ?? 0) + p.gelAmount);
+      const mKey = monthKeyFromTimestamp(p.transactionDate);
+      const compoundKey = `${catId}::${mKey}`;
+      monthlyActualsByCategory.set(
+        compoundKey,
+        (monthlyActualsByCategory.get(compoundKey) ?? 0) + p.gelAmount
+      );
+      if (p.transactionDate >= monthStart && p.transactionDate < monthEnd) {
+        spentByCategoryId.set(catId, (spentByCategoryId.get(catId) ?? 0) + p.gelAmount);
+      }
     }
 
     type Row = {
@@ -141,6 +168,8 @@ export function useBudgetSummary(planMonth = planMonthKey()) {
       target: number;
       monthlyCommitment: number;
       actual: number;
+      rolloverIn: number;
+      effectiveTarget: number;
       remaining: number;
     };
 
@@ -149,8 +178,18 @@ export function useBudgetSummary(planMonth = planMonthKey()) {
       const target = c.targetAmount ?? 0;
       const monthlyCommitment = bucketMonthlyCommitment(c);
       const actual = spentByCategoryId.get(c.id) ?? 0;
-      const remaining = bucket === "fixed" ? target - actual : monthlyCommitment - actual;
-      return { category: c, bucket, target, monthlyCommitment, actual, remaining };
+      const rolloverIn = anchor
+        ? computeRollover({
+            category: c,
+            categoryId: c.id,
+            anchorMonth: anchor,
+            currentMonth: planMonth,
+            monthlyActualsByCategory,
+          })
+        : 0;
+      const effectiveTarget = (bucket === "fixed" ? target : monthlyCommitment) + rolloverIn;
+      const remaining = effectiveTarget - actual;
+      return { category: c, bucket, target, monthlyCommitment, actual, rolloverIn, effectiveTarget, remaining };
     });
 
     const byBucket = {
@@ -165,6 +204,10 @@ export function useBudgetSummary(planMonth = planMonthKey()) {
     const flexActual = byBucket.flex.reduce((s, r) => s + r.actual, 0);
     const nonMonthlyActual = byBucket.non_monthly.reduce((s, r) => s + r.actual, 0);
     const nonMonthlyAccruals = byBucket.non_monthly.reduce((s, r) => s + r.monthlyCommitment, 0);
+    // Sinking-fund balance across all Non-Monthly categories — the
+    // total accrued-but-unspent pool. Useful as a header-level
+    // signal even though each row also displays its own carry.
+    const nonMonthlySinkingFund = byBucket.non_monthly.reduce((s, r) => s + r.rolloverIn, 0);
 
     return {
       rows,
@@ -174,8 +217,10 @@ export function useBudgetSummary(planMonth = planMonthKey()) {
       flexActual,
       nonMonthlyActual,
       nonMonthlyAccruals,
+      nonMonthlySinkingFund,
+      anchor,
     };
-  }, [categories, payments, categorize, planMonth]);
+  }, [categories, payments, categorize, plans, planMonth]);
 }
 
 /**
@@ -216,6 +261,13 @@ export function useBudgetMutations() {
       args: { targetAmount?: number; frequencyMonths?: number; rolloverEnabled?: boolean }
     ) => {
       await db.transact(db.tx.categories[categoryId].update(args));
+    },
+    []
+  );
+
+  const setCategoryRollover = useCallback(
+    async (categoryId: string, enabled: boolean) => {
+      await db.transact(db.tx.categories[categoryId].update({ rolloverEnabled: enabled }));
     },
     []
   );
@@ -285,6 +337,7 @@ export function useBudgetMutations() {
   return {
     setCategoryBucket,
     setCategoryTarget,
+    setCategoryRollover,
     setExpectedIncome,
     setFlexPool,
     setSavingsTarget,

--- a/client/src/ink/Sidebar.tsx
+++ b/client/src/ink/Sidebar.tsx
@@ -27,9 +27,9 @@ export function Sidebar({
     { to: "/transactions", name: "Transactions", glyph: "≡", badge: txCount ? txCount.toLocaleString("en-US") : undefined },
     { to: "/income", name: "Income", glyph: "↓", badge: incomeCount ? incomeCount.toLocaleString("en-US") : undefined },
     { to: "/categories", name: "Categories", glyph: "◐" },
-    { to: "/budgets", name: "Budgets", glyph: "◇", pillBadge: "NEW" },
+    { to: "/budgets", name: "Flex Budgeting", glyph: "◇" },
     { to: "/merchants", name: "Merchants", glyph: "◆" },
-    { to: "/assistant", name: "Assistant", glyph: "✧", pillBadge: "NEW" },
+    { to: "/assistant", name: "Assistant", glyph: "✧" },
     { to: "/signals", name: "Signals", glyph: "✦", badge: signalsCount ? String(signalsCount) : undefined },
     { to: "/manage", name: "Manage", glyph: "⚙" },
   ];

--- a/client/src/ink/Sidebar.tsx
+++ b/client/src/ink/Sidebar.tsx
@@ -27,6 +27,7 @@ export function Sidebar({
     { to: "/transactions", name: "Transactions", glyph: "≡", badge: txCount ? txCount.toLocaleString("en-US") : undefined },
     { to: "/income", name: "Income", glyph: "↓", badge: incomeCount ? incomeCount.toLocaleString("en-US") : undefined },
     { to: "/categories", name: "Categories", glyph: "◐" },
+    { to: "/budgets", name: "Budgets", glyph: "◇", pillBadge: "NEW" },
     { to: "/merchants", name: "Merchants", glyph: "◆" },
     { to: "/assistant", name: "Assistant", glyph: "✧", pillBadge: "NEW" },
     { to: "/signals", name: "Signals", glyph: "✦", badge: signalsCount ? String(signalsCount) : undefined },

--- a/client/src/lib/ai/tools/budgets.ts
+++ b/client/src/lib/ai/tools/budgets.ts
@@ -1,0 +1,487 @@
+// AI tools for the flex-budgeting feature. Read tools surface the
+// current plan to the model; write tools mutate categories +
+// budgetPlans rows via db.transact (mirrors the existing
+// WRITE_TOOLS pattern in write.ts).
+//
+// Auto-apply policy:
+//   - All write tools auto-apply. Reasoning: each write is reversible
+//     in the UI (move bucket back, edit target, reset auto). The
+//     blast radius is one row per call — there is no destructive
+//     equivalent to delete_category here.
+//   - clear_category_budget unclassifies a category (drops bucket +
+//     target + frequency + rollover) but doesn't delete the category
+//     itself. Reversible by re-bucketing.
+
+import { id } from "@instantdb/react";
+import { db } from "../../instant";
+import {
+  anchorMonthFromPlans,
+  bucketMonthlyCommitment,
+  computeFlexPool,
+  computeRollover,
+  monthKeyFromTimestamp,
+  monthlyAccrual,
+  planMonthKey,
+  BUCKETS,
+  type Bucket,
+} from "../../budgets";
+import type { AITool, AIToolContext } from "./types";
+
+const BUCKET_DESC =
+  "One of 'fixed' (predictable monthly costs with per-category targets), 'flex' (discretionary spending sharing one pool), or 'non_monthly' (irregular costs spread across N months).";
+
+function isBucket(v: unknown): v is Bucket {
+  return typeof v === "string" && (BUCKETS as readonly string[]).includes(v);
+}
+
+function planMonthYear(key: string): number {
+  return Number(key.slice(0, 4));
+}
+function planMonthMonth(key: string): number {
+  return Number(key.slice(5, 7)) - 1;
+}
+
+/** Aggregate the same shape useBudgetSummary produces, but pure +
+ *  read-only against the AIToolContext. Reused by both read tools so
+ *  list_budgets_by_bucket and get_budget_summary agree on numbers. */
+function summarize(ctx: AIToolContext, planMonth: string) {
+  const categories = ctx.getAllCategories();
+  // getAllCategories returns InkCategory which lacks bucket/target —
+  // walk the raw categories list instead. The merged version is for
+  // pickers; analytics need the DB row's full shape.
+  const dbCategories = ctx.categories;
+  const monthStart = new Date(planMonthYear(planMonth), planMonthMonth(planMonth), 1).getTime();
+  const monthEnd = new Date(planMonthYear(planMonth), planMonthMonth(planMonth) + 1, 1).getTime();
+  const plans = ctx.getPlans();
+  const anchor = anchorMonthFromPlans(plans);
+
+  const spentByCategoryId = new Map<string, number>();
+  const monthlyActualsByCategory = new Map<string, number>();
+  for (const p of ctx.payments) {
+    if (p.gelAmount === null) continue;
+    if (p.excludedFromAnalytics) continue;
+    // Use the same id-resolution path as the page so AI numbers match
+    // dashboard numbers. categorizeName returns the human name; we
+    // need the id for keying, so reach through the merged-category
+    // map by name.
+    const catName = ctx.categorizeName(p.merchant ?? null);
+    const merged = categories.find((c) => c.name === catName);
+    const catId = merged?.id ?? "other";
+    const mKey = monthKeyFromTimestamp(p.transactionDate);
+    const compoundKey = `${catId}::${mKey}`;
+    monthlyActualsByCategory.set(
+      compoundKey,
+      (monthlyActualsByCategory.get(compoundKey) ?? 0) + p.gelAmount
+    );
+    if (p.transactionDate >= monthStart && p.transactionDate < monthEnd) {
+      spentByCategoryId.set(catId, (spentByCategoryId.get(catId) ?? 0) + p.gelAmount);
+    }
+  }
+
+  const stored = plans.find((p) => p.planMonth === planMonth) ?? null;
+  const expectedIncome =
+    stored && !stored.expectedIncomeAuto ? stored.expectedIncome : autoIncome(ctx);
+  const fixedTargets = dbCategories
+    .filter((c) => c.bucket === "fixed")
+    .reduce((s, c) => s + (c.targetAmount ?? 0), 0);
+  const nonMonthlyAccruals = dbCategories
+    .filter((c) => c.bucket === "non_monthly")
+    .reduce((s, c) => s + monthlyAccrual(c), 0);
+  const savingsTarget = stored?.savingsTarget ?? 0;
+  const flexPoolAuto = computeFlexPool({ expectedIncome, fixedTargets, nonMonthlyAccruals, savingsTarget });
+  const flexPool = stored && !stored.flexPoolAuto ? stored.flexPool : flexPoolAuto;
+
+  const rows = dbCategories.map((c) => {
+    const bucket = isBucket(c.bucket) ? c.bucket : null;
+    const target = c.targetAmount ?? 0;
+    const monthlyCommitment = bucketMonthlyCommitment(c);
+    const actual = spentByCategoryId.get(c.id) ?? 0;
+    const rolloverIn = anchor
+      ? computeRollover({
+          category: c,
+          categoryId: c.id,
+          anchorMonth: anchor,
+          currentMonth: planMonth,
+          monthlyActualsByCategory,
+        })
+      : 0;
+    const effectiveTarget = (bucket === "fixed" ? target : monthlyCommitment) + rolloverIn;
+    return {
+      id: c.id,
+      name: c.name,
+      bucket,
+      target: Math.round(target),
+      monthlyCommitment: Math.round(monthlyCommitment),
+      actual: Math.round(actual),
+      rolloverIn: Math.round(rolloverIn),
+      effectiveTarget: Math.round(effectiveTarget),
+      remaining: Math.round(effectiveTarget - actual),
+      rolloverEnabled: c.rolloverEnabled === true,
+      frequencyMonths: c.frequencyMonths ?? null,
+    };
+  });
+
+  const flexActual = rows
+    .filter((r) => r.bucket === "flex")
+    .reduce((s, r) => s + r.actual, 0);
+  const fixedActual = rows.filter((r) => r.bucket === "fixed").reduce((s, r) => s + r.actual, 0);
+  const nonMonthlyActual = rows.filter((r) => r.bucket === "non_monthly").reduce((s, r) => s + r.actual, 0);
+  const nonMonthlySinkingFund = rows.filter((r) => r.bucket === "non_monthly").reduce((s, r) => s + r.rolloverIn, 0);
+
+  return {
+    planMonth,
+    expectedIncome: Math.round(expectedIncome),
+    expectedIncomeAuto: !stored || stored.expectedIncomeAuto,
+    fixedTargets: Math.round(fixedTargets),
+    nonMonthlyAccruals: Math.round(nonMonthlyAccruals),
+    savingsTarget: Math.round(savingsTarget),
+    flexPool: Math.round(flexPool),
+    flexPoolAuto: !stored || stored.flexPoolAuto,
+    flexActual: Math.round(flexActual),
+    flexRemaining: Math.round(Math.max(0, flexPool - flexActual)),
+    fixedActual: Math.round(fixedActual),
+    nonMonthlyActual: Math.round(nonMonthlyActual),
+    nonMonthlySinkingFund: Math.round(nonMonthlySinkingFund),
+    rows,
+  };
+}
+
+/** 3-month rolling average of GEL credits, excluding excluded rows.
+ *  Mirrors useExpectedIncomeDefault. */
+function autoIncome(ctx: AIToolContext): number {
+  const cutoff = new Date(ctx.now.getFullYear(), ctx.now.getMonth() - 3, 1).getTime();
+  const monthEnd = new Date(ctx.now.getFullYear(), ctx.now.getMonth(), 1).getTime();
+  const monthly = new Map<string, number>();
+  for (const c of ctx.credits) {
+    if (c.gelAmount === null) continue;
+    if (c.excludedFromAnalytics) continue;
+    if (c.transactionDate < cutoff || c.transactionDate >= monthEnd) continue;
+    const key = monthKeyFromTimestamp(c.transactionDate);
+    monthly.set(key, (monthly.get(key) ?? 0) + c.gelAmount);
+  }
+  if (monthly.size === 0) return 0;
+  const totals = Array.from(monthly.values());
+  return totals.reduce((s, x) => s + x, 0) / totals.length;
+}
+
+const getBudgetSummary: AITool = {
+  definition: {
+    name: "get_budget_summary",
+    description:
+      "Returns the user's flex-budgeting plan for the current month: flex pool, flex remaining, fixed/non-monthly/flex actuals, savings target, rollover sinking fund. Use this when the user asks 'how much flex do I have left', 'what's my budget for X', 'am I on track this month', or any plan-aware question. Defaults to the current month when no args.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        month: { type: "integer", minimum: 0, maximum: 11, description: "0-indexed month. Defaults to current." },
+        year: { type: "integer", description: "Four-digit year. Defaults to current." },
+      },
+    },
+  },
+  statusText: "Reading your budget…",
+  executor: (input, ctx) => {
+    const month = typeof input.month === "number" ? input.month : ctx.now.getMonth();
+    const year = typeof input.year === "number" ? input.year : ctx.now.getFullYear();
+    const planMonth = `${year}-${String(month + 1).padStart(2, "0")}`;
+    const summary = summarize(ctx, planMonth);
+    return {
+      planMonth: summary.planMonth,
+      expectedIncome: summary.expectedIncome,
+      expectedIncomeAuto: summary.expectedIncomeAuto,
+      flexPool: summary.flexPool,
+      flexPoolAuto: summary.flexPoolAuto,
+      flexActual: summary.flexActual,
+      flexRemaining: summary.flexRemaining,
+      fixedActual: summary.fixedActual,
+      fixedTargets: summary.fixedTargets,
+      nonMonthlyActual: summary.nonMonthlyActual,
+      nonMonthlyAccruals: summary.nonMonthlyAccruals,
+      nonMonthlySinkingFund: summary.nonMonthlySinkingFund,
+      savingsTarget: summary.savingsTarget,
+    };
+  },
+};
+
+const listBudgetsByBucket: AITool = {
+  definition: {
+    name: "list_budgets_by_bucket",
+    description:
+      "Lists every category grouped by bucket (Fixed, Flex, Non-Monthly, Unclassified) with target, monthly commitment, current-month actual, and rollover. Use this when the user asks 'which categories are over budget', 'show me all my budgets', or 'what's left in fixed'.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  statusText: "Listing your budgets…",
+  executor: (_input, ctx) => {
+    const planMonth = planMonthKey(ctx.now);
+    const { rows } = summarize(ctx, planMonth);
+    const groups: Record<string, typeof rows> = {
+      fixed: [],
+      flex: [],
+      non_monthly: [],
+      unclassified: [],
+    };
+    for (const r of rows) {
+      const key = r.bucket ?? "unclassified";
+      groups[key].push(r);
+    }
+    return groups;
+  },
+};
+
+const setCategoryBucket: AITool = {
+  definition: {
+    name: "set_category_bucket",
+    description:
+      "Assigns a category to a budget bucket. AUTO-APPLIES. Use when the user says 'put rent in fixed', 'move dining to flex', or after creating a category that needs a bucket. To unclassify, call clear_category_budget instead.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        categoryId: { type: "string", description: "InstantDB id of the category. Resolve via list_categories or list_budgets_by_bucket." },
+        bucket: { type: "string", enum: ["fixed", "flex", "non_monthly"], description: BUCKET_DESC },
+      },
+      required: ["categoryId", "bucket"],
+    },
+  },
+  statusText: "Updating the bucket…",
+  executor: async (input, ctx) => {
+    const categoryId = typeof input.categoryId === "string" ? input.categoryId : "";
+    const bucket = typeof input.bucket === "string" ? input.bucket : "";
+    if (!categoryId) throw new Error("`categoryId` is required.");
+    if (!isBucket(bucket)) throw new Error(`\`bucket\` must be one of: ${BUCKETS.join(", ")}.`);
+    const cat = ctx.categories.find((c) => c.id === categoryId);
+    if (!cat) throw new Error(`No category with id "${categoryId}". Use list_categories to find ids.`);
+    await db.transact(db.tx.categories[categoryId].update({ bucket }));
+    return { categoryId, name: cat.name, bucket, applied: true };
+  },
+};
+
+const setCategoryTarget: AITool = {
+  definition: {
+    name: "set_category_target",
+    description:
+      "Sets the budget target for a category. For Fixed: monthly target in GEL. For Non-Monthly: total target across `frequencyMonths` (e.g. ₾2400 / 12 = ₾200/mo accrual). AUTO-APPLIES. The category must have a bucket assigned first — call set_category_bucket if it doesn't. Flex categories don't take targets (the bucket pool is the limit).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        categoryId: { type: "string", description: "InstantDB id of the category." },
+        targetGEL: { type: "number", description: "Target amount in GEL. Must be ≥ 0." },
+        frequencyMonths: {
+          type: "integer",
+          description: "Required for Non-Monthly categories — number of months the targetGEL spreads across (12 for annual, 4 for quarterly). Ignored for Fixed.",
+        },
+      },
+      required: ["categoryId", "targetGEL"],
+    },
+  },
+  statusText: "Updating the target…",
+  executor: async (input, ctx) => {
+    const categoryId = typeof input.categoryId === "string" ? input.categoryId : "";
+    const targetGEL = typeof input.targetGEL === "number" ? input.targetGEL : NaN;
+    const frequencyMonths = typeof input.frequencyMonths === "number" ? input.frequencyMonths : undefined;
+    if (!categoryId) throw new Error("`categoryId` is required.");
+    if (!Number.isFinite(targetGEL) || targetGEL < 0) {
+      throw new Error("`targetGEL` must be a non-negative number.");
+    }
+    const cat = ctx.categories.find((c) => c.id === categoryId);
+    if (!cat) throw new Error(`No category with id "${categoryId}".`);
+    if (cat.bucket === "flex") {
+      throw new Error("Flex categories don't have per-category targets; the bucket pool is the limit. Use set_flex_pool to change the pool.");
+    }
+    if (cat.bucket === "non_monthly" && (!frequencyMonths || frequencyMonths <= 0)) {
+      throw new Error("`frequencyMonths` is required for Non-Monthly categories and must be > 0.");
+    }
+    const updates: Partial<{ targetAmount: number; frequencyMonths: number }> = { targetAmount: targetGEL };
+    if (cat.bucket === "non_monthly" && frequencyMonths) {
+      updates.frequencyMonths = frequencyMonths;
+    }
+    await db.transact(db.tx.categories[categoryId].update(updates));
+    return { categoryId, name: cat.name, targetGEL, frequencyMonths: updates.frequencyMonths ?? null, applied: true };
+  },
+};
+
+const clearCategoryBudget: AITool = {
+  definition: {
+    name: "clear_category_budget",
+    description:
+      "Unclassifies a category — drops its bucket, target, frequency, and rollover flag. Does NOT delete the category itself; it just disappears from the budget formula. AUTO-APPLIES. Reversible by calling set_category_bucket again.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        categoryId: { type: "string", description: "InstantDB id of the category to unclassify." },
+      },
+      required: ["categoryId"],
+    },
+  },
+  statusText: "Unclassifying the category…",
+  executor: async (input, ctx) => {
+    const categoryId = typeof input.categoryId === "string" ? input.categoryId : "";
+    if (!categoryId) throw new Error("`categoryId` is required.");
+    const cat = ctx.categories.find((c) => c.id === categoryId);
+    if (!cat) throw new Error(`No category with id "${categoryId}".`);
+    await db.transact(
+      db.tx.categories[categoryId].update({
+        bucket: undefined,
+        targetAmount: undefined,
+        frequencyMonths: undefined,
+        rolloverEnabled: undefined,
+      })
+    );
+    return { categoryId, name: cat.name, cleared: true };
+  },
+};
+
+// Per-month plan upserts. Mirror the useBudgetMutations.upsertPlan
+// pattern: read plans via the live getter, decide insert-vs-update,
+// fall back to creating a fresh row keyed by id() if none exists.
+async function upsertPlan(
+  ctx: AIToolContext,
+  planMonth: string,
+  updates: Record<string, unknown>
+) {
+  const now = Date.now();
+  const plans = ctx.getPlans();
+  const existing = plans.find((p) => p.planMonth === planMonth);
+  if (existing) {
+    await db.transact(db.tx.budgetPlans[existing.id].update({ ...updates, updatedAt: now }));
+  } else {
+    const newId = id();
+    await db.transact(
+      db.tx.budgetPlans[newId].update({
+        planMonth,
+        expectedIncome: 0,
+        expectedIncomeAuto: true,
+        flexPool: 0,
+        flexPoolAuto: true,
+        createdAt: now,
+        updatedAt: now,
+        ...updates,
+      })
+    );
+  }
+}
+
+const setExpectedIncome: AITool = {
+  definition: {
+    name: "set_expected_income",
+    description:
+      "Sets the expected monthly income (the input to the flex formula) for a given month. AUTO-APPLIES. Pass `amountGEL: null` to revert to the auto-derived 3-month rolling average. Defaults to the current month.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        amountGEL: { type: ["number", "null"], description: "Income in GEL, or null to revert to auto." },
+        month: { type: "string", description: "Plan month as 'YYYY-MM'. Defaults to current." },
+      },
+      required: ["amountGEL"],
+    },
+  },
+  statusText: "Updating expected income…",
+  executor: async (input, ctx) => {
+    const planMonth = typeof input.month === "string" ? input.month : planMonthKey(ctx.now);
+    const amount = input.amountGEL;
+    if (amount === null) {
+      await upsertPlan(ctx, planMonth, { expectedIncomeAuto: true });
+      return { planMonth, applied: true, mode: "auto" };
+    }
+    if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 0) {
+      throw new Error("`amountGEL` must be a non-negative number or null.");
+    }
+    await upsertPlan(ctx, planMonth, { expectedIncome: amount, expectedIncomeAuto: false });
+    return { planMonth, applied: true, mode: "manual", amountGEL: amount };
+  },
+};
+
+const setFlexPool: AITool = {
+  definition: {
+    name: "set_flex_pool",
+    description:
+      "Manually overrides the flex pool for a given month, bypassing the auto-derived formula. AUTO-APPLIES. Pass `amountGEL: null` to revert to auto. Use when the user wants to cap flex spending at a specific number regardless of income/fixed math.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        amountGEL: { type: ["number", "null"], description: "Pool in GEL, or null to revert to auto." },
+        month: { type: "string", description: "Plan month as 'YYYY-MM'. Defaults to current." },
+      },
+      required: ["amountGEL"],
+    },
+  },
+  statusText: "Updating flex pool…",
+  executor: async (input, ctx) => {
+    const planMonth = typeof input.month === "string" ? input.month : planMonthKey(ctx.now);
+    const amount = input.amountGEL;
+    if (amount === null) {
+      await upsertPlan(ctx, planMonth, { flexPoolAuto: true });
+      return { planMonth, applied: true, mode: "auto" };
+    }
+    if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 0) {
+      throw new Error("`amountGEL` must be a non-negative number or null.");
+    }
+    await upsertPlan(ctx, planMonth, { flexPool: amount, flexPoolAuto: false });
+    return { planMonth, applied: true, mode: "manual", amountGEL: amount };
+  },
+};
+
+const setSavingsTarget: AITool = {
+  definition: {
+    name: "set_savings_target",
+    description:
+      "Sets the monthly savings allocation. AUTO-APPLIES. Drops out of the flex pool — savings is deducted from income before flex is computed (matches Monarch's model). Pass 0 to clear.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        amountGEL: { type: "number", description: "Savings in GEL. 0 to clear." },
+        month: { type: "string", description: "Plan month as 'YYYY-MM'. Defaults to current." },
+      },
+      required: ["amountGEL"],
+    },
+  },
+  statusText: "Updating savings target…",
+  executor: async (input, ctx) => {
+    const planMonth = typeof input.month === "string" ? input.month : planMonthKey(ctx.now);
+    const amount = input.amountGEL;
+    if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 0) {
+      throw new Error("`amountGEL` must be a non-negative number.");
+    }
+    await upsertPlan(ctx, planMonth, { savingsTarget: amount });
+    return { planMonth, savingsTarget: amount, applied: true };
+  },
+};
+
+const setCategoryRollover: AITool = {
+  definition: {
+    name: "set_category_rollover",
+    description:
+      "Toggles whether a Fixed category rolls leftover/overshoot to the next month. AUTO-APPLIES. Only meaningful for Fixed categories (Non-Monthly always rolls; Flex never does). Off by default — opt the user in when they explicitly want the carry behaviour.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        categoryId: { type: "string", description: "InstantDB id of a Fixed category." },
+        enabled: { type: "boolean", description: "true to turn rollover on, false to turn it off." },
+      },
+      required: ["categoryId", "enabled"],
+    },
+  },
+  statusText: "Updating rollover…",
+  executor: async (input, ctx) => {
+    const categoryId = typeof input.categoryId === "string" ? input.categoryId : "";
+    const enabled = input.enabled;
+    if (!categoryId) throw new Error("`categoryId` is required.");
+    if (typeof enabled !== "boolean") throw new Error("`enabled` must be a boolean.");
+    const cat = ctx.categories.find((c) => c.id === categoryId);
+    if (!cat) throw new Error(`No category with id "${categoryId}".`);
+    if (cat.bucket !== "fixed") {
+      throw new Error("Rollover toggle only applies to Fixed categories. Non-Monthly always rolls; Flex never does.");
+    }
+    await db.transact(db.tx.categories[categoryId].update({ rolloverEnabled: enabled }));
+    return { categoryId, name: cat.name, rolloverEnabled: enabled, applied: true };
+  },
+};
+
+export const BUDGET_TOOLS: AITool[] = [
+  getBudgetSummary,
+  listBudgetsByBucket,
+  setCategoryBucket,
+  setCategoryTarget,
+  setCategoryRollover,
+  setExpectedIncome,
+  setFlexPool,
+  setSavingsTarget,
+  clearCategoryBudget,
+];

--- a/client/src/lib/ai/tools/budgets.ts
+++ b/client/src/lib/ai/tools/budgets.ts
@@ -47,8 +47,9 @@ function planMonthMonth(key: string): number {
 function summarize(ctx: AIToolContext, planMonth: string) {
   // getAllCategories returns InkCategory which lacks bucket/target —
   // walk the raw categories list (DB rows have the full shape we
-  // need). The merged version is for pickers.
-  const dbCategories = ctx.categories;
+  // need). The merged version is for pickers. Live getter so a write
+  // earlier in the same agent loop is reflected in summary numbers.
+  const dbCategories = ctx.getCategories();
   const monthStart = new Date(planMonthYear(planMonth), planMonthMonth(planMonth), 1).getTime();
   const monthEnd = new Date(planMonthYear(planMonth), planMonthMonth(planMonth) + 1, 1).getTime();
   const plans = ctx.getPlans();
@@ -244,7 +245,11 @@ const setCategoryBucket: AITool = {
     const bucket = typeof input.bucket === "string" ? input.bucket : "";
     if (!categoryId) throw new Error("`categoryId` is required.");
     if (!isBucket(bucket)) throw new Error(`\`bucket\` must be one of: ${BUCKETS.join(", ")}.`);
-    const cat = ctx.categories.find((c) => c.id === categoryId);
+    // Live getter so chained writes (e.g. set_category_bucket then
+    // set_category_target in the same agent turn) see the bucket the
+    // sibling call just set. ctx.categories is captured at agent-run
+    // start and would be stale. (Codex P2 on PR #42 cumulative review.)
+    const cat = ctx.getCategories().find((c) => c.id === categoryId);
     if (!cat) throw new Error(`No category with id "${categoryId}". Use list_categories to find ids.`);
     await db.transact(db.tx.categories[categoryId].update({ bucket }));
     return { categoryId, name: cat.name, bucket, applied: true };
@@ -278,7 +283,11 @@ const setCategoryTarget: AITool = {
     if (!Number.isFinite(targetGEL) || targetGEL < 0) {
       throw new Error("`targetGEL` must be a non-negative number.");
     }
-    const cat = ctx.categories.find((c) => c.id === categoryId);
+    // Live getter so chained writes (e.g. set_category_bucket then
+    // set_category_target in the same agent turn) see the bucket the
+    // sibling call just set. ctx.categories is captured at agent-run
+    // start and would be stale. (Codex P2 on PR #42 cumulative review.)
+    const cat = ctx.getCategories().find((c) => c.id === categoryId);
     if (!cat) throw new Error(`No category with id "${categoryId}".`);
     if (cat.bucket === "flex") {
       throw new Error("Flex categories don't have per-category targets; the bucket pool is the limit. Use set_flex_pool to change the pool.");
@@ -312,7 +321,11 @@ const clearCategoryBudget: AITool = {
   executor: async (input, ctx) => {
     const categoryId = typeof input.categoryId === "string" ? input.categoryId : "";
     if (!categoryId) throw new Error("`categoryId` is required.");
-    const cat = ctx.categories.find((c) => c.id === categoryId);
+    // Live getter so chained writes (e.g. set_category_bucket then
+    // set_category_target in the same agent turn) see the bucket the
+    // sibling call just set. ctx.categories is captured at agent-run
+    // start and would be stale. (Codex P2 on PR #42 cumulative review.)
+    const cat = ctx.getCategories().find((c) => c.id === categoryId);
     if (!cat) throw new Error(`No category with id "${categoryId}".`);
     await db.transact(
       db.tx.categories[categoryId].update({
@@ -485,7 +498,11 @@ const setCategoryRollover: AITool = {
     const enabled = input.enabled;
     if (!categoryId) throw new Error("`categoryId` is required.");
     if (typeof enabled !== "boolean") throw new Error("`enabled` must be a boolean.");
-    const cat = ctx.categories.find((c) => c.id === categoryId);
+    // Live getter so chained writes (e.g. set_category_bucket then
+    // set_category_target in the same agent turn) see the bucket the
+    // sibling call just set. ctx.categories is captured at agent-run
+    // start and would be stale. (Codex P2 on PR #42 cumulative review.)
+    const cat = ctx.getCategories().find((c) => c.id === categoryId);
     if (!cat) throw new Error(`No category with id "${categoryId}".`);
     if (cat.bucket !== "fixed") {
       throw new Error("Rollover toggle only applies to Fixed categories. Non-Monthly always rolls; Flex never does.");

--- a/client/src/lib/ai/tools/budgets.ts
+++ b/client/src/lib/ai/tools/budgets.ts
@@ -45,10 +45,9 @@ function planMonthMonth(key: string): number {
  *  read-only against the AIToolContext. Reused by both read tools so
  *  list_budgets_by_bucket and get_budget_summary agree on numbers. */
 function summarize(ctx: AIToolContext, planMonth: string) {
-  const categories = ctx.getAllCategories();
   // getAllCategories returns InkCategory which lacks bucket/target —
-  // walk the raw categories list instead. The merged version is for
-  // pickers; analytics need the DB row's full shape.
+  // walk the raw categories list (DB rows have the full shape we
+  // need). The merged version is for pickers.
   const dbCategories = ctx.categories;
   const monthStart = new Date(planMonthYear(planMonth), planMonthMonth(planMonth), 1).getTime();
   const monthEnd = new Date(planMonthYear(planMonth), planMonthMonth(planMonth) + 1, 1).getTime();
@@ -60,13 +59,12 @@ function summarize(ctx: AIToolContext, planMonth: string) {
   for (const p of ctx.payments) {
     if (p.gelAmount === null) continue;
     if (p.excludedFromAnalytics) continue;
-    // Use the same id-resolution path as the page so AI numbers match
-    // dashboard numbers. categorizeName returns the human name; we
-    // need the id for keying, so reach through the merged-category
-    // map by name.
-    const catName = ctx.categorizeName(p.merchant ?? null);
-    const merged = categories.find((c) => c.name === catName);
-    const catId = merged?.id ?? "other";
+    // Mirror the page's categoriser exactly: per-transaction override
+    // (paymentId) > per-merchant override > regex on merchant + raw
+    // SMS. Calling the id-returning variant here keeps the AI's
+    // numbers in lockstep with /budgets, /categories, and the donut.
+    // (Codex P2 on PR #42.)
+    const catId = ctx.categorize(p.merchant ?? null, p.rawMessage ?? null, p.id);
     const mKey = monthKeyFromTimestamp(p.transactionDate);
     const compoundKey = `${catId}::${mKey}`;
     monthlyActualsByCategory.set(
@@ -331,6 +329,21 @@ const clearCategoryBudget: AITool = {
 // Per-month plan upserts. Mirror the useBudgetMutations.upsertPlan
 // pattern: read plans via the live getter, decide insert-vs-update,
 // fall back to creating a fresh row keyed by id() if none exists.
+//
+// Module-scope memo for ids the AI just created. When the assistant
+// chains two plan-level writes in one agentic loop (e.g.
+// set_expected_income → set_flex_pool for a month with no prior
+// budgetPlans row), `ctx.getPlans()` still reflects the React
+// snapshot from before the first transact, so the second call's
+// existence check would also miss the row and double-insert. The
+// real InstantDB write would then trip the unique `planMonth`
+// constraint; the demo DB silently duplicates. This memo lets the
+// second call see "yes, planMonth=2026-04 was just created with
+// id=X" and route to the update branch. Mapping is per-process and
+// only grows during the brief window of an agentic loop. (Codex P2
+// on PR #42.)
+const recentlyCreatedPlanIds = new Map<string, string>();
+
 async function upsertPlan(
   ctx: AIToolContext,
   planMonth: string,
@@ -338,11 +351,19 @@ async function upsertPlan(
 ) {
   const now = Date.now();
   const plans = ctx.getPlans();
-  const existing = plans.find((p) => p.planMonth === planMonth);
+  const existing =
+    plans.find((p) => p.planMonth === planMonth) ??
+    // The memo carries the id but not the row body, so we synthesize
+    // the minimum the existing-branch needs (just the id).
+    (() => {
+      const memoedId = recentlyCreatedPlanIds.get(planMonth);
+      return memoedId ? { id: memoedId } : null;
+    })();
   if (existing) {
     await db.transact(db.tx.budgetPlans[existing.id].update({ ...updates, updatedAt: now }));
   } else {
     const newId = id();
+    recentlyCreatedPlanIds.set(planMonth, newId);
     await db.transact(
       db.tx.budgetPlans[newId].update({
         planMonth,

--- a/client/src/lib/ai/tools/types.ts
+++ b/client/src/lib/ai/tools/types.ts
@@ -29,9 +29,13 @@ export interface AIToolContext {
   payments: ConvertedPayment[];
   credits: ConvertedCredit[];
   failedPayments: FailedPayment[];
-  /** Raw DB-backed category rows. Use sparingly — most tools should
-   *  prefer `getAllCategories()` which merges DEFAULT_CATEGORIES so
-   *  tools can target defaults that aren't yet persisted in DB. */
+  /** Snapshot of DB-backed category rows captured at agent-run start.
+   *  Sufficient for read-only flows that don't depend on writes earlier
+   *  in the same agentic loop. Tools that need to see fresh state across
+   *  chained writes (e.g. `set_category_target` reading the bucket
+   *  `set_category_bucket` just set) should use `getCategories()` below
+   *  instead. Most tools should prefer `getAllCategories()` for the
+   *  merged InkCategory list. */
   categories: Category[];
   bankSenders: BankSender[];
   /** Live merchant-override rows. Write tools (apply_category_override)
@@ -66,6 +70,12 @@ export interface AIToolContext {
    *  getAllCategories — use this from write tools that need to find
    *  an existing row's id. */
   getOverrides: Live<MerchantCategoryOverride[]>;
+  /** Returns live raw category rows (with bucket/target/etc fields).
+   *  Use this from chained budget write tools where the second call
+   *  needs to see the bucket / target the first call just set —
+   *  `ctx.categories` is captured at agent-run start and would be
+   *  stale across in-loop writes. (Codex P2 on PR #42.) */
+  getCategories: Live<Category[]>;
   /** Live budget-plan rows (one per "YYYY-MM" the user has saved
    *  changes for). Budget read tools use this to expose the current
    *  flex pool / expected income; write tools use it to find an

--- a/client/src/lib/ai/tools/types.ts
+++ b/client/src/lib/ai/tools/types.ts
@@ -47,6 +47,14 @@ export interface AIToolContext {
    *  static `autoCategorize` so an "I moved Spotify to Subscriptions"
    *  override actually shows up in the AI's view of the data. */
   categorizeName: (merchant: string | null | undefined) => string;
+  /** Override-aware category-id lookup. Same priority order as the
+   *  page's categoriser: per-transaction override (when paymentId
+   *  given) > per-merchant override > regex on merchant + raw SMS.
+   *  Use this from analytics tools that need to bucket transactions
+   *  by category id; passing `paymentId` ensures per-transaction
+   *  overrides land in the right bucket so AI numbers match what
+   *  /budgets, /categories, and the donut display. */
+  categorize: (merchant: string | null | undefined, raw?: string | null, paymentId?: string | null) => string;
   /** Returns the merged category list (DEFAULT_CATEGORIES + DB rows,
    *  deduped by name with DB winning). Use this from tools that need
    *  to expose categories to the model (list_categories) or validate

--- a/client/src/lib/ai/tools/types.ts
+++ b/client/src/lib/ai/tools/types.ts
@@ -7,7 +7,13 @@ import type { AIToolDefinition } from "../types";
 import type { AIBlock } from "../../aiThreads";
 import type { ConvertedPayment } from "../../../hooks/useTransactions";
 import type { ConvertedCredit } from "../../../hooks/useCredits";
-import type { FailedPayment, Category, BankSender, MerchantCategoryOverride } from "../../instant";
+import type {
+  FailedPayment,
+  Category,
+  BankSender,
+  MerchantCategoryOverride,
+  BudgetPlan,
+} from "../../instant";
 import type { InkCategory } from "../../utils";
 
 /** A snapshot getter that returns the freshest value available at the
@@ -52,6 +58,12 @@ export interface AIToolContext {
    *  getAllCategories — use this from write tools that need to find
    *  an existing row's id. */
   getOverrides: Live<MerchantCategoryOverride[]>;
+  /** Live budget-plan rows (one per "YYYY-MM" the user has saved
+   *  changes for). Budget read tools use this to expose the current
+   *  flex pool / expected income; write tools use it to find an
+   *  existing row's id for upsert decisions instead of calling
+   *  db.queryOnce (which the demo DB doesn't implement). */
+  getPlans: Live<BudgetPlan[]>;
 }
 
 export interface AITool {

--- a/client/src/lib/budgets.ts
+++ b/client/src/lib/budgets.ts
@@ -144,10 +144,100 @@ export function planMonthKey(date = new Date()): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
 }
 
+/** Convert a `transactionDate` timestamp to its month key. */
+export function monthKeyFromTimestamp(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/**
+ * List the month keys from `start` (inclusive) to `end` (exclusive)
+ * in chronological order. Both bounds are "YYYY-MM" strings. Returns
+ * empty when `end` is at or before `start`.
+ */
+export function monthRange(start: string, end: string): string[] {
+  const out: string[] = [];
+  let [y, m] = start.split("-").map(Number);
+  const [endY, endM] = end.split("-").map(Number);
+  while (y < endY || (y === endY && m < endM)) {
+    out.push(`${y}-${String(m).padStart(2, "0")}`);
+    m += 1;
+    if (m > 12) {
+      m = 1;
+      y += 1;
+    }
+  }
+  return out;
+}
+
 /** Median of a non-empty array; mean used as a tie-breaker. */
 export function median(values: number[]): number {
   if (values.length === 0) return 0;
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
   return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Walk months from `anchorMonth` (inclusive) to the month before
+ * `currentMonth` accumulating `(target − actual)` for Fixed (only
+ * when `rolloverEnabled`) or `(accrual − actual)` for Non-Monthly.
+ *
+ * Negatives carry — overshoot in March means April's effective
+ * target drops by the overshoot. That's the same semantics Monarch
+ * uses; users who don't want the carry should leave
+ * `rolloverEnabled: false` on Fixed rows.
+ *
+ * Pure: takes a precomputed `monthlyActualsByCategory` lookup so a
+ * page rendering 30 categories doesn't iterate the payments list 30
+ * times. The lookup key shape is `${categoryId}::${monthKey}`.
+ *
+ * Returns 0 (no carry) when:
+ *   - the category has no bucket
+ *   - the bucket is Flex (flex pool doesn't roll forward)
+ *   - the bucket is Fixed and rolloverEnabled is false/missing
+ *   - currentMonth ≤ anchorMonth (no prior months to walk)
+ *   - the category has no target/frequency to compare against
+ */
+export function computeRollover(args: {
+  category: Pick<Category, "bucket" | "targetAmount" | "frequencyMonths" | "rolloverEnabled">;
+  categoryId: string;
+  anchorMonth: string;
+  currentMonth: string;
+  monthlyActualsByCategory: Map<string, number>;
+}): number {
+  const { category, categoryId, anchorMonth, currentMonth, monthlyActualsByCategory } = args;
+  if (!category.bucket || category.bucket === "flex") return 0;
+  if (category.bucket === "fixed" && !category.rolloverEnabled) return 0;
+
+  const months = monthRange(anchorMonth, currentMonth);
+  if (months.length === 0) return 0;
+
+  const targetForMonth =
+    category.bucket === "fixed"
+      ? category.targetAmount ?? 0
+      : monthlyAccrual(category);
+  if (targetForMonth === 0) return 0;
+
+  let carry = 0;
+  for (const month of months) {
+    const actual = monthlyActualsByCategory.get(`${categoryId}::${month}`) ?? 0;
+    carry += targetForMonth - actual;
+  }
+  return carry;
+}
+
+/**
+ * Earliest plan month from a list of stored plans. Used as the
+ * rollover anchor — months before the user opened /budgets are
+ * treated as having zero contribution (empty sum). Returns null
+ * when the user hasn't saved any plan yet, in which case rollover
+ * is 0 across the board (and the page still renders sensible
+ * Phase-1-style numbers).
+ */
+export function anchorMonthFromPlans(plans: Array<{ planMonth: string }>): string | null {
+  if (plans.length === 0) return null;
+  return plans
+    .map((p) => p.planMonth)
+    .sort((a, b) => a.localeCompare(b))[0];
 }

--- a/client/src/lib/budgets.ts
+++ b/client/src/lib/budgets.ts
@@ -1,0 +1,153 @@
+// Pure utility module for flex budgeting. No React, no InstantDB —
+// just the math + classification logic. Imported by useBudgets.ts
+// (the hook layer) and by future AI tools (Phase 3) so the same
+// formula drives the UI and chat.
+
+import type { Category } from "./instant";
+import type { ConvertedPayment } from "../hooks/useTransactions";
+
+export const BUCKETS = ["fixed", "flex", "non_monthly"] as const;
+export type Bucket = (typeof BUCKETS)[number];
+
+export const BUCKET_LABELS: Record<Bucket, string> = {
+  fixed: "Fixed",
+  flex: "Flex",
+  non_monthly: "Non-Monthly",
+};
+
+export const BUCKET_DESCRIPTIONS: Record<Bucket, string> = {
+  fixed: "Predictable monthly costs (rent, utilities, subscriptions). Each category has its own target.",
+  flex: "Discretionary spending (dining, shopping, entertainment). Shares one pool across all categories.",
+  non_monthly: "Irregular but expected (annual insurance, holidays). Spreads target across N months.",
+};
+
+/**
+ * Monthly accrual for a Non-Monthly category. e.g. ₾2,400 across
+ * 12 months = ₾200/month. Returns 0 for non-`non_monthly` buckets
+ * or when frequencyMonths is missing/zero.
+ *
+ * Phase 1 doesn't yet display accruals on /budgets — Phase 2 wires
+ * the rollover math that consumes this. Exported now so the formula
+ * in computeFlexPool can subtract accruals from the income side.
+ */
+export function monthlyAccrual(category: Pick<Category, "bucket" | "targetAmount" | "frequencyMonths">): number {
+  if (category.bucket !== "non_monthly") return 0;
+  if (!category.targetAmount || !category.frequencyMonths) return 0;
+  if (category.frequencyMonths <= 0) return 0;
+  return category.targetAmount / category.frequencyMonths;
+}
+
+/**
+ * Canonical flex-pool formula:
+ *   flex = expectedIncome
+ *        - sum(fixed targets)
+ *        - sum(non-monthly accruals)
+ *        - savingsTarget
+ *
+ * Returns a non-negative number; if the sums exceed expected income
+ * the result is clamped to 0 so the UI shows "₾0 left" instead of a
+ * negative pool. The user is over-allocated and needs to either
+ * raise income or lower targets — clamping avoids the misleading
+ * impression that they have negative-flex spending power.
+ *
+ * Pure: takes the resolved input numbers, doesn't peek at React
+ * state. Same function used by the page header, the AI tools, and
+ * Phase 2's rollover-aware variant.
+ */
+export function computeFlexPool(input: {
+  expectedIncome: number;
+  fixedTargets: number;
+  nonMonthlyAccruals: number;
+  savingsTarget: number;
+}): number {
+  const { expectedIncome, fixedTargets, nonMonthlyAccruals, savingsTarget } = input;
+  const raw = expectedIncome - fixedTargets - nonMonthlyAccruals - savingsTarget;
+  return Math.max(0, raw);
+}
+
+/**
+ * Sum of monthly targets across categories in a given bucket.
+ * For Fixed: targetAmount as-is. For Non-Monthly: monthlyAccrual.
+ * Flex categories return 0 (the bucket pool isn't a sum of children).
+ *
+ * Tolerates undefined targets — returns 0 for them — so a
+ * partially-classified state still renders without throwing.
+ */
+export function bucketMonthlyCommitment(category: Pick<Category, "bucket" | "targetAmount" | "frequencyMonths">): number {
+  if (category.bucket === "fixed") return category.targetAmount ?? 0;
+  if (category.bucket === "non_monthly") return monthlyAccrual(category);
+  return 0;
+}
+
+/**
+ * Suggest a bucket for a category based on its recent spending pattern.
+ * Used by the /budgets setup wizard to pre-populate bucket assignments
+ * — the user can always change the suggestion before saving.
+ *
+ * Heuristics:
+ *   - Stable monthly cadence + low variance → Fixed
+ *   - High variance + many small transactions → Flex
+ *   - Long gaps + one large transaction → Non-Monthly
+ *
+ * Returns null when there isn't enough history to suggest. The wizard
+ * should default unclassified rows to Flex in that case (it's the
+ * safest "I don't know yet" assignment — Flex doesn't impose a target).
+ */
+export function classifyHistorical(
+  payments: ConvertedPayment[],
+  categoryFor: (p: ConvertedPayment) => string,
+  categoryId: string,
+  windowMonths = 3,
+  now = new Date()
+): Bucket | null {
+  const cutoff = new Date(now.getFullYear(), now.getMonth() - windowMonths, now.getDate()).getTime();
+  const matching = payments.filter(
+    (p) => p.gelAmount !== null && p.transactionDate >= cutoff && categoryFor(p) === categoryId
+  );
+  if (matching.length === 0) return null;
+
+  // Group by month-of-year. A category that's spent in nearly every
+  // month with low coefficient-of-variation is Fixed; one that's
+  // spent in only a few months with one large hit is Non-Monthly;
+  // everything else is Flex.
+  const byMonth = new Map<string, number>();
+  for (const p of matching) {
+    if (p.gelAmount === null) continue;
+    const d = new Date(p.transactionDate);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    byMonth.set(key, (byMonth.get(key) ?? 0) + p.gelAmount);
+  }
+  const monthsCovered = byMonth.size;
+  const totals = Array.from(byMonth.values());
+  const mean = totals.reduce((s, x) => s + x, 0) / totals.length;
+  const variance =
+    totals.reduce((s, x) => s + (x - mean) ** 2, 0) / totals.length;
+  const stddev = Math.sqrt(variance);
+  const cov = mean > 0 ? stddev / mean : 0;
+
+  // Spent in most months of the window with low variability — Fixed.
+  if (monthsCovered >= windowMonths - 1 && cov < 0.35) return "fixed";
+
+  // Sparse coverage but each hit is large — Non-Monthly. "Large" is
+  // relative to the user's other categories; we use a simple
+  // monthsCovered-vs-window ratio as the proxy. Refine in Phase 2 if
+  // the suggestions feel wrong.
+  if (monthsCovered <= Math.ceil(windowMonths / 2) && matching.length <= 3) {
+    return "non_monthly";
+  }
+
+  return "flex";
+}
+
+/** "YYYY-MM" key for a Date. Used as the budgetPlans.planMonth value. */
+export function planMonthKey(date = new Date()): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+/** Median of a non-empty array; mean used as a tie-breaker. */
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}

--- a/client/src/lib/instant.ts
+++ b/client/src/lib/instant.ts
@@ -45,6 +45,28 @@ const schema = i.schema({
       color: i.string(),
       icon: i.string(),
       isDefault: i.boolean(),
+      // Flex-budgeting fields (all optional, all client-managed). See
+      // service-side schema for full descriptions. Categories without
+      // a `bucket` are unclassified and only show in the /budgets
+      // setup wizard.
+      bucket: i.string().optional(),
+      targetAmount: i.number().optional(),
+      frequencyMonths: i.number().optional(),
+      rolloverEnabled: i.boolean().optional(),
+    }),
+    // Per-month flex-budgeting plan, keyed on "YYYY-MM". Holds the
+    // user's expected-income override + flex-pool override + savings
+    // target for that month. Phase 1 reads/writes only the current
+    // month; Phase 2 walks prior months for rollover math.
+    budgetPlans: i.entity({
+      planMonth: i.string().unique(),
+      expectedIncome: i.number(),
+      expectedIncomeAuto: i.boolean(),
+      flexPool: i.number(),
+      flexPoolAuto: i.boolean(),
+      savingsTarget: i.number().optional(),
+      createdAt: i.number(),
+      updatedAt: i.number(),
     }),
     bankSenders: i.entity({
       senderId: i.string().unique(),
@@ -181,6 +203,28 @@ export type Category = {
   color: string;
   icon: string;
   isDefault: boolean;
+  // Stored as a free-form string in InstantDB (the schema's
+  // `i.string().optional()` resolves to `string | undefined` at the
+  // type level). Consumers narrow to the Bucket literal union via
+  // `lib/budgets.ts`'s BUCKETS check before reading it as one of
+  // the three valid values; an unrecognised string is treated as
+  // unclassified.
+  bucket?: string;
+  targetAmount?: number;
+  frequencyMonths?: number;
+  rolloverEnabled?: boolean;
+};
+
+export type BudgetPlan = {
+  id: string;
+  planMonth: string;
+  expectedIncome: number;
+  expectedIncomeAuto: boolean;
+  flexPool: number;
+  flexPoolAuto: boolean;
+  savingsTarget?: number;
+  createdAt: number;
+  updatedAt: number;
 };
 
 export type BankSender = {

--- a/client/src/pages/Budgets.tsx
+++ b/client/src/pages/Budgets.tsx
@@ -1,0 +1,753 @@
+import { useMemo, useState } from "react";
+import { useTheme, useViewport } from "../ink/theme";
+import { Card, CardLabel, CardTitle, Pill, PageHeader } from "../ink/primitives";
+import {
+  useBudgetMutations,
+  useBudgetPlan,
+  useBudgetSummary,
+  useCategoryMedianSpend,
+} from "../hooks/useBudgets";
+import { BUCKETS, BUCKET_DESCRIPTIONS, BUCKET_LABELS, type Bucket, planMonthKey } from "../lib/budgets";
+import { useCategories } from "../hooks/useCategories";
+import type { Category } from "../lib/instant";
+import { format } from "date-fns";
+
+export function Budgets() {
+  const T = useTheme();
+  const planMonth = planMonthKey();
+  const plan = useBudgetPlan(planMonth);
+  const summary = useBudgetSummary(planMonth);
+  const { setCategoryBucket, setCategoryTarget, setExpectedIncome, setFlexPool, setSavingsTarget } =
+    useBudgetMutations();
+
+  const flexUsedPct = plan.flexPool > 0 ? Math.min(100, (summary.flexActual / plan.flexPool) * 100) : 0;
+  const flexRemaining = Math.max(0, plan.flexPool - summary.flexActual);
+  const daysLeft = useMemo(() => {
+    const now = new Date();
+    const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    return Math.max(1, lastDay - now.getDate() + 1);
+  }, []);
+
+  const showWizard = summary.byBucket.fixed.length === 0 &&
+    summary.byBucket.flex.length === 0 &&
+    summary.byBucket.non_monthly.length === 0;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
+      <PageHeader
+        eyebrow={`Plan for ${format(new Date(), "MMMM yyyy")}`}
+        title="Budgets"
+        rightSlot={
+          <Pill bg={T.accentSoft} color={T.accent}>
+            {summary.byBucket.unclassified.length} unclassified
+          </Pill>
+        }
+      />
+
+      {/* Headline: flex remaining */}
+      <Card pad="26px 30px" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <CardLabel>Flex remaining · GEL</CardLabel>
+        <div
+          style={{
+            fontSize: "clamp(44px, 6vw, 72px)",
+            fontWeight: 700,
+            letterSpacing: -3,
+            lineHeight: 1,
+            color: T.text,
+            fontFamily: T.sans,
+            whiteSpace: "nowrap",
+          }}
+        >
+          <span style={{ color: T.accent, opacity: 0.9 }}>₾</span>
+          {Math.round(flexRemaining).toLocaleString("en-US")}
+          <span style={{ fontSize: "0.42em", color: T.muted }}>
+            .{flexRemaining.toFixed(2).split(".")[1] || "00"}
+          </span>
+        </div>
+        <div style={{ fontSize: 12.5, color: T.muted, fontFamily: T.sans }}>
+          ₾{Math.round(flexRemaining / daysLeft).toLocaleString("en-US")}/day for the next {daysLeft} day
+          {daysLeft === 1 ? "" : "s"} · ₾{Math.round(plan.flexPool).toLocaleString("en-US")} pool
+          {plan.flexPoolIsAuto ? " (auto)" : " (manual)"}
+        </div>
+        {/* Flex usage bar */}
+        <div
+          style={{
+            marginTop: 8,
+            height: 8,
+            background: T.panelAlt,
+            borderRadius: 4,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              width: `${flexUsedPct}%`,
+              height: "100%",
+              background: T.accent,
+              transition: "width 200ms ease-out",
+            }}
+          />
+        </div>
+        <div style={{ fontSize: 11, color: T.dim, fontFamily: T.mono, fontVariantNumeric: "tabular-nums" }}>
+          ₾{Math.round(summary.flexActual).toLocaleString("en-US")} spent · {flexUsedPct.toFixed(0)}% of pool
+        </div>
+      </Card>
+
+      {showWizard ? (
+        <SetupWizard onClassify={setCategoryBucket} />
+      ) : (
+        <>
+          {/* Bucket strip */}
+          <BucketStrip summary={summary} flexPool={plan.flexPool} />
+
+          {/* Income / savings / flex pool inputs */}
+          <PlanInputs
+            plan={plan}
+            onSetIncome={(v) => setExpectedIncome(planMonth, v)}
+            onSetFlexPool={(v) => setFlexPool(planMonth, v)}
+            onSetSavingsTarget={(v) => setSavingsTarget(planMonth, v)}
+          />
+
+          {/* Bucket sections */}
+          {BUCKETS.map((bucket) => (
+            <BucketSection
+              key={bucket}
+              bucket={bucket}
+              rows={summary.byBucket[bucket]}
+              onSetTarget={setCategoryTarget}
+              onSetBucket={setCategoryBucket}
+            />
+          ))}
+
+          {/* Unclassified */}
+          {summary.byBucket.unclassified.length > 0 && (
+            <UnclassifiedSection
+              rows={summary.byBucket.unclassified}
+              onSetBucket={setCategoryBucket}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Setup wizard ──────────────────────────────────────────────────
+
+function SetupWizard({ onClassify }: { onClassify: (catId: string, b: Bucket) => Promise<void> }) {
+  const T = useTheme();
+  const { categories } = useCategories();
+  const seedable = categories.length > 0;
+
+  if (!seedable) {
+    return (
+      <Card pad="40px 30px" style={{ textAlign: "center" }}>
+        <CardLabel>No categories yet</CardLabel>
+        <div style={{ fontSize: 14, color: T.muted, fontFamily: T.sans, marginTop: 12, lineHeight: 1.5 }}>
+          Open the <strong>Categories</strong> page to seed the default set, or let your transactions
+          categorise themselves automatically. Once you have at least one category, return here to set
+          a budget.
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card pad="22px 24px" style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <div>
+        <CardTitle>Let's set this up</CardTitle>
+        <div style={{ fontSize: 13, color: T.muted, fontFamily: T.sans, marginTop: 6, lineHeight: 1.5 }}>
+          Pick a bucket for each category. <strong>Fixed</strong> = predictable monthly costs (rent,
+          utilities). <strong>Flex</strong> = discretionary spending that shares one pool.{" "}
+          <strong>Non-Monthly</strong> = annual / quarterly costs that accrue across months. You can
+          change any of these later — nothing here is permanent.
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {categories.map((c) => (
+          <UnclassifiedRow key={c.id} category={c} onClassify={onClassify} />
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+// ─── Bucket strip (3 progress bars) ────────────────────────────────
+
+function BucketStrip({
+  summary,
+  flexPool,
+}: {
+  summary: ReturnType<typeof useBudgetSummary>;
+  flexPool: number;
+}) {
+  const T = useTheme();
+  const vp = useViewport();
+
+  const items: Array<{ label: string; actual: number; target: number; color: string }> = [
+    { label: "Fixed", actual: summary.fixedActual, target: summary.fixedTarget, color: T.green },
+    { label: "Non-Monthly", actual: summary.nonMonthlyActual, target: summary.nonMonthlyAccruals, color: T.blue },
+    { label: "Flex", actual: summary.flexActual, target: flexPool, color: T.accent },
+  ];
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: vp.veryNarrow ? "1fr" : "1fr 1fr 1fr",
+        gap: T.density.gap,
+      }}
+    >
+      {items.map((it) => {
+        const pct = it.target > 0 ? Math.min(100, (it.actual / it.target) * 100) : 0;
+        return (
+          <Card key={it.label} pad="16px 18px" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+              <CardLabel>{it.label}</CardLabel>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: T.dim,
+                  fontFamily: T.mono,
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                ₾{Math.round(it.actual)} / ₾{Math.round(it.target)}
+              </span>
+            </div>
+            <div style={{ height: 6, background: T.panelAlt, borderRadius: 3, overflow: "hidden" }}>
+              <div
+                style={{
+                  width: `${pct}%`,
+                  height: "100%",
+                  background: it.color,
+                  transition: "width 200ms ease-out",
+                }}
+              />
+            </div>
+            <div style={{ fontSize: 10, color: T.muted, fontFamily: T.mono }}>
+              {pct.toFixed(0)}% used
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Plan inputs (income + savings + flex pool) ───────────────────
+
+function PlanInputs({
+  plan,
+  onSetIncome,
+  onSetFlexPool,
+  onSetSavingsTarget,
+}: {
+  plan: ReturnType<typeof useBudgetPlan>;
+  onSetIncome: (v: number | null) => Promise<void>;
+  onSetFlexPool: (v: number | null) => Promise<void>;
+  onSetSavingsTarget: (v: number) => Promise<void>;
+}) {
+  const T = useTheme();
+  const vp = useViewport();
+
+  return (
+    <Card pad="22px 24px" style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <CardTitle>Income & allocations</CardTitle>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: vp.veryNarrow ? "1fr" : "1fr 1fr 1fr",
+          gap: T.density.gap,
+        }}
+      >
+        <NumberField
+          label="Expected income"
+          value={plan.expectedIncome}
+          isAuto={plan.expectedIncomeIsAuto}
+          autoHint="3-month avg of your credits"
+          onChange={onSetIncome}
+        />
+        <NumberField
+          label="Savings target"
+          value={plan.savingsTarget}
+          isAuto={false}
+          autoHint="0 by default"
+          onChange={(v) => onSetSavingsTarget(v ?? 0)}
+        />
+        <NumberField
+          label="Flex pool"
+          value={plan.flexPool}
+          isAuto={plan.flexPoolIsAuto}
+          autoHint={`${plan.expectedIncome > 0 ? "income − fixed − non-monthly − savings" : "no income detected"}`}
+          onChange={onSetFlexPool}
+        />
+      </div>
+    </Card>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  isAuto,
+  autoHint,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  isAuto: boolean;
+  autoHint: string;
+  onChange: (v: number | null) => Promise<void>;
+}) {
+  const T = useTheme();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(Math.round(value)));
+
+  const startEdit = () => {
+    setDraft(String(Math.round(value)));
+    setEditing(true);
+  };
+
+  const commit = async () => {
+    const parsed = Number(draft);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      setEditing(false);
+      return;
+    }
+    await onChange(parsed);
+    setEditing(false);
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <CardLabel>{label}</CardLabel>
+      {editing ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ color: T.accent, fontFamily: T.sans, fontWeight: 700, fontSize: 22 }}>₾</span>
+          <input
+            value={draft}
+            autoFocus
+            onChange={(e) => setDraft(e.target.value.replace(/[^0-9.]/g, ""))}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commit();
+              if (e.key === "Escape") setEditing(false);
+            }}
+            style={{
+              flex: 1,
+              padding: "6px 10px",
+              background: T.panelAlt,
+              border: `1px solid ${T.line}`,
+              borderRadius: 8,
+              color: T.text,
+              fontSize: 22,
+              fontFamily: T.sans,
+              fontWeight: 700,
+              outline: "none",
+              minWidth: 0,
+            }}
+          />
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={startEdit}
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 4,
+            padding: 0,
+            border: "none",
+            background: "transparent",
+            color: T.text,
+            fontSize: 28,
+            fontWeight: 700,
+            fontFamily: T.sans,
+            letterSpacing: -1,
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          <span style={{ color: T.accent, opacity: 0.9 }}>₾</span>
+          {Math.round(value).toLocaleString("en-US")}
+        </button>
+      )}
+      <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 10.5, color: T.dim, fontFamily: T.mono }}>
+        <span>{isAuto ? `auto · ${autoHint}` : "manual"}</span>
+        {!isAuto && (
+          <button
+            type="button"
+            onClick={() => onChange(null)}
+            style={{
+              padding: 0,
+              background: "transparent",
+              border: "none",
+              color: T.accent,
+              fontFamily: T.mono,
+              fontSize: 10.5,
+              cursor: "pointer",
+            }}
+          >
+            reset
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Bucket section (Fixed / Flex / Non-Monthly) ──────────────────
+
+function BucketSection({
+  bucket,
+  rows,
+  onSetTarget,
+  onSetBucket,
+}: {
+  bucket: Bucket;
+  rows: Array<{ category: Category; bucket: Bucket | null; target: number; monthlyCommitment: number; actual: number; remaining: number }>;
+  onSetTarget: (
+    catId: string,
+    args: { targetAmount?: number; frequencyMonths?: number; rolloverEnabled?: boolean }
+  ) => Promise<void>;
+  onSetBucket: (catId: string, b: Bucket | null) => Promise<void>;
+}) {
+  const T = useTheme();
+  if (rows.length === 0) return null;
+
+  return (
+    <Card pad="22px 24px" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div>
+        <CardTitle>{BUCKET_LABELS[bucket]}</CardTitle>
+        <div style={{ fontSize: 12, color: T.muted, fontFamily: T.sans, marginTop: 4, lineHeight: 1.5 }}>
+          {BUCKET_DESCRIPTIONS[bucket]}
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {rows.map((r) => (
+          <BucketRow
+            key={r.category.id}
+            row={r}
+            onSetTarget={(args) => onSetTarget(r.category.id, args)}
+            onMoveToBucket={(b) => onSetBucket(r.category.id, b)}
+          />
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function BucketRow({
+  row,
+  onSetTarget,
+  onMoveToBucket,
+}: {
+  row: { category: Category; bucket: Bucket | null; target: number; monthlyCommitment: number; actual: number; remaining: number };
+  onSetTarget: (args: { targetAmount?: number; frequencyMonths?: number }) => Promise<void>;
+  onMoveToBucket: (b: Bucket | null) => Promise<void>;
+}) {
+  const T = useTheme();
+  const [editing, setEditing] = useState(false);
+  const [targetDraft, setTargetDraft] = useState(String(row.target || ""));
+  const [freqDraft, setFreqDraft] = useState(String(row.category.frequencyMonths || 12));
+
+  const showsTarget = row.bucket === "fixed" || row.bucket === "non_monthly";
+  const pct = row.monthlyCommitment > 0 ? Math.min(100, (row.actual / row.monthlyCommitment) * 100) : 0;
+  const overspent = showsTarget && row.actual > row.monthlyCommitment;
+
+  const commit = async () => {
+    const target = Number(targetDraft);
+    const freq = Number(freqDraft);
+    if (!Number.isFinite(target) || target < 0) {
+      setEditing(false);
+      return;
+    }
+    if (row.bucket === "non_monthly") {
+      const f = Number.isFinite(freq) && freq > 0 ? freq : 12;
+      await onSetTarget({ targetAmount: target, frequencyMonths: f });
+    } else {
+      await onSetTarget({ targetAmount: target });
+    }
+    setEditing(false);
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr auto auto",
+        gap: 12,
+        alignItems: "center",
+        padding: "10px 12px",
+        background: T.panelAlt,
+        borderRadius: 10,
+        border: `1px solid ${T.line}`,
+      }}
+    >
+      <div style={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 5,
+              background: row.category.color,
+              flexShrink: 0,
+            }}
+          />
+          <span style={{ fontSize: 13.5, fontWeight: 600, color: T.text, fontFamily: T.sans }}>
+            {row.category.name}
+          </span>
+          {overspent && (
+            <Pill bg="rgba(255,90,58,0.16)" color={T.accent}>
+              over
+            </Pill>
+          )}
+        </div>
+        {showsTarget && row.target > 0 && (
+          <div style={{ height: 4, background: T.panel, borderRadius: 2, overflow: "hidden" }}>
+            <div
+              style={{
+                width: `${pct}%`,
+                height: "100%",
+                background: overspent ? T.accent : row.category.color,
+                transition: "width 200ms ease-out",
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          fontFamily: T.mono,
+          fontVariantNumeric: "tabular-nums",
+          minWidth: 100,
+        }}
+      >
+        <span style={{ fontSize: 13, color: T.text, fontWeight: 600 }}>
+          ₾{Math.round(row.actual).toLocaleString("en-US")}
+        </span>
+        {showsTarget && (
+          <span style={{ fontSize: 10, color: T.dim }}>
+            of ₾{Math.round(row.monthlyCommitment).toLocaleString("en-US")}
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: "flex", gap: 6 }}>
+        {showsTarget && (
+          editing ? (
+            <div
+              style={{
+                display: "flex",
+                gap: 4,
+                background: T.panel,
+                border: `1px solid ${T.line}`,
+                borderRadius: 6,
+                padding: 4,
+              }}
+            >
+              <input
+                value={targetDraft}
+                autoFocus
+                onChange={(e) => setTargetDraft(e.target.value.replace(/[^0-9.]/g, ""))}
+                onBlur={commit}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") commit();
+                  if (e.key === "Escape") setEditing(false);
+                }}
+                placeholder="target"
+                style={{
+                  width: row.bucket === "non_monthly" ? 70 : 90,
+                  padding: "4px 8px",
+                  background: T.panelAlt,
+                  border: "none",
+                  borderRadius: 4,
+                  color: T.text,
+                  fontSize: 12,
+                  fontFamily: T.sans,
+                  outline: "none",
+                }}
+              />
+              {row.bucket === "non_monthly" && (
+                <input
+                  value={freqDraft}
+                  onChange={(e) => setFreqDraft(e.target.value.replace(/[^0-9]/g, ""))}
+                  onBlur={commit}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") commit();
+                  }}
+                  placeholder="months"
+                  style={{
+                    width: 60,
+                    padding: "4px 8px",
+                    background: T.panelAlt,
+                    border: "none",
+                    borderRadius: 4,
+                    color: T.text,
+                    fontSize: 12,
+                    fontFamily: T.sans,
+                    outline: "none",
+                  }}
+                />
+              )}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setTargetDraft(String(row.target || ""));
+                setFreqDraft(String(row.category.frequencyMonths || 12));
+                setEditing(true);
+              }}
+              style={{
+                padding: "5px 10px",
+                background: "transparent",
+                border: `1px solid ${T.line}`,
+                borderRadius: 6,
+                color: T.muted,
+                fontSize: 11,
+                fontFamily: T.sans,
+                cursor: "pointer",
+              }}
+            >
+              {row.target > 0 ? "edit" : "set target"}
+            </button>
+          )
+        )}
+        <BucketDropdown current={row.bucket} onChange={onMoveToBucket} />
+      </div>
+    </div>
+  );
+}
+
+function BucketDropdown({
+  current,
+  onChange,
+}: {
+  current: Bucket | null;
+  onChange: (b: Bucket | null) => Promise<void>;
+}) {
+  const T = useTheme();
+  return (
+    <select
+      value={current ?? ""}
+      onChange={(e) => onChange((e.target.value || null) as Bucket | null)}
+      style={{
+        padding: "5px 10px",
+        background: T.panel,
+        border: `1px solid ${T.line}`,
+        borderRadius: 6,
+        color: T.muted,
+        fontSize: 11,
+        fontFamily: T.sans,
+        cursor: "pointer",
+      }}
+    >
+      <option value="">—</option>
+      {BUCKETS.map((b) => (
+        <option key={b} value={b}>
+          {BUCKET_LABELS[b]}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// ─── Unclassified section ─────────────────────────────────────────
+
+function UnclassifiedSection({
+  rows,
+  onSetBucket,
+}: {
+  rows: Array<{ category: Category; actual: number }>;
+  onSetBucket: (catId: string, b: Bucket | null) => Promise<void>;
+}) {
+  const T = useTheme();
+  return (
+    <Card pad="22px 24px" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div>
+        <CardTitle>Unclassified</CardTitle>
+        <div style={{ fontSize: 12, color: T.muted, fontFamily: T.sans, marginTop: 4 }}>
+          Categories without a bucket. Assign one to include them in the formula.
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {rows.map((r) => (
+          <UnclassifiedRow key={r.category.id} category={r.category} onClassify={onSetBucket} />
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function UnclassifiedRow({
+  category,
+  onClassify,
+}: {
+  category: Category;
+  onClassify: (catId: string, b: Bucket) => Promise<void>;
+}) {
+  const T = useTheme();
+  const median = useCategoryMedianSpend(category.id);
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr auto",
+        gap: 12,
+        alignItems: "center",
+        padding: "10px 12px",
+        background: T.panelAlt,
+        borderRadius: 10,
+        border: `1px solid ${T.line}`,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: 5,
+            background: category.color,
+            flexShrink: 0,
+          }}
+        />
+        <span style={{ fontSize: 13.5, fontWeight: 600, color: T.text, fontFamily: T.sans }}>
+          {category.name}
+        </span>
+        {median > 0 && (
+          <span style={{ fontSize: 10.5, color: T.dim, fontFamily: T.mono }}>
+            ~₾{Math.round(median)}/mo
+          </span>
+        )}
+      </div>
+      <div style={{ display: "flex", gap: 6 }}>
+        {BUCKETS.map((b) => (
+          <button
+            key={b}
+            type="button"
+            onClick={() => onClassify(category.id, b)}
+            style={{
+              padding: "5px 10px",
+              background: T.panel,
+              border: `1px solid ${T.line}`,
+              borderRadius: 6,
+              color: T.muted,
+              fontSize: 11,
+              fontFamily: T.sans,
+              cursor: "pointer",
+            }}
+          >
+            {BUCKET_LABELS[b]}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Budgets.tsx
+++ b/client/src/pages/Budgets.tsx
@@ -17,8 +17,14 @@ export function Budgets() {
   const planMonth = planMonthKey();
   const plan = useBudgetPlan(planMonth);
   const summary = useBudgetSummary(planMonth);
-  const { setCategoryBucket, setCategoryTarget, setExpectedIncome, setFlexPool, setSavingsTarget } =
-    useBudgetMutations();
+  const {
+    setCategoryBucket,
+    setCategoryTarget,
+    setCategoryRollover,
+    setExpectedIncome,
+    setFlexPool,
+    setSavingsTarget,
+  } = useBudgetMutations();
 
   const flexUsedPct = plan.flexPool > 0 ? Math.min(100, (summary.flexActual / plan.flexPool) * 100) : 0;
   const flexRemaining = Math.max(0, plan.flexPool - summary.flexActual);
@@ -114,8 +120,10 @@ export function Budgets() {
               key={bucket}
               bucket={bucket}
               rows={summary.byBucket[bucket]}
+              sinkingFund={bucket === "non_monthly" ? summary.nonMonthlySinkingFund : 0}
               onSetTarget={setCategoryTarget}
               onSetBucket={setCategoryBucket}
+              onSetRollover={setCategoryRollover}
             />
           ))}
 
@@ -402,16 +410,20 @@ function NumberField({
 function BucketSection({
   bucket,
   rows,
+  sinkingFund,
   onSetTarget,
   onSetBucket,
+  onSetRollover,
 }: {
   bucket: Bucket;
-  rows: Array<{ category: Category; bucket: Bucket | null; target: number; monthlyCommitment: number; actual: number; remaining: number }>;
+  rows: Array<{ category: Category; bucket: Bucket | null; target: number; monthlyCommitment: number; actual: number; rolloverIn: number; effectiveTarget: number; remaining: number }>;
+  sinkingFund: number;
   onSetTarget: (
     catId: string,
     args: { targetAmount?: number; frequencyMonths?: number; rolloverEnabled?: boolean }
   ) => Promise<void>;
   onSetBucket: (catId: string, b: Bucket | null) => Promise<void>;
+  onSetRollover: (catId: string, enabled: boolean) => Promise<void>;
 }) {
   const T = useTheme();
   if (rows.length === 0) return null;
@@ -419,7 +431,21 @@ function BucketSection({
   return (
     <Card pad="22px 24px" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
       <div>
-        <CardTitle>{BUCKET_LABELS[bucket]}</CardTitle>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12 }}>
+          <CardTitle>{BUCKET_LABELS[bucket]}</CardTitle>
+          {bucket === "non_monthly" && sinkingFund !== 0 && (
+            <span
+              style={{
+                fontSize: 11,
+                color: sinkingFund >= 0 ? T.green : T.accent,
+                fontFamily: T.mono,
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              {sinkingFund >= 0 ? "+" : "−"}₾{Math.abs(Math.round(sinkingFund)).toLocaleString("en-US")} sinking fund
+            </span>
+          )}
+        </div>
         <div style={{ fontSize: 12, color: T.muted, fontFamily: T.sans, marginTop: 4, lineHeight: 1.5 }}>
           {BUCKET_DESCRIPTIONS[bucket]}
         </div>
@@ -431,6 +457,7 @@ function BucketSection({
             row={r}
             onSetTarget={(args) => onSetTarget(r.category.id, args)}
             onMoveToBucket={(b) => onSetBucket(r.category.id, b)}
+            onSetRollover={(enabled) => onSetRollover(r.category.id, enabled)}
           />
         ))}
       </div>
@@ -442,10 +469,12 @@ function BucketRow({
   row,
   onSetTarget,
   onMoveToBucket,
+  onSetRollover,
 }: {
-  row: { category: Category; bucket: Bucket | null; target: number; monthlyCommitment: number; actual: number; remaining: number };
+  row: { category: Category; bucket: Bucket | null; target: number; monthlyCommitment: number; actual: number; rolloverIn: number; effectiveTarget: number; remaining: number };
   onSetTarget: (args: { targetAmount?: number; frequencyMonths?: number }) => Promise<void>;
   onMoveToBucket: (b: Bucket | null) => Promise<void>;
+  onSetRollover: (enabled: boolean) => Promise<void>;
 }) {
   const T = useTheme();
   const [editing, setEditing] = useState(false);
@@ -453,8 +482,14 @@ function BucketRow({
   const [freqDraft, setFreqDraft] = useState(String(row.category.frequencyMonths || 12));
 
   const showsTarget = row.bucket === "fixed" || row.bucket === "non_monthly";
-  const pct = row.monthlyCommitment > 0 ? Math.min(100, (row.actual / row.monthlyCommitment) * 100) : 0;
-  const overspent = showsTarget && row.actual > row.monthlyCommitment;
+  // Bar measures actual / effectiveTarget so a positive rollover gives
+  // headroom and a negative one shrinks the bar — visually consistent
+  // with the displayed "of ₾X" denominator below.
+  const denom = row.effectiveTarget > 0 ? row.effectiveTarget : row.monthlyCommitment;
+  const pct = denom > 0 ? Math.min(100, (row.actual / denom) * 100) : 0;
+  const overspent = showsTarget && row.actual > Math.max(0, row.effectiveTarget);
+  const rolloverEnabled = row.bucket === "fixed" && row.category.rolloverEnabled === true;
+  const showRolloverHint = showsTarget && row.rolloverIn !== 0;
 
   const commit = async () => {
     const target = Number(targetDraft);
@@ -526,7 +561,7 @@ function BucketRow({
           alignItems: "flex-end",
           fontFamily: T.mono,
           fontVariantNumeric: "tabular-nums",
-          minWidth: 100,
+          minWidth: 110,
         }}
       >
         <span style={{ fontSize: 13, color: T.text, fontWeight: 600 }}>
@@ -534,12 +569,44 @@ function BucketRow({
         </span>
         {showsTarget && (
           <span style={{ fontSize: 10, color: T.dim }}>
-            of ₾{Math.round(row.monthlyCommitment).toLocaleString("en-US")}
+            of ₾{Math.round(Math.max(0, row.effectiveTarget)).toLocaleString("en-US")}
+          </span>
+        )}
+        {showRolloverHint && (
+          <span
+            style={{
+              fontSize: 10,
+              color: row.rolloverIn >= 0 ? T.green : T.accent,
+            }}
+          >
+            {row.rolloverIn >= 0 ? "+" : "−"}₾{Math.abs(Math.round(row.rolloverIn)).toLocaleString("en-US")} carried
           </span>
         )}
       </div>
 
-      <div style={{ display: "flex", gap: 6 }}>
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        {row.bucket === "fixed" && (
+          <button
+            type="button"
+            onClick={() => onSetRollover(!rolloverEnabled)}
+            title={rolloverEnabled ? "Rollover ON — leftover/overshoot carries to next month" : "Rollover OFF — each month starts fresh"}
+            style={{
+              padding: "5px 8px",
+              background: rolloverEnabled ? T.accentSoft : "transparent",
+              border: `1px solid ${rolloverEnabled ? T.accent : T.line}`,
+              borderRadius: 6,
+              color: rolloverEnabled ? T.accent : T.muted,
+              fontSize: 10.5,
+              fontFamily: T.mono,
+              letterSpacing: 0.4,
+              textTransform: "uppercase",
+              cursor: "pointer",
+              fontWeight: 700,
+            }}
+          >
+            {rolloverEnabled ? "↻ on" : "↻ off"}
+          </button>
+        )}
         {showsTarget && (
           editing ? (
             <div

--- a/client/src/pages/Budgets.tsx
+++ b/client/src/pages/Budgets.tsx
@@ -42,7 +42,7 @@ export function Budgets() {
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
       <PageHeader
         eyebrow={`Plan for ${format(new Date(), "MMMM yyyy")}`}
-        title="Budgets"
+        title="Flex Budgeting"
         rightSlot={
           <Pill bg={T.accentSoft} color={T.accent}>
             {summary.byBucket.unclassified.length} unclassified

--- a/client/src/pages/Budgets.tsx
+++ b/client/src/pages/Budgets.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useTheme, useViewport } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, PageHeader } from "../ink/primitives";
 import {
@@ -480,6 +480,7 @@ function BucketRow({
   const [editing, setEditing] = useState(false);
   const [targetDraft, setTargetDraft] = useState(String(row.target || ""));
   const [freqDraft, setFreqDraft] = useState(String(row.category.frequencyMonths || 12));
+  const editorRef = useRef<HTMLDivElement | null>(null);
 
   const showsTarget = row.bucket === "fixed" || row.bucket === "non_monthly";
   // Bar measures actual / effectiveTarget so a positive rollover gives
@@ -505,6 +506,16 @@ function BucketRow({
       await onSetTarget({ targetAmount: target });
     }
     setEditing(false);
+  };
+
+  // For the Non-Monthly two-input editor, blur on the target input
+  // fires when the user clicks the months input, which would commit
+  // and unmount the months input before they can type. Skip the
+  // close when focus is moving to a sibling inside the editor; only
+  // commit on a real "exited the editor" blur. (Codex P2 on PR #42.)
+  const onFieldBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (editorRef.current?.contains(e.relatedTarget as Node | null)) return;
+    void commit();
   };
 
   return (
@@ -610,6 +621,7 @@ function BucketRow({
         {showsTarget && (
           editing ? (
             <div
+              ref={editorRef}
               style={{
                 display: "flex",
                 gap: 4,
@@ -623,7 +635,7 @@ function BucketRow({
                 value={targetDraft}
                 autoFocus
                 onChange={(e) => setTargetDraft(e.target.value.replace(/[^0-9.]/g, ""))}
-                onBlur={commit}
+                onBlur={onFieldBlur}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") commit();
                   if (e.key === "Escape") setEditing(false);
@@ -645,9 +657,10 @@ function BucketRow({
                 <input
                   value={freqDraft}
                   onChange={(e) => setFreqDraft(e.target.value.replace(/[^0-9]/g, ""))}
-                  onBlur={commit}
+                  onBlur={onFieldBlur}
                   onKeyDown={(e) => {
                     if (e.key === "Enter") commit();
+                    if (e.key === "Escape") setEditing(false);
                   }}
                   placeholder="months"
                   style={{

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -244,7 +244,13 @@ export function Dashboard() {
 
           <CashflowBar T={T} income={income} spent={stats.total} />
           {T.chartsVisible && trendData.length > 0 && (
-            <div style={{ marginTop: 22 }}>
+            // Wrapper width matches the chart's so the bottom labels
+            // line up with the chart's data points. Without this, the
+            // labels container fills the Card width while the chart
+            // stays at 640px on wide screens — APR ends up under the
+            // empty space right of the chart while the actual data dot
+            // is at the chart's right edge (~JAN-aligned in screenshots).
+            <div style={{ marginTop: 22, width: 640, maxWidth: "100%" }}>
               <AreaChart
                 data={trendData}
                 width={640}

--- a/client/src/pages/Income.tsx
+++ b/client/src/pages/Income.tsx
@@ -160,7 +160,11 @@ export function Income() {
             {monthly.count} incoming transactions · {format(now, "MMMM yyyy")}
           </div>
           {T.chartsVisible && credits9mTrend.some((d) => d.value > 0) && (
-            <div style={{ marginTop: 14 }}>
+            // Wrapper width matches the chart's so the bottom labels
+            // line up with the chart's data points (matches the same
+            // fix on Dashboard.tsx — without this, on wide screens the
+            // labels span Card width while the chart stays at 560px).
+            <div style={{ marginTop: 14, width: 560, maxWidth: "100%" }}>
               <AreaChart
                 data={credits9mTrend}
                 width={560}

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -1,6 +1,7 @@
 export { Dashboard } from "./Dashboard";
 export { Transactions } from "./Transactions";
 export { Categories } from "./Categories";
+export { Budgets } from "./Budgets";
 export { Merchants } from "./Merchants";
 export { Income } from "./Income";
 export { Analytics as Signals } from "./Analytics";

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -117,6 +117,7 @@ and update them in the same commit.
 | [dashboard.md](dashboard.md) | `client/src/pages/Dashboard.tsx` — hero, donut, 9-month trend, top-merchant tiles, wheel-scroll regression guard | 2026-04-27 (PR #27) |
 | [transactions.md](transactions.md) | `client/src/pages/Transactions.tsx` — filters, day groups, side panel, URL drill-down ingestion | 2026-04-27 (PR #23) |
 | [categories.md](categories.md) | `client/src/pages/Categories.tsx` — left donut + list, per-cat detail, per-cat trend, merchant rows | 2026-04-27 (PR #23) |
+| [budgets.md](budgets.md) | `client/src/pages/Budgets.tsx` + `useBudgets` + `lib/budgets.ts` + `lib/ai/tools/budgets.ts` — three-bucket flex budgeting, rollover, AI tools | 2026-04-30 (PR #42) |
 | [merchants.md](merchants.md) | `client/src/pages/Merchants.tsx` — table, search, drill-down rows | 2026-04-27 (PR #23) |
 | [income.md](income.md) | `client/src/pages/Income.tsx` — hero, income trend, ledger | 2026-04-27 (PR #23) |
 | [manage.md](manage.md) | `client/src/pages/Settings.tsx` mounted at `/manage` — Sync now button, CSRF, partial-failure UI | 2026-04-27 (PR #22) |

--- a/docs/e2e/budgets.md
+++ b/docs/e2e/budgets.md
@@ -1,0 +1,405 @@
+# Flex Budgeting — manual E2E
+
+Surface: `client/src/pages/Budgets.tsx`, `client/src/hooks/useBudgets.ts`,
+`client/src/lib/budgets.ts`, plus the AI tools in `client/src/lib/ai/tools/budgets.ts`.
+
+**Demo mode required.** Confirm via Prereqs in `README.md` before running.
+Open `http://localhost:5173/budgets`.
+
+## Demo-data baseline (current month)
+
+The seed in `client/src/dev/demoData.ts` ships pre-classified bucket
+assignments + two `budgetPlans` rows (current + previous month, both
+auto-everything). Specifically:
+
+- **Fixed**: Subscriptions (target ₾200, rollover ON), Utilities (₾220,
+  rollover OFF), Loans (₾800, rollover OFF).
+- **Non-Monthly**: Travel (target ₾2400 / 12 months → ₾200/mo accrual).
+- **Flex**: Groceries, Dining, Delivery, Transport, Shopping, Health,
+  Entertainment, Cash, Other (no per-category targets).
+- **Plans seeded**: previous month + current month, savingsTarget = ₾500
+  on both, expectedIncome and flexPool both auto-derived.
+- **Current-month spending**: dampened to ~50% count × 50% amount so net
+  cashflow is positive and `flex remaining` shows real headroom (≥₾3k
+  typical). Past months keep full volume so the rollover anchor has real
+  prior actuals to walk over.
+
+These numbers are deterministic for a given calendar day; reseeded as the
+day rolls over.
+
+---
+
+## T-BUD-01 — Page loads with three buckets populated
+
+**Steps**
+1. Navigate to `http://localhost:5173/budgets`.
+2. Wait for the page to render.
+
+**Expected**
+- Sidebar entry **Flex Budgeting** appears between Categories and Merchants
+  with glyph `◇`. No NEW pill.
+- Eyebrow: `Plan for <current month name> <year>` (e.g. `Plan for April 2026`).
+- Title: `Flex Budgeting`.
+- Right-side pill shows `0 unclassified` (every demo category has a bucket).
+- Headline card "Flex remaining · GEL" renders a non-zero number (≥₾2k on a
+  typical demo day).
+- Subtitle reads `₾<X>/day for the next <N> days · ₾<pool> pool (auto)`.
+- Progress bar under the headline is coral, fills proportionally to actuals,
+  followed by `₾<spent> spent · <pct>% of pool`.
+- Three small cards in a row: **Fixed**, **Non-Monthly**, **Flex**.
+- Income & allocations card with three editable fields: Expected income,
+  Savings target, Flex pool.
+- Three bucket sections render below: **Fixed** (3 rows), **Non-Monthly**
+  (1 row: Travel), **Flex** (≥7 rows).
+
+---
+
+## T-BUD-02 — Headline math is internally consistent
+
+**Steps**
+1. From the Budgets page, note: expectedIncome (top of Income card),
+   sum of fixed targets (Fixed bucket card "of ₾X"), Non-Monthly accruals
+   ("of ₾X" on the Non-Monthly bucket card), savings target, and the flex
+   pool.
+2. Compute: `flexPool_expected = expectedIncome − fixedTargets −
+   nonMonthlyAccruals − savingsTarget`.
+
+**Expected**
+- The displayed Flex pool number equals `flexPool_expected` (within ±₾1
+  rounding).
+- The headline "Flex remaining" equals `flexPool − flexActual` (the spent
+  number on the Flex bucket-strip card).
+- Negative results clamp to 0 — if the math goes below zero, the headline
+  reads ₾0 not a negative number.
+
+---
+
+## T-BUD-03 — Bucket-strip progress bars match per-row sums
+
+**Steps**
+1. Sum the actuals shown on every Fixed-row's right-side stack.
+2. Sum the actuals shown on every Non-Monthly-row's right-side stack.
+3. Sum the actuals shown on every Flex-row's right-side stack.
+4. Compare each total against the corresponding card in the bucket strip.
+
+**Expected**
+- Fixed strip "₾A / ₾B" — A matches the per-row sum, B matches the sum of
+  category target amounts.
+- Non-Monthly strip A matches per-row sum, B matches sum of monthly
+  accruals (target ÷ frequencyMonths).
+- Flex strip A matches per-row sum, B matches the flex pool from T-BUD-02.
+
+---
+
+## T-BUD-04 — Expected income manual override + reset
+
+**Steps**
+1. Click the Expected income field — value becomes editable. Note the auto
+   value before editing.
+2. Type `9000` and press Enter.
+3. The field re-renders showing the new value.
+4. Below the field, click `reset` next to "manual".
+
+**Expected**
+- After step 3: Expected income shows `₾9,000` and the helper line reads
+  `manual` instead of `auto · 3-month avg of your credits`.
+- A `reset` link appears next to "manual".
+- The headline Flex remaining recomputes against the new income.
+- After step 4: Field snaps back to the original auto value, helper line
+  flips back to `auto · …`, the `reset` link disappears.
+- The headline updates again to reflect the auto value.
+
+---
+
+## T-BUD-05 — Savings target slider commits + reflects in flex pool
+
+**Steps**
+1. Click the Savings target field. Note the current Flex pool value.
+2. Type `1500` and press Enter.
+
+**Expected**
+- Savings target field shows `₾1,500`.
+- Flex pool drops by exactly `(new - old)` = ₾1000 if it was ₾500 before.
+- Headline Flex remaining drops by the same amount.
+
+---
+
+## T-BUD-06 — Flex pool manual override + reset
+
+**Steps**
+1. Click the Flex pool field. Note the auto value.
+2. Type `2500` + Enter.
+3. Click `reset` next to "manual".
+
+**Expected**
+- Step 2: Flex pool reads `₾2,500` with helper `manual` and a `reset` link.
+- Headline + Flex bucket-strip card update accordingly.
+- Step 3: Snaps back to the auto-derived value (the income-minus-everything
+  formula). Helper flips to `auto · income − fixed − non-monthly − savings`.
+
+---
+
+## T-BUD-07 — Edit Fixed-category target inline
+
+**Steps**
+1. In the Fixed section, click `set target` (or the existing target value)
+   on the Subscriptions row.
+2. The input is pre-filled with `200`. Type `350` and press Enter.
+
+**Expected**
+- Target updates to `₾350`. Per-row "of ₾X" updates. Per-row progress bar
+  re-scales.
+- Fixed bucket-strip card "of ₾X" total recomputes (was ₾1220, now ₾1370 if
+  Subs went 200→350).
+- Flex pool drops by the difference (since fixed targets feed the formula).
+
+---
+
+## T-BUD-08 — Edit Non-Monthly target + frequency without losing focus
+
+**Codex P2 regression guard from PR #42.**
+
+**Steps**
+1. In the Non-Monthly section, click `set target` on the Travel row.
+2. Two inputs appear inline (target + months). Target is pre-filled with
+   `2400`, months with `12`.
+3. Click into the **months** input directly (don't tab — actually click).
+4. Without that triggering a close, change months to `6`.
+5. Press Enter.
+
+**Expected**
+- Step 3: The months input keeps focus and remains editable. The editor
+  does NOT close on click-out from target → months.
+- Step 5: Both target and months commit. The per-row monthly accrual now
+  shows ₾2400 ÷ 6 = ₾400/mo.
+- Non-Monthly bucket-strip card "of ₾X" reflects the new accrual.
+
+---
+
+## T-BUD-09 — Fixed rollover toggle + carry indicator
+
+**Steps**
+1. In the Fixed section, find the Subscriptions row. The `↻ ON` button is
+   highlighted (rollover enabled by demo seed).
+2. With at least one prior plan-month saved (the demo seed includes the
+   previous month), the row's right-side stack should show
+   `±₾<X> carried` beneath the spent number — green for positive carry,
+   coral for negative.
+3. Click `↻ ON` to toggle off. Click again to re-enable.
+4. Repeat with Utilities (rollover OFF in the demo seed).
+
+**Expected**
+- Step 1–2: Subscriptions shows the carry line because rollover is ON
+  AND there's a prior plan month for the anchor.
+- Step 3: When toggled off, the carry line disappears for Subscriptions.
+  Toggling back on, it returns.
+- Step 4: Utilities does NOT show a carry line by default (rollover OFF).
+  Toggling ON makes the carry line appear (it'll likely be positive since
+  Utilities was under target last month).
+
+---
+
+## T-BUD-10 — Non-Monthly sinking fund header
+
+**Steps**
+1. Look at the Non-Monthly section header.
+2. Verify the inline `+₾<X> sinking fund` text on the right.
+
+**Expected**
+- The total reads `+₾<X>` in green when the sum of unspent accruals is
+  positive (typical case — Travel hasn't been spent yet).
+- If Travel was overspent, the value would render in coral with `−₾<X>`.
+- The number equals the sum of `rolloverIn` across Non-Monthly rows.
+
+---
+
+## T-BUD-11 — Reassign category bucket via dropdown
+
+**Steps**
+1. In the Flex section, find the **Dining** row.
+2. Click the bucket dropdown on its right edge. Select **Fixed**.
+3. Verify Dining now appears in the Fixed section with no target set.
+4. Click `set target` on the new Fixed Dining row, set ₾400, Enter.
+5. Move it back to Flex via the dropdown.
+
+**Expected**
+- Step 3: Dining disappears from Flex section, appears in Fixed.
+- Step 4: Target commits, per-row "of ₾400" appears, Fixed bucket-strip
+  total grows by ₾400.
+- Step 5: Dining returns to Flex section, but its target is preserved (not
+  reset) — re-classifying back to Fixed would still show ₾400.
+
+---
+
+## T-BUD-12 — Excluded transactions don't count toward budgets
+
+**Steps**
+1. Open `/transactions` and exclude one Groceries payment via the detail
+   panel toggle.
+2. Note the displayed amount on the excluded transaction.
+3. Return to `/budgets`.
+
+**Expected**
+- The Groceries row's actual drops by exactly the excluded transaction's
+  GEL amount.
+- Flex bucket-strip card "₾A / ₾B" updates A.
+- Headline Flex remaining grows by the excluded amount.
+- Re-include the same transaction → numbers revert.
+
+---
+
+## T-BUD-13 — Setup wizard renders for fully unclassified accounts
+
+**Setup**
+- In TweaksPanel, switch to "Empty demo" or use a real account with no
+  category bucket assignments.
+
+**Steps**
+1. Navigate to `/budgets`.
+
+**Expected**
+- The wizard "Let's set this up" card renders instead of the bucket
+  sections.
+- Each category row shows three bucket buttons: Fixed / Flex / Non-Monthly.
+- A `~₾N/mo` median spend hint renders next to each row that has prior
+  spending.
+- Click any bucket button on a row → category is classified, row leaves the
+  wizard list. Once all rows are classified, the wizard disappears and the
+  regular page renders.
+
+---
+
+## T-BUD-14 — Sidebar reflects unclassified count
+
+**Steps**
+1. From a fully classified state, move one category to "—" (unclassified)
+   via the bucket dropdown in its row.
+2. Reload `/budgets`.
+
+**Expected**
+- The right-side pill in the page header now reads `1 unclassified`.
+- An **Unclassified** section appears at the bottom listing the category.
+- Reassigning that category to a bucket clears the pill back to `0
+  unclassified` and removes the Unclassified section.
+
+---
+
+## T-BUD-15 — Assistant: get_budget_summary matches page
+
+**Steps**
+1. From `/budgets`, note the current values: flex remaining, fixed actual,
+   non-monthly accruals, savings target.
+2. Open `/assistant` (with API key configured).
+3. Type: `How much flex do I have left this month?` and submit.
+4. Type: `What's my savings target?` and submit.
+
+**Expected**
+- The assistant calls `get_budget_summary`, returns numbers that match
+  step 1 within ±₾1 rounding.
+- The savings target answer matches step 1 exactly.
+- The status text during the tool call reads `Reading your budget…`.
+
+---
+
+## T-BUD-16 — Assistant: chained writes don't duplicate plans
+
+**Codex P2 regression guard from PR #42.**
+
+**Setup**
+- Wipe the budgetPlans table (TweaksPanel "Delete all data") OR use a real
+  account with no plans saved yet.
+
+**Steps**
+1. Open `/assistant`.
+2. Type: `Set my expected income to 8000 and cap flex at 2500 for this
+   month.` and submit.
+3. After the assistant responds, check `/budgets` — verify both values are
+   set.
+4. Use TweaksPanel's data inspector (or check via the InstantDB dashboard
+   for real accounts) to count `budgetPlans` rows for the current month.
+
+**Expected**
+- The assistant calls both `set_expected_income` and `set_flex_pool` in the
+  same turn.
+- After the calls complete, exactly **one** `budgetPlans` row exists for
+  the current month, with both `expectedIncome=8000`,
+  `expectedIncomeAuto=false`, `flexPool=2500`, `flexPoolAuto=false`.
+- Pre-fix bug: two duplicate rows OR a unique-constraint error during the
+  second tool call.
+
+---
+
+## T-BUD-17 — Assistant: bucket reassignment tool
+
+**Steps**
+1. From `/assistant`, type: `Move dining to fixed and give it a 400 budget`
+   and submit.
+
+**Expected**
+- The assistant calls `set_category_bucket` (dining → fixed) followed by
+  `set_category_target` (dining, 400) in the same turn.
+- Reload `/budgets` — Dining now appears in the Fixed section with target
+  ₾400.
+- The Codex P2 fix #1 (memo for chained creates) only covers
+  budgetPlans; chained category writes use upsert-by-id which is
+  naturally idempotent.
+
+---
+
+## T-BUD-18 — Assistant: AI numbers match page after raw-SMS-driven category
+
+**Codex P2 regression guard from PR #42.**
+
+**Steps**
+1. Pick a category that depends on rawMessage matching for some
+   transactions (e.g. Subscriptions — the demo seed uses
+   `apple.com/bill itunes` which only matches via rawMessage).
+2. From `/budgets`, note the Subscriptions actual.
+3. From `/assistant`, type: `What did I spend on Subscriptions this month?`
+   and submit.
+
+**Expected**
+- The assistant's number matches the `/budgets` row exactly.
+- Pre-fix bug: AI used `categorizeName(merchant)` only and ignored
+  rawMessage / per-transaction overrides, so the numbers diverged for
+  raw-SMS-matched payments.
+
+---
+
+## T-BUD-19 — Sinking fund accrues across months
+
+**Steps**
+1. Note the current Non-Monthly section's `+₾<X> sinking fund` value.
+2. Note Travel's per-row carry indicator.
+3. Spend ₾0 on Travel this month (don't add a Travel transaction).
+
+**Expected**
+- The sinking fund header value equals: `(months_since_anchor − 1) ×
+  monthly_accrual − total_actual_since_anchor`. With the demo's two-month
+  plan (previous + current), if Travel had ₾0 actual last month and ₾0
+  this month, the carried value is `1 × 200 − 0 = ₾200` (one prior month
+  of accrual).
+- This is the demo's expected state on a fresh seed — Travel typically
+  has zero actuals because the random walk doesn't always land on travel
+  merchants in the current month.
+
+---
+
+## T-BUD-20 — Page survives the month rollover
+
+**Setup (manual)**
+- Set system clock forward to the 1st of next month, OR seed a future
+  date by manipulating `now` in the demo (advanced).
+
+**Steps**
+1. Reload `/budgets`.
+
+**Expected**
+- planMonth flips to the new month.
+- Current-month actuals reset to 0 (no transactions yet in the new month).
+- The previous month's plan becomes the rollover anchor — Subscriptions
+  (Fixed, rollover ON) and Travel (Non-Monthly) carry their prior surplus
+  forward.
+- Fixed-rollover-OFF rows (Utilities, Loans) start fresh with no carry.
+- The Income card's auto-derived expected income may shift because the
+  3-month rolling window moved forward by one month.

--- a/service/src/instant-schema.ts
+++ b/service/src/instant-schema.ts
@@ -70,11 +70,58 @@ const schema = i.schema({
     // User-defined categories shown on the dashboard. Managed by the
     // client — included here so the schema-backed bootstrap pass in
     // setup/apply.ts can register all namespaces the app uses.
+    //
+    // The four budget-related fields (bucket, targetAmount,
+    // frequencyMonths, rolloverEnabled) are added by the flex-budgeting
+    // feature. All optional + client-managed: the service never sets
+    // them, only persists what the /budgets page writes. Categories
+    // without a bucket are treated as "unclassified" and only appear in
+    // the /budgets setup wizard until the user assigns them.
     categories: i.entity({
       name: i.string(),
       color: i.string(),
       icon: i.string(),
       isDefault: i.boolean(),
+      // "fixed" | "flex" | "non_monthly". Drives which section the
+      // category renders in on /budgets and which formula it
+      // contributes to in computeFlexPool. Optional so existing
+      // pre-feature rows tolerate the schema migration.
+      bucket: i.string().optional(),
+      // GEL. For Fixed categories: monthly target. For Non-Monthly:
+      // total target across `frequencyMonths` (Phase 2 divides it).
+      // Flex categories don't have a target — the bucket-level pool
+      // is the limit. Optional so unclassified rows have no value.
+      targetAmount: i.number().optional(),
+      // Non-Monthly only. Number of months the targetAmount spreads
+      // across (e.g. 12 for an annual sinking fund). Always rolling
+      // for Non-Monthly; this field is meaningless for the other
+      // buckets. Phase 2 wires the accrual math.
+      frequencyMonths: i.number().optional(),
+      // Fixed only. When true, leftover or overshoot from a month
+      // carries to the next month's effective target. Phase 2 wires
+      // the rollover math (always-on for Non-Monthly regardless of
+      // this flag).
+      rolloverEnabled: i.boolean().optional(),
+    }),
+
+    // Per-month flex-budgeting plan. One row per month keyed on
+    // "YYYY-MM" so the user can override expected income or the flex
+    // pool just for one month without losing the auto-derive behavior
+    // in future months. Phase 1 only writes the row when the user
+    // saves changes; later months auto-derive from the formula.
+    budgetPlans: i.entity({
+      planMonth: i.string().unique(),
+      // Both income + pool default to auto-derived numbers. The "Auto"
+      // booleans flip false the moment the user types a manual value,
+      // which freezes that month's number while leaving the auto path
+      // active for other months.
+      expectedIncome: i.number(),
+      expectedIncomeAuto: i.boolean(),
+      flexPool: i.number(),
+      flexPoolAuto: i.boolean(),
+      savingsTarget: i.number().optional(),
+      createdAt: i.number(),
+      updatedAt: i.number(),
     }),
 
     // Configured bank SMS senders, one row per sender the user trusts.


### PR DESCRIPTION
## Summary

First of three stacked PRs implementing Monarch-style flex budgeting. This phase lands the data model + page UI; later phases add rollover (Phase 2) and AI tools (Phase 3).

**Mental model** (mirrors [Monarch's three-bucket flex budgeting](https://help.monarch.com/hc/en-us/articles/32125337244052-Using-Flex-Budgeting)):
- **Fixed** — predictable monthly costs with per-category targets (rent, subscriptions)
- **Flex** — discretionary spending sharing a single pool ceiling (one number)
- **Non-Monthly** — irregular costs spread across N months (annual insurance, holidays)

**Headline math**: `flexPool = expectedIncome − Σ(fixed targets) − Σ(non-monthly accruals) − savingsTarget`. The page surfaces "flex remaining" as the actionable number.

## What this changes

### Schema (additive optional, both `client/src/lib/instant.ts` + `service/src/instant-schema.ts`)
- `categories` gains `bucket`, `targetAmount`, `frequencyMonths`, `rolloverEnabled` — all optional. Existing rows tolerate the migration. `frequencyMonths` and `rolloverEnabled` aren't read in Phase 1 but ship now to avoid a Phase-2 schema migration.
- New `budgetPlans` entity keyed on `planMonth` ("YYYY-MM"), holds `expectedIncome` + `flexPool` + `savingsTarget` for that month, each with an Auto/Manual flag so the user can override one month without losing auto-derive in others.

### New files
- **`client/src/lib/budgets.ts`** — pure utility: `BUCKETS`, `monthlyAccrual`, `computeFlexPool`, `classifyHistorical` (variance-based bucket suggestion for the wizard), `planMonthKey`, `median`.
- **`client/src/hooks/useBudgets.ts`** — `useBudgetPlan`, `useBudgetSummary`, `useExpectedIncomeDefault` (3-month rolling avg of credits, excludes `excludedFromAnalytics`), `useBudgetMutations` (single seam for `db.transact` writes).
- **`client/src/pages/Budgets.tsx`** — headline card + bucket strip + income/savings/flex-pool inputs + per-bucket sections + setup wizard.

### Wiring
- `/budgets` route in `App.tsx`
- Sidebar entry between Categories and Merchants with `NEW` pill badge
- `pages/index.ts` re-export

## Behaviour

- **First visit**: setup wizard renders — pick Fixed / Flex / Non-Monthly per category. Median spend hint per row (`~₾N/mo`) helps calibrate. No required setup; user can return later to classify more.
- **Headline**: "Flex remaining · ₾X" + "₾Y/day for the next N days" pacing. Progress bar shows `flexActual / flexPool`.
- **Bucket strip**: three progress bars (Fixed, Non-Monthly, Flex) with `actual / target` per bucket.
- **Income inputs**: three editable fields. Each shows `auto · <hint>` when auto-derived; clicking edits, blur or Enter commits. A `reset` button next to a manual value snaps back to auto.
- **Per-bucket sections**: each shows category rows with target + spent + a small per-row progress bar; over-target rows get an "over" Pill. Edit target inline. Move to a different bucket via dropdown.
- **Unclassified**: shown as its own section when there are unclassified categories alongside classified ones.

## Out of scope (deferred)

- **Rollover math** (Phase 2): Fixed opt-in, Non-Monthly always-on. The schema fields exist but aren't read.
- **AI tools** (Phase 3): `get_budget_summary`, `set_category_bucket`, etc.
- **Demo-mode seed** (Phase 3): `dev/demoData.ts` doesn't yet seed budgets, so demo mode shows the empty wizard.
- **Per-month category-target overrides**: targets are global per category. Users edit anytime; historical months use the current target.

## Verified locally

- `cd client && bun run build` — clean (TypeScript + Vite). Bundle grew ~5KB gzipped.
- `cd service && bun test` — 193 pass, 0 fail.

## Test plan

- [ ] Open `/budgets` with no categories classified → setup wizard renders.
- [ ] Pick Flex for one category → moves to the Flex section, headline updates.
- [ ] Pick Fixed + set target ₾800 → bucket strip "Fixed" bar fills proportionally to actual.
- [ ] Pick Non-Monthly + target ₾2400 / 12 months → contributes ₾200/mo to the formula.
- [ ] Edit "Expected income" → flex pool recomputes; auto badge flips to "manual" with a reset link.
- [ ] Click reset → field snaps back to auto-derived 3-month avg.
- [ ] Set savings target → flex pool drops by that amount.
- [ ] In a sibling tab, look at `/categories` — categories still display normally; the new fields are invisible there. (Schema change is non-breaking.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Budgets page with setup wizard, per-bucket editors, progress bars, flex-remaining headline, and unclassified category list.
  * Per-month budget plans with auto/manual values, editable numeric inputs, and rollover handling.
  * Category budgeting: targets, bucket assignment (fixed/flex/non-monthly), frequency, rollover toggle, and median-spend hints.
  * Assistant integration for reading and updating budgets.

* **UI Tweaks**
  * Sidebar adds a "Flex Budgeting" entry and removes the "NEW" badge from Assistant.
  * Chart layout fixes on Dashboard and Income for better label alignment.

* **Documentation**
  * End-to-end test plan added for Budgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->