### PR TITLE
Add pay-cycle date filter (25-to-25 salary period)

### DIFF
--- a/client/src/hooks/useRangeState.ts
+++ b/client/src/hooks/useRangeState.ts
@@ -12,6 +12,12 @@ export interface RangeStateProps {
   customStart: string;
   customEnd: string;
   onCustomChange: (start: string, end: string) => void;
+  cycleDay: number;
+  cycleOffset: number;
+  cycleLabel: string;
+  onCycleDayChange: (day: number) => void;
+  onCyclePrev: () => void;
+  onCycleNext: () => void;
 }
 
 export interface UseRangeStateResult {
@@ -26,6 +32,11 @@ export interface UseRangeStateOptions {
   customInitial?: { start: string; end: string };
 }
 
+function loadCycleDay(): number {
+  const stored = parseInt(localStorage.getItem("xarji-cycle-day") ?? "25", 10);
+  return Number.isNaN(stored) ? 25 : Math.max(1, Math.min(31, stored));
+}
+
 export function useRangeState(
   initial: RangeKey = "Month",
   options?: UseRangeStateOptions
@@ -35,30 +46,41 @@ export function useRangeState(
   const [active, setActive] = useState<RangeKey>(useCustom ? "Custom" : initial);
   const [customStart, setCustomStart] = useState(useCustom ? customInitial!.start : "");
   const [customEnd, setCustomEnd] = useState(useCustom ? customInitial!.end : "");
-  // `clockTick` advances at the next local-midnight boundary so a
-  // long-lived dashboard tab doesn't keep showing yesterday's "Today"
-  // (or the previous month's "Month") after the calendar rolls over.
-  // Including it in the memo deps below recomputes the range without
-  // wedging it on a stale `new Date()` from the initial render.
+  const [cycleDay, setCycleDay] = useState<number>(loadCycleDay);
+  const [cycleOffset, setCycleOffset] = useState(0);
   const clockTick = useMidnightTick();
 
   const range = useMemo(
-    () => rangeFromKey(active, new Date(), { start: customStart, end: customEnd }),
+    () => rangeFromKey(active, new Date(), { start: customStart, end: customEnd, cycleDay, cycleOffset }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [active, customStart, customEnd, clockTick]
+    [active, customStart, customEnd, cycleDay, cycleOffset, clockTick]
   );
 
   return {
     range,
     props: {
       active,
-      onRange: (k) => setActive(k as RangeKey),
+      onRange: (k) => {
+        if (k === "Cycle") setCycleOffset(0);
+        setActive(k as RangeKey);
+      },
       customStart,
       customEnd,
       onCustomChange: (start, end) => {
         setCustomStart(start);
         setCustomEnd(end);
       },
+      cycleDay,
+      cycleOffset,
+      cycleLabel: range.key === "Cycle" ? range.label : "",
+      onCycleDayChange: (day) => {
+        const clamped = Math.max(1, Math.min(31, day));
+        setCycleDay(clamped);
+        localStorage.setItem("xarji-cycle-day", String(clamped));
+        setCycleOffset(0);
+      },
+      onCyclePrev: () => setCycleOffset((o) => o - 1),
+      onCycleNext: () => setCycleOffset((o) => o + 1),
     },
   };
 }

--- a/client/src/ink/primitives.tsx
+++ b/client/src/ink/primitives.tsx
@@ -171,12 +171,17 @@ export function PageHeader({
   eyebrow,
   title,
   rightSlot,
-  ranges = ["Today", "Week", "Month", "Year", "Custom"],
+  ranges = ["Today", "Week", "Month", "Year", "Custom", "Cycle"],
   active = "Month",
   onRange,
   customStart,
   customEnd,
   onCustomChange,
+  cycleDay,
+  cycleLabel,
+  onCycleDayChange,
+  onCyclePrev,
+  onCycleNext,
 }: {
   eyebrow?: React.ReactNode;
   title: React.ReactNode;
@@ -189,9 +194,38 @@ export function PageHeader({
   customEnd?: string;
   /** Fired whenever either custom date input changes. */
   onCustomChange?: (start: string, end: string) => void;
+  /** 1–31; the cycle-start day of month, only used when active === "Cycle". */
+  cycleDay?: number;
+  /** Formatted label for the active cycle, e.g. "Apr 25 – May 24, 2026". */
+  cycleLabel?: string;
+  onCycleDayChange?: (day: number) => void;
+  onCyclePrev?: () => void;
+  onCycleNext?: () => void;
 }) {
   const T = useTheme();
   const showCustomInputs = ranges && ranges.includes("Custom") && active === "Custom" && onCustomChange;
+  const showCycleControls = active === "Cycle" && onCyclePrev;
+
+  const pillStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    padding: "4px 8px",
+    background: T.panel,
+    borderRadius: 12,
+    border: `1px solid ${T.line}`,
+  };
+  const navBtnStyle: React.CSSProperties = {
+    background: "transparent",
+    border: "none",
+    cursor: "pointer",
+    color: T.muted,
+    fontSize: 14,
+    padding: "2px 6px",
+    borderRadius: 6,
+    lineHeight: 1,
+    fontFamily: T.mono,
+  };
 
   return (
     <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 20, marginBottom: 6, flexWrap: "wrap" }}>
@@ -204,17 +238,7 @@ export function PageHeader({
       <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
         {rightSlot}
         {showCustomInputs && (
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 6,
-              padding: "4px 8px",
-              background: T.panel,
-              borderRadius: 12,
-              border: `1px solid ${T.line}`,
-            }}
-          >
+          <div style={pillStyle}>
             <input
               type="date"
               value={customStart ?? ""}
@@ -247,6 +271,41 @@ export function PageHeader({
               }}
             />
           </div>
+        )}
+        {showCycleControls && (
+          <>
+            <div style={pillStyle}>
+              <button type="button" style={navBtnStyle} onClick={onCyclePrev} title="Previous cycle">←</button>
+              <span style={{ fontSize: 12, fontFamily: T.mono, color: T.text, whiteSpace: "nowrap", padding: "0 2px" }}>
+                {cycleLabel}
+              </span>
+              <button type="button" style={navBtnStyle} onClick={onCycleNext} title="Next cycle">→</button>
+            </div>
+            <div style={{ ...pillStyle, gap: 4 }}>
+              <span style={{ fontSize: 11, color: T.muted, fontFamily: T.sans, whiteSpace: "nowrap" }}>Day</span>
+              <input
+                type="number"
+                min={1}
+                max={31}
+                value={cycleDay ?? 25}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value, 10);
+                  if (!Number.isNaN(v)) onCycleDayChange?.(v);
+                }}
+                style={{
+                  width: 38,
+                  background: "transparent",
+                  border: "none",
+                  color: T.text,
+                  fontSize: 12,
+                  fontFamily: T.mono,
+                  padding: "4px 4px",
+                  outline: "none",
+                  textAlign: "center",
+                }}
+              />
+            </div>
+          </>
         )}
         {ranges && (
           <div style={{ display: "flex", background: T.panel, borderRadius: 12, padding: 3, border: `1px solid ${T.line}` }}>

--- a/client/src/lib/dateRange.ts
+++ b/client/src/lib/dateRange.ts
@@ -20,9 +20,9 @@ import {
   format,
 } from "date-fns";
 
-export type RangeKey = "Today" | "Week" | "Month" | "Year" | "Custom";
+export type RangeKey = "Today" | "Week" | "Month" | "Year" | "Custom" | "Cycle";
 
-export const RANGE_OPTIONS: RangeKey[] = ["Today", "Week", "Month", "Year", "Custom"];
+export const RANGE_OPTIONS: RangeKey[] = ["Today", "Week", "Month", "Year", "Custom", "Cycle"];
 
 export interface DateRange {
   /** Inclusive start, local time. */
@@ -39,6 +39,27 @@ export interface DateRange {
 export interface CustomRange {
   start: string; // YYYY-MM-DD
   end: string;
+  cycleDay?: number;   // 1–31; which day of the month each cycle starts
+  cycleOffset?: number; // 0 = current cycle, -1 = previous, +1 = next
+}
+
+/** Compute a pay-cycle DateRange for a given cycle-start day and offset.
+ *  offset=0 → the cycle whose start day most recently passed (current);
+ *  offset=-1 → the one before that; offset=+1 → the upcoming one. */
+export function rangeFromCycle(cycleDay: number, offset: number, now: Date): DateRange {
+  const day = Math.max(1, Math.min(31, Math.round(cycleDay)));
+  // Determine the base month: the most recent month where day ≤ today.
+  const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), day);
+  const baseMonth = thisMonthStart > now ? now.getMonth() - 1 : now.getMonth();
+  // JS Date constructor handles month underflow/overflow automatically.
+  const startDate = new Date(now.getFullYear(), baseMonth + offset, day);
+  const endDate = endOfDay(new Date(startDate.getFullYear(), startDate.getMonth() + 1, day - 1));
+  return {
+    start: startOfDay(startDate),
+    end: endDate,
+    label: `${format(startDate, "MMM d")} – ${format(endDate, "MMM d, yyyy")}`,
+    key: "Cycle",
+  };
 }
 
 /** Build a DateRange from the active button + optional custom dates.
@@ -69,6 +90,8 @@ export function rangeFromKey(key: RangeKey, now: Date, custom?: CustomRange): Da
       const end = endOfYear(now);
       return { start, end, label: format(start, "yyyy"), key };
     }
+    case "Cycle":
+      return rangeFromCycle(custom?.cycleDay ?? 25, custom?.cycleOffset ?? 0, now);
     case "Custom": {
       if (isValidIsoDateRange(custom)) {
         // <input type="date"> emits YYYY-MM-DD which `new Date(...)`
@@ -147,6 +170,8 @@ export function previousRange(range: DateRange): DateRange {
       return { start: startOfMonth(prevStart), end: endOfMonth(prevStart), label: format(prevStart, "MMMM yyyy"), key: "Month" };
     case "Year":
       return { start: startOfYear(prevStart), end: endOfYear(prevStart), label: format(prevStart, "yyyy"), key: "Year" };
+    case "Cycle":
+      return { start: prevStart, end: prevEnd, label: `${format(prevStart, "MMM d")} – ${format(prevEnd, "MMM d, yyyy")}`, key: "Cycle" };
     case "Custom":
     default:
       return { start: prevStart, end: prevEnd, label: `${format(prevStart, "MMM d")} – ${format(prevEnd, "MMM d, yyyy")}`, key: "Custom" };

--- a/docs/e2e/dashboard.md
+++ b/docs/e2e/dashboard.md
@@ -29,7 +29,7 @@ These numbers are deterministic for a given calendar day; reseeded as the day ro
 **Expected**
 - Eyebrow: `Good morning|afternoon|evening` (depending on local hour).
 - Title: `<current month name> <year>, at a glance` (e.g. `April 2026, at a glance`).
-- Range buttons visible top-right: **Today / Week / Month / Year / Custom** with **Month** highlighted.
+- Range buttons visible top-right: **Today / Week / Month / Year / Custom / Cycle** with **Month** highlighted.
 - Sidebar shows ~1,000+ transactions counter (proves demo mode is active).
 - Hero "You spent" figure ≥ ₾10,000 (current-month payments + IKEA outlier + recurring subs).
 - Subline: `±₾<delta> more|less than <prev month name> · <N> days · <count> transactions` where `<N>` ≤ days elapsed in the month and `<count>` ≥ 100 on demo data.
@@ -46,16 +46,18 @@ These numbers are deterministic for a given calendar day; reseeded as the day ro
 2. Click **Year**.
 3. Click **Custom**, then set `From` and `To` date inputs to a known window (e.g. last 30 days).
 4. Click **Today**.
-5. Click **Month** to return.
+5. Click **Cycle** — leave the default day (25). Use ← → to navigate one cycle back and one cycle forward.
+6. Click **Month** to return.
 
 **Expected (each step)**
-- Eyebrow on the hero card updates: e.g. Week → "OUTGOING · <Mon-Sun range>", Year → "OUTGOING · <year>", Custom → "OUTGOING · <Mmm d – Mmm d>", Today → "OUTGOING · <full date>".
+- Eyebrow on the hero card updates: e.g. Week → "OUTGOING · <Mon-Sun range>", Year → "OUTGOING · <year>", Custom → "OUTGOING · <Mmm d – Mmm d>", Today → "OUTGOING · <full date>", Cycle → "OUTGOING · <Mmm d – Mmm d, yyyy>".
 - Page title updates: "<range.label>, at a glance" — e.g. "2026, at a glance" for Year, "April 1 – April 27, 2026, at a glance" for Custom.
 - "You spent" figure recomputes; Year ≥ Month, Today usually small, Week ≤ Month.
 - Subline `<N> days · <count> transactions` matches the active range length capped at days elapsed (Today = 1, Week ≤ 7, Year up to 117 in late April).
 - Donut center label matches the range (e.g. Year → `<year>`, Month → uppercase month name, Today → date label).
 - Top merchants title reads "Top merchants · <range.label>".
 - Custom button: when active, two `<input type="date">` controls render inline in the header.
+- Cycle button: when active, a `← [Mmm d – Mmm d, yyyy] →` navigation pill and a `Day [N]` input appear inline; ← shifts to the prior cycle, → shifts forward.
 
 ---
 

--- a/docs/e2e/income.md
+++ b/docs/e2e/income.md
@@ -22,7 +22,7 @@ Open `http://localhost:5173/income`. Default range: **Month**.
 **Expected**
 - Eyebrow: "Money in · <range.label>".
 - Title: "Income".
-- Range buttons visible top-right with **Month** highlighted.
+- Range buttons visible top-right (**Today / Week / Month / Year / Custom / Cycle**) with **Month** highlighted.
 - Hero card shows `+₾<total>` for incoming GEL credits in the active range, plus a `<count> incoming transactions · <month>` subline.
 - 9-month income trend AreaChart below the hero (when `T.chartsVisible` and at least one month had income).
 
@@ -31,7 +31,7 @@ Open `http://localhost:5173/income`. Default range: **Month**.
 ## T-INC-02 — Range buttons re-scope hero + ledger
 
 **Steps**
-1. Click **Today / Week / Year / Custom**.
+1. Click **Today / Week / Year / Custom / Cycle** in turn.
 
 **Expected**
 - Hero `+₾<total>` and incoming-transaction count update.

--- a/docs/e2e/ranges.md
+++ b/docs/e2e/ranges.md
@@ -110,8 +110,10 @@ This pins `rangeToDateParams` and the threading through every drill-down call si
 2. Switch to **Week** → same.
 3. Switch to **Month** → same.
 4. Switch to **Year** → same.
+5. Switch to **Cycle** → same.
 
 **Expected**
 - Each pill compares against the equivalent prior period (yesterday, last
-  week, last month, last year). The label format on the pill matches the
+  week, last month, last year, previous cycle). The label format on the pill matches the
   source range shape.
+- Cycle: prior period is the previous ~30-day cycle window (e.g. if active is Apr 25–May 24, prev is Mar 25–Apr 24).

--- a/docs/e2e/transactions.md
+++ b/docs/e2e/transactions.md
@@ -25,7 +25,7 @@ sidebar). Default range: **Month**.
 **Expected**
 - Eyebrow: "All transactions · read-only from SMS".
 - Title: "Transactions".
-- Range buttons visible top-right with **Month** highlighted.
+- Range buttons visible top-right (**Today / Week / Month / Year / Custom / Cycle**) with **Month** highlighted.
 - "<N> results" pill in the top-right reflects the visible filtered count.
 - Filter row: search box, kind pills (All / Successful / Declined), bank dropdown, category dropdown.
 - Day-grouped list newest-first, each day group has its date label + transaction count + GEL day-total.
@@ -35,13 +35,15 @@ sidebar). Default range: **Month**.
 ## T-TX-02 — Range buttons re-scope the ledger
 
 **Steps**
-1. From Month, click **Today / Week / Year / Custom** in turn.
+1. From Month, click **Today / Week / Year / Custom / Cycle** in turn.
 2. With Custom, set `From`/`To` and verify the list updates.
+3. With Cycle, use ← → to navigate one cycle back; verify the day-group dates match the cycle window shown in the nav pill.
 
 **Expected**
 - "<N> results" updates to reflect the active range.
 - Day groups visible all fall within the active range.
-- Custom date inputs in the header show the picked window.
+- Custom: date inputs appear inline in the header.
+- Cycle: `← [Mmm d – Mmm d, yyyy] →` nav pill and `Day [N]` input appear; transactions outside the cycle window are absent.
 
 ---
 


### PR DESCRIPTION

  - Adds a Cycle range filter alongside Today / Week / Month / Year / Custom
  - User sets their salary cycle start day (e.g. 25) — the filter computes the exact 25→24 window for any month, not a calendar month
  - ← → arrows navigate between past and future cycles; the chosen day persists across refreshes via localStorage['xarji-cycle-day']

  How it works

  rangeFromCycle(cycleDay, offset, now) finds the most recent month where day ≤ today (offset=0), then shifts by offset months. End is always day - 1 of the next month — so day=25 gives Apr 25–May 24,
   day=1 gives a full calendar month. JS Date overflow handles short months naturally.

  No changes needed in any page component — all pages already spread {...rangeProps} into PageHeader, so the Cycle tab and its controls appear everywhere automatically.

  Files changed

  - client/src/lib/dateRange.ts — new "Cycle" RangeKey + rangeFromCycle()
  - client/src/hooks/useRangeState.ts — cycle day/offset state + localStorage persistence
  - client/src/ink/primitives.tsx — cycle navigation pill + day input in PageHeader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Cycle" date range mode for viewing data based on custom pay cycle windows.
  * Users can navigate between cycle periods using previous/next controls.
  * Added ability to set the day of month for cycle calculations with persistent storage across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->