### PR TITLE
Detect TBC inline refunds + add permanent delete with tombstones

### DIFF
--- a/client/src/hooks/useTransactions.ts
+++ b/client/src/hooks/useTransactions.ts
@@ -3,6 +3,7 @@ import { db, type Payment } from "../lib/instant";
 import { groupBy, getDateGroup } from "../lib/utils";
 import { formatLocalDay } from "../ink/format";
 import { useGelConverter } from "../lib/exchangeRates";
+import { isDemoMode } from "../dev/demoMode";
 import { startOfMonth, endOfMonth, subMonths, isWithinInterval } from "date-fns";
 
 export function usePayments() {
@@ -48,6 +49,56 @@ export function useTransactionExclude() {
       await db.transact(db.tx.payments[id].update({ excludedFromAnalytics: excluded }));
     } else {
       await db.transact(db.tx.credits[id].update({ excludedFromAnalytics: excluded }));
+    }
+  };
+}
+
+/**
+ * Permanently delete a transaction. Goes through the bun service's
+ * /api/transactions/delete endpoint so the service can record a
+ * tombstone in ~/.xarji/state.db — without that, the next SMS sync
+ * would re-import the row because dedup is keyed on the SMS-derived
+ * transactionId which would then be missing from InstantDB.
+ *
+ * Demo mode skips the service round-trip and writes directly to the
+ * in-memory demo store; demo data resets on reload anyway.
+ *
+ * If the service rejects (5xx, network error), falls back to a
+ * client-only delete so the user-visible action still happens — but
+ * logs a warning since the SMS will re-import on next sync.
+ */
+export function useTransactionDelete() {
+  return async (
+    kind: "payment" | "credit",
+    instantId: string,
+    transactionId: string
+  ): Promise<void> => {
+    if (isDemoMode()) {
+      const collection = kind === "payment" ? db.tx.payments : db.tx.credits;
+      await db.transact(collection[instantId].delete());
+      return;
+    }
+    try {
+      const res = await fetch("/api/transactions/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transactionId, instantId, kind }),
+      });
+      if (!res.ok) {
+        console.warn(
+          "[delete] service rejected, falling back to client-only delete",
+          res.status
+        );
+        const collection = kind === "payment" ? db.tx.payments : db.tx.credits;
+        await db.transact(collection[instantId].delete());
+      }
+    } catch (err) {
+      console.warn(
+        "[delete] service unreachable, falling back to client-only delete",
+        err
+      );
+      const collection = kind === "payment" ? db.tx.payments : db.tx.credits;
+      await db.transact(collection[instantId].delete());
     }
   };
 }

