### PR TITLE
Fix category picker: scroll chaining dismiss + space key propagation

### DIFF
--- a/client/src/components/CategoryPicker.tsx
+++ b/client/src/components/CategoryPicker.tsx
@@ -236,6 +236,7 @@ export function CategoryPicker({
               if (error) setError(null);
             }}
             onKeyDown={(e) => {
+              e.stopPropagation();
               if (e.key === "Enter") {
                 e.preventDefault();
                 submitNew();
@@ -337,7 +338,7 @@ export function CategoryPicker({
               <ScopeBtn T={T} label={`All ${merchant.slice(0, 10)}${merchant.length > 10 ? "…" : ""} transactions`} active={scope === "merchant"} onClick={() => setScope("merchant")} />
             </div>
           )}
-          <div style={{ display: "flex", flexDirection: "column", flex: 1, overflowY: "auto", minHeight: 0 }}>
+          <div style={{ display: "flex", flexDirection: "column", flex: 1, overflowY: "auto", minHeight: 0, overscrollBehavior: "contain" }}>
             {allCategories.map((cat) => (
               <CategoryRow
                 key={cat.id}


### PR DESCRIPTION
## Summary                                                                                                                                                    
  - Scrolling the category list to its top/bottom boundary chained to the                                                                                     
    page scroll, triggering the scroll-dismiss logic and closing the picker.
    Fixed with `overscrollBehavior: contain` on the inner list div.                                                                                             
  - Typing a space in the "New category" input bubbled up to the transaction
    row's keydown handler, selecting the row and opening transaction details.                                                                                   
    Fixed with `e.stopPropagation()` in the input's onKeyDown.                                                                                                  
                                                                                                                                                                
  ## Test plan                                                                                                                                                  
  - [ ] Open category picker with many categories — scroll to bottom, keep                                                                                    
        scrolling — picker stays open, page does not scroll                                                                                                     
  - [ ] Click "+ New category…", type a name with spaces — transaction row                                                                                      
        does not select or open details                                                                                                                         
  - [ ] Escape still closes the picker / exits create mode as expected 