--- a/client/src/ink/TxRow.tsx
+++ b/client/src/ink/TxRow.tsx
@@ -7,6 +7,13 @@ import { formatTime, currencySymbol } from "./format";
 
 export interface InkTx {
   id: string;
+  /** SMS-derived stable id (e.g. `tbc-2026-05-05-...`). Distinct from
+   *  `id` which is the InstantDB row id. The delete flow sends both
+   *  to the service: `id` for the InstantDB delete, `transactionId`
+   *  for the state.db tombstone that prevents re-import on next sync.
+   *  Optional because failed-payment rows are read-only (no delete
+   *  surface today). */
+  transactionId?: string;
   kind: "payment" | "failed" | "credit";
   merchant: string;
   rawMerchant?: string;

--- a/client/src/pages/Income.tsx
+++ b/client/src/pages/Income.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from "react";
-import { useTheme, useViewport } from "../ink/theme";
+import { useTheme, useViewport, type InkTheme } from "../ink/theme";
 import { Card, CardLabel, CardTitle, Pill, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { useConvertedCredits, useRangeCredits } from "../hooks/useCredits";
+import { useTransactionDelete, useTransactionExclude } from "../hooks/useTransactions";
 import { useBankSenders } from "../hooks/useBankSenders";
 import { useRangeState } from "../hooks/useRangeState";
 import { AreaChart } from "../ink/charts";
@@ -13,6 +14,8 @@ import { format, subMonths } from "date-fns";
 export function Income() {
   const T = useTheme();
   const vp = useViewport();
+  const setExcluded = useTransactionExclude();
+  const deleteTx = useTransactionDelete();
   const now = new Date();
   const { range, props: rangeProps } = useRangeState("Month");
   const { credits } = useConvertedCredits();
@@ -48,6 +51,7 @@ export function Income() {
   const allTx: InkTx[] = useMemo(() => {
     return credits.map((c) => ({
       id: c.id,
+      transactionId: c.transactionId,
       kind: "credit" as const,
       merchant: c.counterparty || "Income",
       rawMerchant: c.rawMessage,
@@ -417,6 +421,36 @@ export function Income() {
                   <span style={{ fontSize: 12.5, color: T.text, fontFamily: T.sans, fontWeight: 600 }}>{v}</span>
                 </div>
               ))}
+              <ExcludeToggleRow
+                T={T}
+                excluded={!!selected.excludedFromAnalytics}
+                onToggle={async (next) => {
+                  await setExcluded("credit", selected.id, next);
+                }}
+              />
+              {selected.transactionId && (
+                <DeleteRow
+                  T={T}
+                  onDelete={async () => {
+                    const dateStr = new Date(selected.transactionDate).toLocaleString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    });
+                    const amountStr = `${currencySymbol(selected.currency)}${(selected.amount ?? 0).toFixed(2)}`;
+                    const counterparty = selected.counterparty || selected.merchant || "Income";
+                    if (
+                      !window.confirm(
+                        `Delete this credit?\n\n${counterparty} · +${amountStr} · ${dateStr}\n\nIt will be removed from InstantDB and tombstoned so the next SMS sync won't re-import it. This cannot be undone.`
+                      )
+                    ) {
+                      return;
+                    }
+                    await deleteTx("credit", selected.id, selected.transactionId!);
+                    setSelectedId(null);
+                  }}
+                />
+              )}
             </div>
             <div style={{ marginTop: 18 }}>
               <CardLabel>Raw SMS</CardLabel>
@@ -441,6 +475,98 @@ export function Income() {
           </Card>
         )}
       </div>
+    </div>
+  );
+}
+
+// Same shape as the helpers on Transactions.tsx — duplicated rather
+// than promoted to a shared module because both pages compose them
+// inline against page-local state and the prop surface is small.
+
+function ExcludeToggleRow({
+  T,
+  excluded,
+  onToggle,
+}: {
+  T: InkTheme;
+  excluded: boolean;
+  onToggle: (next: boolean) => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const handle = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onToggle(!excluded);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 0", borderBottom: `1px solid ${T.line}` }}>
+      <span style={{ fontSize: 12, color: T.muted, fontFamily: T.sans }}>In analytics</span>
+      <button
+        type="button"
+        onClick={handle}
+        disabled={busy}
+        title={excluded ? "Include this credit in income totals" : "Exclude this credit from income totals"}
+        style={{
+          padding: "4px 10px",
+          borderRadius: 999,
+          border: `1px solid ${T.line}`,
+          background: excluded ? T.panelAlt : "transparent",
+          color: excluded ? T.dim : T.text,
+          fontSize: 11.5,
+          fontWeight: 600,
+          fontFamily: T.sans,
+          cursor: busy ? "not-allowed" : "pointer",
+        }}
+      >
+        {excluded ? "Excluded · re-include" : "Included · exclude"}
+      </button>
+    </div>
+  );
+}
+
+function DeleteRow({
+  T,
+  onDelete,
+}: {
+  T: InkTheme;
+  onDelete: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const handle = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onDelete();
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 0", borderBottom: `1px solid ${T.line}` }}>
+      <span style={{ fontSize: 12, color: T.muted, fontFamily: T.sans }}>Permanent</span>
+      <button
+        type="button"
+        onClick={handle}
+        disabled={busy}
+        title="Remove this credit from InstantDB and tombstone it so SMS resyncs don't re-import it"
+        style={{
+          padding: "4px 10px",
+          borderRadius: 999,
+          border: `1px solid ${T.accent}55`,
+          background: "transparent",
+          color: T.accent,
+          fontSize: 11.5,
+          fontWeight: 600,
+          fontFamily: T.sans,
+          cursor: busy ? "not-allowed" : "pointer",
+        }}
+      >
+        {busy ? "Deleting…" : "Delete"}
+      </button>
     </div>
   );
 }

--- a/client/src/pages/Transactions.tsx
+++ b/client/src/pages/Transactions.tsx
@@ -4,7 +4,7 @@ import { useTheme, useViewport, type InkTheme } from "../ink/theme";
 import { Card, CardLabel, PageHeader } from "../ink/primitives";
 import { TxRow, type InkTx } from "../ink/TxRow";
 import { CategoryPicker } from "../components/CategoryPicker";
-import { useConvertedPayments, useFailedPayments, useTransactionExclude } from "../hooks/useTransactions";
+import { useConvertedPayments, useFailedPayments, useTransactionDelete, useTransactionExclude } from "../hooks/useTransactions";
 import { useBankSenders } from "../hooks/useBankSenders";
 import { useRangeState } from "../hooks/useRangeState";
 import { isInRange, isValidIsoDateRange } from "../lib/dateRange";
@@ -19,6 +19,7 @@ export function Transactions() {
   const { payments } = useConvertedPayments();
   const { failedPayments } = useFailedPayments();
   const setExcluded = useTransactionExclude();
+  const deleteTx = useTransactionDelete();
   const { senders } = useBankSenders();
   const { categorize: categorizeId, allCategories } = useCategorizer();
   // Drill-down search params accepted on first paint. Anything that doesn't
@@ -55,6 +56,7 @@ export function Transactions() {
     const combined: InkTx[] = [
       ...payments.map((p) => ({
         id: p.id,
+        transactionId: p.transactionId,
         kind: "payment" as const,
         merchant: p.merchant || "",
         rawMerchant: p.rawMessage,
@@ -70,6 +72,7 @@ export function Transactions() {
       })),
       ...failedPayments.map((f) => ({
         id: f.id,
+        transactionId: f.transactionId,
         kind: "failed" as const,
         merchant: f.merchant || "",
         rawMerchant: f.rawMessage,
@@ -400,6 +403,35 @@ export function Transactions() {
                   }}
                 />
               )}
+              {selected.kind !== "failed" && selected.transactionId && (
+                <DeleteRow
+                  T={T}
+                  onDelete={async () => {
+                    const dateStr = new Date(selected.transactionDate).toLocaleString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    });
+                    const amountStr = selected.amount != null
+                      ? `${currencySymbol(selected.currency)}${selected.amount.toFixed(2)}`
+                      : "—";
+                    const merchant = selected.merchant || selected.counterparty || "Unknown";
+                    if (
+                      !window.confirm(
+                        `Delete this transaction?\n\n${merchant} · ${amountStr} · ${dateStr}\n\nIt will be removed from InstantDB and tombstoned so the next SMS sync won't re-import it. This cannot be undone.`
+                      )
+                    ) {
+                      return;
+                    }
+                    await deleteTx(
+                      selected.kind === "credit" ? "credit" : "payment",
+                      selected.id,
+                      selected.transactionId!
+                    );
+                    setSelectedId(null);
+                  }}
+                />
+              )}
             </div>
             <div style={{ marginTop: 18 }}>
               <CardLabel>Raw SMS</CardLabel>
@@ -484,6 +516,64 @@ function ExcludeToggleRow({
         }}
       >
         {excluded ? "Excluded · re-include" : "Included · exclude"}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Permanent-delete affordance in the detail panel. Sits below the
+ * Exclude toggle and rendered in destructive accent so the user can't
+ * confuse it with the soft-toggle. Goes through useTransactionDelete
+ * which calls the bun service so the tombstone is recorded — without
+ * that, the next SMS sync would re-import the row.
+ */
+function DeleteRow({
+  T,
+  onDelete,
+}: {
+  T: InkTheme;
+  onDelete: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const handle = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onDelete();
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        padding: "8px 0",
+        borderBottom: `1px solid ${T.line}`,
+      }}
+    >
+      <span style={{ fontSize: 12, color: T.muted, fontFamily: T.sans }}>Permanent</span>
+      <button
+        type="button"
+        onClick={handle}
+        disabled={busy}
+        title="Remove this transaction from InstantDB and tombstone it so SMS resyncs don't re-import it"
+        style={{
+          padding: "4px 10px",
+          borderRadius: 999,
+          border: `1px solid ${T.accent}55`,
+          background: "transparent",
+          color: T.accent,
+          fontSize: 11.5,
+          fontWeight: 600,
+          fontFamily: T.sans,
+          cursor: busy ? "not-allowed" : "pointer",
+        }}
+      >
+        {busy ? "Deleting…" : "Delete"}
       </button>
     </div>
   );

--- a/docs/e2e/income.md
+++ b/docs/e2e/income.md
@@ -87,3 +87,52 @@ This pins the Codex HIGH fix from PR #16 (`0e8803a`).
 **Expected**
 - Tooltip shows bucket label + `₾<value>` + (if prior bucket exists) `vs <prev label> ₾<prev value> ±X%`.
 - Same theme rules as Dashboard trend tooltip.
+
+---
+
+## T-INC-07 — Detail panel exclude toggle (added in tombstone-delete PR)
+
+**Steps**
+1. Click any credit row to open the detail panel.
+2. Find the `In analytics` row near the bottom; the button reads `Included · exclude`.
+3. Click it.
+
+**Expected**
+- Button flips to `Excluded · re-include` with dimmed background.
+- The credit no longer counts toward the hero `+₾<total>` or the 9-month trend.
+- The row stays visible in the ledger but renders the "Excluded" pill (same as transactions).
+- Click `Excluded · re-include` to restore — totals come back.
+
+---
+
+## T-INC-08 — Detail panel delete confirm dialog
+
+**Steps**
+1. Open detail panel, find the `Permanent` row, click `Delete`.
+
+**Expected**
+- `window.confirm` shows: counterparty + `+<currency><amount>` + date + the tombstone warning.
+
+---
+
+## T-INC-09 — Delete accept removes credit + closes panel
+
+**Steps**
+1. Open detail panel, click `Delete`, click `OK`.
+
+**Expected**
+- Detail panel closes.
+- The credit vanishes from the ledger.
+- Hero `+₾<total>` recomputes lower by exactly the deleted credit's GEL-equivalent.
+- After page reload, the credit is still gone.
+
+---
+
+## T-INC-10 — Deleted credit stays gone after service sync (real data)
+
+**Steps**
+1. Delete a real-data credit via T-INC-09.
+2. Open `/manage`, click `Sync now`.
+
+**Expected**
+- The credit does NOT reappear after sync completes — same tombstone path as T-TX-17.

--- a/docs/e2e/transactions.md
+++ b/docs/e2e/transactions.md
@@ -174,3 +174,77 @@ This pins the Codex MEDIUM fix from PR #23 (`fdfffee`).
 **Expected**
 - Day total in the right of the day-group header sums only the `kind === "payment"` rows that have a `gelAmount` resolved.
 - If a day has only declines, the right side shows `—`, not `−₾0`.
+
+---
+
+## T-TX-13 — Delete transaction confirm dialog
+
+**Steps**
+1. Click any payment row to open the detail panel.
+2. Scroll to the bottom of the detail card; find the `Permanent` row with a `Delete` button (coral outline).
+3. Click `Delete`.
+4. The browser's `window.confirm` dialog appears.
+
+**Expected**
+- The dialog text includes the merchant name, the formatted amount with currency symbol, and the date.
+- The dialog warns "It will be removed from InstantDB and tombstoned so the next SMS sync won't re-import it. This cannot be undone."
+
+---
+
+## T-TX-14 — Delete cancel keeps the row
+
+**Steps**
+1. Open detail panel, click `Delete`, then click `Cancel` in the confirm dialog.
+
+**Expected**
+- The row stays in the ledger.
+- The detail panel stays open with the same row selected.
+- No request to `/api/transactions/delete` should fire (check Network tab).
+
+---
+
+## T-TX-15 — Delete accept removes row + closes panel
+
+**Steps**
+1. Open detail panel, click `Delete`, click `OK` in the confirm dialog.
+
+**Expected**
+- The detail panel closes (`selectedId` resets).
+- The row vanishes from the ledger immediately.
+- The day-group total recomputes without that row's contribution.
+- A `POST /api/transactions/delete` request fires (in real-data mode; demo mode goes straight to the in-memory store).
+
+---
+
+## T-TX-16 — Deleted row stays gone after page reload
+
+**Steps**
+1. Delete a row via T-TX-15.
+2. Hit browser refresh.
+
+**Expected**
+- The row does NOT reappear.
+- This proves the InstantDB delete persisted.
+
+---
+
+## T-TX-17 — Deleted row stays gone after service sync (real data only)
+
+**Steps**
+1. Delete a real-data payment via T-TX-15.
+2. Open `/manage`, click `Sync now`.
+
+**Expected**
+- The row does NOT reappear after sync completes.
+- This proves the state.db tombstone is being honored — without the tombstone, the dedup logic (keyed on transactionId) would re-import the row because its transactionId is no longer in InstantDB.
+
+---
+
+## T-TX-18 — Failed-payment rows do not show a Delete button
+
+**Steps**
+1. Filter to `Kind: failed` and click a failed payment.
+
+**Expected**
+- The detail panel renders without a `Permanent` row / `Delete` button.
+- Failed payments don't carry a `transactionId` field consumers would need for the tombstone, and a re-imported failed-payment SMS would still be useful diagnostic info anyway.

--- a/service/src/__tests__/instant-sync.test.ts
+++ b/service/src/__tests__/instant-sync.test.ts
@@ -209,6 +209,42 @@ describe("StateDb tombstones", () => {
     expect(skipped).toBe(1);
   });
 
+  test("partial-failure retry: warm syncedIds cache must catch the second pass even when tombstones exist", () => {
+    // Codex P2 on PR #46. processNewMessages intentionally retries the
+    // same SMS batch when a non-InstantDB target (webhook/local) fails,
+    // without marking the message as processed in state.db. The
+    // InstantDB-side dedup must still skip the already-written row on
+    // that retry — otherwise a duplicate InstantDB row gets inserted.
+    //
+    // The bug being guarded: when tombstones exist, the dedup-check Set
+    // is a temporary union of syncedIds + tombstones. If
+    // syncTransactions only added the just-written id to that temporary
+    // Set (instead of the persistent syncedIds), the next call would
+    // rebuild the union from a stale syncedIds and re-import the row.
+    //
+    // This test simulates the production sequence directly without
+    // standing up InstantDB: build the union, mark a row "written" by
+    // adding to the persistent set, then check that the next sync's
+    // freshly-built union still treats the row as already-synced.
+    db.markTransactionDeleted("tomb-1", "payment");
+    const syncedIds = new Set<string>(); // simulates module-level cache
+    const buildUnion = () =>
+      new Set([...syncedIds, ...db.loadDeletedTransactionIds()]);
+
+    // Sync 1: row "tx-A" not in either set, should be selected for write.
+    const sync1 = applyDedup([tx({ id: "tx-A" })], buildUnion());
+    expect(sync1.toSync.map((t) => t.id)).toEqual(["tx-A"]);
+
+    // Imitate the post-write step: mark tx-A in the persistent set.
+    for (const t of sync1.toSync) syncedIds.add(t.id);
+
+    // Sync 2 (retry path): same input, freshly-built union from the
+    // *persistent* syncedIds + tombstones. tx-A must now be deduped.
+    const sync2 = applyDedup([tx({ id: "tx-A" })], buildUnion());
+    expect(sync2.toSync).toEqual([]);
+    expect(sync2.skipped).toBe(1);
+  });
+
   test("tombstones survive close + reopen (persistent)", () => {
     db.markTransactionDeleted("tx-survives", "payment");
     db.close();

--- a/service/src/__tests__/instant-sync.test.ts
+++ b/service/src/__tests__/instant-sync.test.ts
@@ -1,5 +1,9 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { routeTransactions, applyDedup } from "../instant-sync";
+import { StateDb } from "../state-db";
 import type { Transaction } from "../parser";
 
 function tx(overrides: Partial<Transaction>): Transaction {
@@ -98,6 +102,30 @@ describe("routeTransactions", () => {
     expect(r.credits.length).toBe(1);
     expect(r.failedPayments.length).toBe(0);
   });
+
+  test("reversals are dropped — never reach any bucket", () => {
+    // TBC refunds (transactionType: "reversal", direction: "in") would
+    // otherwise land in credits via the direction === "in" rule. The
+    // user wants refund SMS to vanish from analytics entirely — neither
+    // outgoing spend nor incoming credit. Filter happens before bucketing.
+    const r = routeTransactions([
+      tx({ id: "rev1", direction: "in", transactionType: "reversal" }),
+      tx({ id: "ok1", direction: "in", transactionType: "transfer_in" }),
+      tx({ id: "rev2", direction: "in", transactionType: "reversal" }),
+    ]);
+    expect(r.credits.map((t) => t.id)).toEqual(["ok1"]);
+    expect(r.failedPayments).toEqual([]);
+    expect(r.successfulPayments).toEqual([]);
+  });
+
+  test("reversals dropped even if status is something other than success", () => {
+    const r = routeTransactions([
+      tx({ id: "rev", direction: "in", transactionType: "reversal", status: "failed" }),
+    ]);
+    expect(r.credits).toEqual([]);
+    expect(r.failedPayments).toEqual([]);
+    expect(r.successfulPayments).toEqual([]);
+  });
 });
 
 describe("applyDedup", () => {
@@ -133,5 +161,59 @@ describe("applyDedup", () => {
     const txs = [tx({ id: "a" }), tx({ id: "b" }), tx({ id: "c" }), tx({ id: "d" })];
     const { toSync } = applyDedup(txs, new Set(["b"]));
     expect(toSync.map((t) => t.id)).toEqual(["a", "c", "d"]);
+  });
+});
+
+describe("StateDb tombstones", () => {
+  let dir: string;
+  let db: StateDb;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "xarji-state-test-"));
+    db = new StateDb(join(dir, "state.db"));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("markTransactionDeleted records the id and isTransactionDeleted reads it back", () => {
+    expect(db.isTransactionDeleted("tx-1")).toBe(false);
+    db.markTransactionDeleted("tx-1", "payment");
+    expect(db.isTransactionDeleted("tx-1")).toBe(true);
+  });
+
+  test("loadDeletedTransactionIds returns the full Set for the dedup hot path", () => {
+    db.markTransactionDeleted("tx-1", "payment");
+    db.markTransactionDeleted("tx-2", "credit");
+    db.markTransactionDeleted("tx-3", "failedPayment");
+    const ids = db.loadDeletedTransactionIds();
+    expect(ids).toEqual(new Set(["tx-1", "tx-2", "tx-3"]));
+  });
+
+  test("double-delete is idempotent (no error, single row)", () => {
+    db.markTransactionDeleted("tx-1", "payment");
+    db.markTransactionDeleted("tx-1", "payment");
+    expect(db.loadDeletedTransactionIds().size).toBe(1);
+  });
+
+  test("dedup honors tombstones — applyDedup with merged set skips the row", () => {
+    db.markTransactionDeleted("tx-deleted", "payment");
+    const txs = [tx({ id: "tx-deleted" }), tx({ id: "tx-kept" })];
+    // Mirror the syncTransactions production path: union the in-memory
+    // syncedIds (empty here, simulating a fresh restart) with the
+    // tombstones, then call applyDedup.
+    const merged = new Set([...new Set<string>(), ...db.loadDeletedTransactionIds()]);
+    const { toSync, skipped } = applyDedup(txs, merged);
+    expect(toSync.map((t) => t.id)).toEqual(["tx-kept"]);
+    expect(skipped).toBe(1);
+  });
+
+  test("tombstones survive close + reopen (persistent)", () => {
+    db.markTransactionDeleted("tx-survives", "payment");
+    db.close();
+    const reopened = new StateDb(join(dir, "state.db"));
+    expect(reopened.isTransactionDeleted("tx-survives")).toBe(true);
+    reopened.close();
   });
 });

--- a/service/src/http.ts
+++ b/service/src/http.ts
@@ -32,6 +32,7 @@ import {
 import { patchConfig, CONFIG_PATH } from "./config";
 import { getProvider, serialiseEvent } from "./ai";
 import type { AIProviderId, AIStreamRequest } from "./ai/types";
+import { deleteTransaction } from "./instant-sync";
 
 export interface HttpServerOptions {
   port: number;
@@ -377,6 +378,58 @@ export function startHttpServer(opts: HttpServerOptions): HttpServerHandle {
         if (!opts.service) return json({ error: "Service not running" }, { status: 503 });
         const outcome = await opts.service.processNewMessages();
         return json(outcome);
+      }
+      if (path === "/api/transactions/delete" && req.method === "POST") {
+        const csrf = assertSafeOrigin(req);
+        if (csrf) return csrf;
+        if (!opts.service || !opts.service.stateDb) {
+          return json({ error: "Service not running" }, { status: 503 });
+        }
+        const stateDb = opts.service.stateDb;
+        let body: { transactionId?: string; instantId?: string; kind?: string };
+        try {
+          body = (await req.json()) as typeof body;
+        } catch {
+          return json({ error: "Invalid JSON body" }, { status: 400 });
+        }
+        const { transactionId, instantId, kind } = body;
+        if (typeof transactionId !== "string" || !transactionId) {
+          return json({ error: "`transactionId` is required" }, { status: 400 });
+        }
+        if (typeof instantId !== "string" || !instantId) {
+          return json({ error: "`instantId` is required" }, { status: 400 });
+        }
+        if (kind !== "payment" && kind !== "credit" && kind !== "failedPayment") {
+          return json(
+            { error: "`kind` must be 'payment', 'credit', or 'failedPayment'" },
+            { status: 400 }
+          );
+        }
+        // Delete from InstantDB FIRST. If the InstantDB delete fails the
+        // tombstone is never written, so on next sync the SMS does NOT
+        // get blocked from re-importing — the user keeps the row and
+        // can retry. Reversed order would orphan a tombstone on a failed
+        // delete and silently drop the SMS forever.
+        const deleteResult = await deleteTransaction(instantId, kind, transactionId);
+        if (!deleteResult.success) {
+          return json(
+            { deleted: false, error: deleteResult.error ?? "delete failed" },
+            { status: 502 }
+          );
+        }
+        try {
+          stateDb.markTransactionDeleted(transactionId, kind);
+        } catch (err) {
+          // Tombstone failed but InstantDB delete succeeded. The user
+          // sees the row gone; on next sync the SMS will re-import.
+          // Log loudly so we can spot this in real usage.
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(
+            `[delete] tombstone write failed for ${transactionId}: ${message} — row will re-import on next sync`
+          );
+          return json({ deleted: true, tombstoned: false, warning: message });
+        }
+        return json({ deleted: true, tombstoned: true });
       }
       if (path === "/api/exchange-rate" && req.method === "GET") {
         const dateParam = url.searchParams.get("date");

--- a/service/src/instant-sync.ts
+++ b/service/src/instant-sync.ts
@@ -2,6 +2,7 @@ import { init, id } from "@instantdb/admin";
 import schema from "./instant-schema";
 import type { Config } from "./config";
 import type { Transaction } from "./parser";
+import type { StateDb } from "./state-db";
 
 export interface InstantSyncResult {
   success: boolean;
@@ -35,17 +36,23 @@ let syncedIds: Set<string> | null = null;
  * Rule: direction === "in" → credits, status === "failed" → failedPayments,
  * everything else → payments. The direction check runs first so a failed
  * incoming (if we ever add that kind) still lands with other incoming.
+ *
+ * Reversals are dropped before bucketing — the user's intent is "the refund
+ * didn't happen as far as my analytics is concerned" so neither outgoing
+ * spend nor incoming credit. The state-db cursor still advances past these
+ * messages in service.ts so we don't keep re-parsing them on every sync.
  */
 export function routeTransactions(transactions: Transaction[]): {
   credits: Transaction[];
   failedPayments: Transaction[];
   successfulPayments: Transaction[];
 } {
-  const credits = transactions.filter((tx) => tx.direction === "in");
-  const failedPayments = transactions.filter(
+  const visible = transactions.filter((tx) => tx.transactionType !== "reversal");
+  const credits = visible.filter((tx) => tx.direction === "in");
+  const failedPayments = visible.filter(
     (tx) => tx.direction !== "in" && tx.status === "failed"
   );
-  const successfulPayments = transactions.filter(
+  const successfulPayments = visible.filter(
     (tx) => tx.direction !== "in" && tx.status === "success"
   );
   return { credits, failedPayments, successfulPayments };
@@ -115,7 +122,8 @@ export function initInstantDB(config: Config["instantdb"]): boolean {
  */
 export async function syncTransactions(
   transactions: Transaction[],
-  bankSenderId: string
+  bankSenderId: string,
+  stateDb?: StateDb
 ): Promise<InstantSyncResult> {
   if (!db) {
     return { success: false, syncedCount: 0, paymentsCount: 0, failedPaymentsCount: 0, creditsCount: 0, error: "InstantDB not initialized" };
@@ -130,7 +138,17 @@ export async function syncTransactions(
     if (syncedIds === null) {
       syncedIds = await loadSyncedIds();
     }
-    const dedupSet = syncedIds;
+    // Merge user tombstones (state.db) into the dedup set so a deleted
+    // transaction stays gone even after its InstantDB row is removed.
+    // Pre-tombstone, the dedup logic was rebuilt-from-InstantDB-only so a
+    // deleted row's transactionId would fall out of the Set on the next
+    // restart and the SMS would re-import. Tombstones are read fresh each
+    // sync cycle (cheap — sub-millisecond on a few-thousand-row table)
+    // so a delete done while the service is running takes effect on the
+    // very next sync, not just after a restart.
+    const tombstoneIds = stateDb ? stateDb.loadDeletedTransactionIds() : new Set<string>();
+    const dedupSet =
+      tombstoneIds.size === 0 ? syncedIds : new Set([...syncedIds, ...tombstoneIds]);
     const { toSync, skipped } = applyDedup(transactions, dedupSet);
     transactions = toSync;
     if (skipped > 0) {
@@ -303,6 +321,51 @@ export async function queryFailedPayments(options?: {
  */
 export function isConnected(): boolean {
   return db !== null;
+}
+
+export type DeletableKind = "payment" | "credit" | "failedPayment";
+
+/**
+ * Delete a transaction from InstantDB plus any rows that reference it
+ * (today: `transactionCategoryOverrides.paymentId`). All ops happen in
+ * a single `db.transact` so a partial failure leaves no half-deleted
+ * state. The in-memory dedup cache is also pruned of the deleted
+ * `transactionId` so a re-encountered SMS in the same process becomes
+ * eligible for re-import (the caller's tombstone in state.db blocks
+ * the actual re-import; this just keeps the in-process Set honest).
+ */
+export async function deleteTransaction(
+  instantId: string,
+  kind: DeletableKind,
+  transactionId: string
+): Promise<{ success: boolean; error?: string }> {
+  if (!db) return { success: false, error: "InstantDB not initialized" };
+  try {
+    const ops: unknown[] = [];
+    if (kind === "payment") {
+      ops.push(db.tx.payments[instantId].delete());
+      // Cascade: drop the per-transaction category override that
+      // references this payment, if any. Same pattern as
+      // useCategoryActions.deleteCategory does for merchant overrides.
+      const overrides = await db.query({
+        transactionCategoryOverrides: { $: { where: { paymentId: instantId } } } as any,
+      });
+      for (const o of (overrides.transactionCategoryOverrides ?? []) as Array<{ id: string }>) {
+        ops.push(db.tx.transactionCategoryOverrides[o.id].delete());
+      }
+    } else if (kind === "credit") {
+      ops.push(db.tx.credits[instantId].delete());
+    } else {
+      ops.push(db.tx.failedPayments[instantId].delete());
+    }
+    await db.transact(ops as Parameters<typeof db.transact>[0]);
+    if (syncedIds) syncedIds.delete(transactionId);
+    return { success: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("[InstantDB] Delete error:", message);
+    return { success: false, error: message };
+  }
 }
 
 /**

--- a/service/src/instant-sync.ts
+++ b/service/src/instant-sync.ts
@@ -228,8 +228,14 @@ export async function syncTransactions(
     if (operations.length > 0) {
       await db.transact(operations);
       // Record the ids we just wrote so a subsequent call in the same process
-      // won't retry them.
-      for (const tx of transactions) dedupSet.add(tx.id);
+      // won't retry them. Write to the persistent `syncedIds`, NOT
+      // `dedupSet` — when tombstones exist, dedupSet is a temporary copy
+      // (union of syncedIds + tombstones) and any add() against it would be
+      // discarded after this turn. processNewMessages's intentional retry-
+      // without-marking-processed flow then re-presents the same SMS on the
+      // next sync and would insert duplicate InstantDB rows. (Codex P2 on
+      // PR #46.)
+      for (const tx of transactions) syncedIds.add(tx.id);
     }
 
     console.log(

--- a/service/src/parsers/__tests__/tbc.test.ts
+++ b/service/src/parsers/__tests__/tbc.test.ts
@@ -356,6 +356,28 @@ describe("TBC parser — reversal (უKUGatareba:)", () => {
     expect(t.cardLastDigits).toBe("6109");
     expect(t.merchant).toBe("jetshr");
   });
+
+  // Inline-shape reversal: a real-world SMS reported by the user where TBC
+  // collapses header + amount + card + merchant + date + balance onto one
+  // line. The line-anchored RE_CARD_AMOUNT misses this so detect() needs
+  // RE_REVERSAL_INLINE to fire instead. The merchant extractor also takes
+  // its inline branch (substring between ")" and the date).
+  test("inline-shape reversal classified correctly", () => {
+    const t = tbcParser.parse(
+      mk(
+        700,
+        "\u10E3\u10D9\u10E3\u10D2\u10D0\u10E2\u10D0\u10E0\u10D4\u10D1\u10D0: 13.90 GEL TBC Concept 360 VISA Signature (***8058) BOLTTAXI 05/05/2026 17:25:01 \u10DC\u10D0\u10E8\u10D7\u10D8: 400.00 GEL"
+      )
+    )!;
+    expect(t.transactionType).toBe("reversal");
+    expect(t.direction).toBe("in");
+    expect(t.status).toBe("success");
+    expect(t.amount).toBe(13.9);
+    expect(t.currency).toBe("GEL");
+    expect(t.cardLastDigits).toBe("8058");
+    expect(t.merchant).toBe("BOLTTAXI");
+    expect(t.balance).toBe(400);
+  });
 });
 
 // ── Self-transfers ─────────────────────────────────────────────────────────

--- a/service/src/parsers/tbc.ts
+++ b/service/src/parsers/tbc.ts
@@ -63,6 +63,12 @@ const RE_FAILED = /საბარათე ოპერაცია\s*([\d.,]+)
 // U+10E3 U+10D9 U+10E3 U+10D2 U+10D0 U+10E2 U+10D0 U+10E0 U+10D4 U+10D1 U+10D0 = uKUGatareba
 const RE_REVERSAL = /უკუგატარება:/;
 
+// Inline shape — same SMS but everything on one line. Seen in the wild as e.g.
+// "უკუგატარება: 13.90 GEL TBC Concept 360 VISA Signature (***8058) BOLTTAXI 05/05/2026 17:25:01 ნაშთი: 400.00 GEL"
+// Captures the amount + currency right after the header so detect() can fire
+// without needing the line-anchored RE_CARD_AMOUNT to also match.
+const RE_REVERSAL_INLINE = /უკუგატარება:\s*([\d.,]+)\s*([A-Z]{3})/;
+
 // ── Bill / utility payment (გAdaXda:\nNNN CUR\nMERCHANT) ──────────────────
 // U+10D2 U+10D0 U+10D3 U+10D0 U+10EE U+10D3 U+10D0 = გAdaXda (note: ხ ≠ რ in გAdaRicxVa)
 const RE_BILL = /გადახდა:\s*([\d.,]+)\s*([A-Z]{3})/;
@@ -133,7 +139,11 @@ function detect(text: string): Detected | null {
   if (RE_DEPOSIT.test(text)) return { kind: "deposit",       status: "success" };
   if (RE_ATM.test(text))    return { kind: "atm_withdrawal", status: "success" };
   // Reversal check must precede the generic card-amount check — layout is identical.
-  if (RE_REVERSAL.test(text) && RE_CARD_AMOUNT.test(text)) {
+  // Two shapes supported: the original multi-line layout (RE_REVERSAL header +
+  // RE_CARD_AMOUNT on its own line), and a newer inline layout where TBC
+  // collapses everything onto one line (RE_REVERSAL_INLINE captures both
+  // header and amount in a single match).
+  if (RE_REVERSAL_INLINE.test(text) || (RE_REVERSAL.test(text) && RE_CARD_AMOUNT.test(text))) {
     return { kind: "reversal", status: "success" };
   }
   if (RE_CARD_AMOUNT.test(text) && (RE_CARD_PARENS.test(text) || RE_CARD_STARS.test(text))) {
@@ -147,11 +157,24 @@ function parseCard(text: string): string | null {
   return m ? m[1] : null;
 }
 
-/** Merchant for card payments: the line immediately after the card-number line. */
+/** Merchant for card payments: the line immediately after the card-number line.
+ *  For inline-shape SMS where everything is on one line, falls back to the
+ *  text immediately after the card-parens marker (e.g. "(***8058) BOLTTAXI
+ *  05/05/2026" → "BOLTTAXI"), trimmed against the date that follows. */
 function parseMerchantFromCard(text: string): string | null {
   const lines = text.trim().split(/\r?\n/).map(stripTrailingNoise).filter(Boolean);
   for (let i = 0; i < lines.length; i++) {
-    if (RE_CARD_STARS.test(lines[i])) return lines[i + 1] ?? null;
+    if (RE_CARD_STARS.test(lines[i])) {
+      // Multi-line: merchant is the next line after the card line.
+      if (lines[i + 1] != null) return lines[i + 1];
+      // Inline single-line shape: card-parens + merchant + date sit on the
+      // same line. Pull the substring after the closing paren and stop at
+      // the date.
+      const afterParens = lines[i].split(/\)\s*/)[1];
+      if (!afterParens) return null;
+      const beforeDate = afterParens.split(/\s+\d{2}\/\d{2}\/\d{4}/)[0];
+      return beforeDate.trim() || null;
+    }
   }
   return null;
 }
@@ -305,7 +328,12 @@ function parse(raw: RawMessage): Transaction | null {
 
     case "payment":
     case "reversal": {
-      const m = text.match(RE_CARD_AMOUNT);
+      // Multi-line shape stores amount on its own line (RE_CARD_AMOUNT).
+      // Inline reversal shape (RE_REVERSAL_INLINE) captures it from the
+      // header line directly. Try the inline match first for reversals
+      // since that path is the one detect() may have fired on.
+      let m = detected.kind === "reversal" ? text.match(RE_REVERSAL_INLINE) : null;
+      if (!m) m = text.match(RE_CARD_AMOUNT);
       if (!m) return null;
       amount = parseFlexibleAmount(m[1]);
       currency = m[2];

--- a/service/src/service.ts
+++ b/service/src/service.ts
@@ -25,7 +25,10 @@ export interface SyncOutcome {
 
 export class ExpenseTrackerService {
   private config: Config;
-  private stateDb: StateDb | null = null;
+  // Public so HTTP handlers can reach the tombstone helpers without
+  // routing every state.db touch through the service surface. Still
+  // null until init() runs, so callers must check before use.
+  public stateDb: StateDb | null = null;
   private watcher: ReturnType<typeof watch> | null = null;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
   private isProcessing = false;
@@ -132,8 +135,11 @@ export class ExpenseTrackerService {
             continue;
           }
 
-          // Sync to all targets (local, webhook, InstantDB)
-          const syncResults = await syncAllTargets(newTransactions, this.config, senderId);
+          // Sync to all targets (local, webhook, InstantDB). Pass stateDb
+          // so the InstantDB dedup path can union user tombstones into
+          // its skip set; without this, deleted transactions would
+          // re-import on the next sync.
+          const syncResults = await syncAllTargets(newTransactions, this.config, senderId, this.stateDb!);
 
           // Determine which targets are enabled, then collect failures.
           // Local file is always enabled (it's the failsafe backup).

--- a/service/src/state-db.ts
+++ b/service/src/state-db.ts
@@ -66,6 +66,13 @@ export interface SyncState {
   lastSyncAt: Date;
 }
 
+/**
+ * The kinds of InstantDB collections a tombstone can apply to.
+ * Mirrors `routeTransactions`'s output buckets so we can recover the
+ * source collection if we ever need to re-import a tombstoned row.
+ */
+export type TombstoneKind = "payment" | "credit" | "failedPayment";
+
 export class StateDb {
   private db: Database;
 
@@ -105,7 +112,58 @@ export class StateDb {
 
       CREATE INDEX IF NOT EXISTS idx_transactions_message_id
         ON processed_transactions(message_id);
+
+      -- User-deleted transactions. The dedup hot-path in instant-sync.ts
+      -- merges these IDs into its existing-IDs Set so a re-encountered
+      -- SMS skips through the same dedup path as already-synced rows.
+      -- Stays-deleted across service restarts, since this table is on
+      -- disk in ~/.xarji/state.db (not in InstantDB).
+      CREATE TABLE IF NOT EXISTS deleted_transactions (
+        transaction_id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        deleted_at TEXT NOT NULL
+      );
     `);
+  }
+
+  /**
+   * Record a user-initiated tombstone. Subsequent syncs see the
+   * `transactionId` in the dedup Set via `loadDeletedTransactionIds`
+   * and skip re-importing the SMS even though the InstantDB row is
+   * gone. INSERT OR REPLACE so a double-delete is idempotent.
+   */
+  markTransactionDeleted(transactionId: string, kind: TombstoneKind): void {
+    this.db
+      .query(
+        `
+        INSERT INTO deleted_transactions (transaction_id, kind, deleted_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(transaction_id) DO UPDATE SET
+          kind = excluded.kind,
+          deleted_at = excluded.deleted_at
+      `
+      )
+      .run(transactionId, kind, new Date().toISOString());
+  }
+
+  /** True if the user previously deleted this transaction. */
+  isTransactionDeleted(transactionId: string): boolean {
+    const row = this.db
+      .query("SELECT 1 FROM deleted_transactions WHERE transaction_id = ?")
+      .get(transactionId);
+    return row !== null;
+  }
+
+  /**
+   * Bulk read for the dedup hot path. Returns a Set so the syncer can
+   * union it with the existing transactionIds in O(n+m) and call the
+   * existing applyDedup unmodified.
+   */
+  loadDeletedTransactionIds(): Set<string> {
+    const rows = this.db
+      .query("SELECT transaction_id FROM deleted_transactions")
+      .all() as Array<{ transaction_id: string }>;
+    return new Set(rows.map((r) => r.transaction_id));
   }
 
   /**

--- a/service/src/sync.ts
+++ b/service/src/sync.ts
@@ -146,7 +146,8 @@ export function initSyncTargets(config: Config): void {
 async function syncToInstant(
   transactions: Transaction[],
   config: Config,
-  bankSenderId: string
+  bankSenderId: string,
+  stateDb?: import("./state-db").StateDb
 ): Promise<SyncResult> {
   if (!config.instantdb.enabled) {
     return { success: true, syncedCount: 0 };
@@ -160,7 +161,7 @@ async function syncToInstant(
     }
   }
 
-  const result = await syncToInstantDB(transactions, bankSenderId);
+  const result = await syncToInstantDB(transactions, bankSenderId, stateDb);
   return {
     success: result.success,
     syncedCount: result.syncedCount,
@@ -169,17 +170,21 @@ async function syncToInstant(
 }
 
 /**
- * Sync transactions to all configured targets
+ * Sync transactions to all configured targets. The optional `stateDb`
+ * is threaded into the InstantDB path so the dedup logic can union
+ * user-tombstoned transactionIds into its skip set; without it, deleted
+ * transactions would re-import on the next sync.
  */
 export async function syncAllTargets(
   transactions: Transaction[],
   config: Config,
-  bankSenderId: string = "SOLO"
+  bankSenderId: string = "SOLO",
+  stateDb?: import("./state-db").StateDb
 ): Promise<{ local: SyncResult; webhook: SyncResult; instantdb: SyncResult }> {
   const [local, webhook, instantdb] = await Promise.all([
     syncToLocalFile(transactions, config.localBackupPath),
     syncToWebhook(transactions, config.webhook),
-    syncToInstant(transactions, config, bankSenderId),
+    syncToInstant(transactions, config, bankSenderId, stateDb),
   ]);
 
   return { local, webhook, instantdb };


### PR DESCRIPTION
Two transaction-handling fixes shipped together because they share the same surface.

**TBC inline refunds.** TBC sends a refund SMS that the parser already handles in its multi-line shape (`უკუგატარება:` header on one line, amount on the next), but the user reported a newer inline variant where everything is on one line: `უკუგატარება: 13.90 GEL TBC Concept 360 VISA Signature (***8058) BOLTTAXI 05/05/2026 17:25:01 ნაშთი: 400.00 GEL`. The line-anchored `RE_CARD_AMOUNT` doesn't match, so detect() fell through and the refund was logged as outgoing spending. Added `RE_REVERSAL_INLINE` that captures amount+currency from the header line, taught detect() to fire on either shape, extended `parseMerchantFromCard` to pull the merchant from the substring between `(***NNNN)` and the date when no separate merchant line exists, and updated the reversal/payment branch to try the inline regex first for reversals. For the user's intent of "the refund didn't happen as far as my analytics is concerned", `routeTransactions` now drops everything with `transactionType === "reversal"` before bucketing — both shapes get the same treatment for consistency. The state.db cursor still advances past these messages so they're not re-parsed every sync.

**Permanent delete with state.db tombstones.** Today `excludedFromAnalytics` (PR #36) hides a row from analytics but keeps it in the ledger with an Excluded pill. The user wanted true delete that removes from InstantDB, the ledger, and analytics, and stays gone across SMS resyncs. The hard part is the last bit: dedup at `instant-sync.ts:applyDedup` keys off `transactionId` and rebuilds its existing-IDs Set from current InstantDB rows — once a row is deleted, the next sync re-imports the SMS because its `transactionId` is gone from the Set.

Added a `deleted_transactions` table to state.db with `markTransactionDeleted` / `isTransactionDeleted` / `loadDeletedTransactionIds` helpers. The dedup hot path unions the in-memory `syncedIds` with the tombstone Set so a re-encountered deleted SMS skips through the same path as already-synced rows. Union rebuilt every sync cycle so a delete done while the service is running takes effect on the very next sync.

UI: a Permanent / Delete row sits below the In analytics / Exclude row in both `Transactions.tsx` and `Income.tsx` (Income's panel was missing both a delete and an exclude toggle previously — both ship in this PR). `window.confirm()` with merchant + amount + date so the user can audit before destruction. The client hook `useTransactionDelete` posts to a new `POST /api/transactions/delete` endpoint that does the InstantDB delete first then the tombstone write — that ordering means a half-failure keeps the data instead of orphaning a tombstone. Demo mode skips the round-trip and writes to the in-memory store directly. Service-unreachable falls back to a client-only delete with a console warning that the SMS will re-import.

Cascade cleanup: the service's delete also removes any `transactionCategoryOverrides` rows pointing at the deleted payment, in the same transact. Mirrors `useCategoryActions.deleteCategory` for merchant overrides.

No AI tool surface for delete — same precedent as the `delete_category` removal in PR #35. Destructive deletes need explicit human confirmation that an AI tool call would bypass.

Test coverage: TBC inline reversal fixture asserts merchant/amount/balance. Two routing tests confirm reversals never reach any bucket. State-db tombstone suite covers write/read, idempotent double-delete, dedup integration, and persistence across close/reopen. E2E walkthroughs in `docs/e2e/transactions.md` (T-TX-13..18) and `docs/e2e/income.md` (T-INC-07..10) cover confirm-cancel-keeps-row, panel auto-close, post-reload persistence, post-sync persistence, and the failed-payment guard. `bun test` 201 pass (was 196), `bun run typecheck` and `bun run build` both clean.