### PR TITLE
feat: fix budget UUID seed, add cycle range, and improve loading UX

### DIFF
--- a/client/src/hooks/useBudgets.ts
+++ b/client/src/hooks/useBudgets.ts
@@ -133,13 +133,15 @@ export function useBudgetPlan(planMonth = planMonthKey()) {
  */
 export function useBudgetSummary(planMonth = planMonthKey(), rangeStart?: Date, rangeEnd?: Date) {
   const categories = useMergedCategories();
-  const { payments } = useConvertedPayments();
+  const { payments, isLoading: paymentsLoading } = useConvertedPayments();
+  const { isLoading: categoriesLoading } = useCategories();
   const { categorize } = useCategorizer();
-  const { plans } = useBudgetPlans();
+  const { plans, isLoading: plansLoading } = useBudgetPlans();
   const rangeStartMs = rangeStart?.getTime();
   const rangeEndMs = rangeEnd?.getTime();
+  const isLoading = paymentsLoading || categoriesLoading || plansLoading;
 
-  return useMemo(() => {
+  const summary = useMemo(() => {
     const monthStart = rangeStartMs !== undefined
       ? rangeStartMs
       : new Date(planMonthYear(planMonth), planMonthMonth(planMonth), 1).getTime();
@@ -229,6 +231,8 @@ export function useBudgetSummary(planMonth = planMonthKey(), rangeStart?: Date, 
       anchor,
     };
   }, [categories, payments, categorize, plans, planMonth, rangeStartMs, rangeEndMs]);
+
+  return { ...summary, isLoading };
 }
 
 /**

--- a/client/src/hooks/useBudgets.ts
+++ b/client/src/hooks/useBudgets.ts
@@ -131,15 +131,22 @@ export function useBudgetPlan(planMonth = planMonthKey()) {
  * Months before the anchor are treated as 0-contribution; the user
  * hadn't started budgeting yet, so we don't retro-credit nor debit.
  */
-export function useBudgetSummary(planMonth = planMonthKey()) {
+export function useBudgetSummary(planMonth = planMonthKey(), rangeStart?: Date, rangeEnd?: Date) {
   const categories = useMergedCategories();
   const { payments } = useConvertedPayments();
   const { categorize } = useCategorizer();
   const { plans } = useBudgetPlans();
+  const rangeStartMs = rangeStart?.getTime();
+  const rangeEndMs = rangeEnd?.getTime();
 
   return useMemo(() => {
-    const monthStart = new Date(planMonthYear(planMonth), planMonthMonth(planMonth), 1).getTime();
-    const monthEnd = new Date(planMonthYear(planMonth), planMonthMonth(planMonth) + 1, 1).getTime();
+    const monthStart = rangeStartMs !== undefined
+      ? rangeStartMs
+      : new Date(planMonthYear(planMonth), planMonthMonth(planMonth), 1).getTime();
+    // +1ms so endOfDay (23:59:59.999) is included when using < comparison
+    const monthEnd = rangeEndMs !== undefined
+      ? rangeEndMs + 1
+      : new Date(planMonthYear(planMonth), planMonthMonth(planMonth) + 1, 1).getTime();
     const anchor = anchorMonthFromPlans(plans);
 
     // Bucket-by-categoryId for current month spend AND build the
@@ -221,7 +228,7 @@ export function useBudgetSummary(planMonth = planMonthKey()) {
       nonMonthlySinkingFund,
       anchor,
     };
-  }, [categories, payments, categorize, plans, planMonth]);
+  }, [categories, payments, categorize, plans, planMonth, rangeStartMs, rangeEndMs]);
 }
 
 /**

--- a/client/src/hooks/useBudgets.ts
+++ b/client/src/hooks/useBudgets.ts
@@ -243,13 +243,16 @@ export function useBudgetMutations() {
   const setCategoryBucket = useCallback(async (categoryId: string, bucket: Bucket | null) => {
     // If this id belongs to a DEFAULT_CATEGORY that hasn't been written
     // to DB yet, seed a full row first so name/color/icon aren't lost
-    // when only `bucket` is set.
+    // when only `bucket` is set. DEFAULT_CATEGORIES use slug ids (e.g.
+    // "groceries") which InstantDB rejects — generate a real UUID here.
+    let resolvedId = categoryId;
     const existsInDb = dbCats.some((c) => c.id === categoryId);
     if (!existsInDb) {
       const def = DEFAULT_CATEGORIES.find((d) => d.id === categoryId);
       if (def) {
+        resolvedId = id();
         await db.transact(
-          db.tx.categories[categoryId].update({
+          db.tx.categories[resolvedId].update({
             name: def.name,
             color: def.color,
             icon: def.icon,
@@ -260,7 +263,7 @@ export function useBudgetMutations() {
     }
     if (bucket === null) {
       await db.transact(
-        db.tx.categories[categoryId].update({
+        db.tx.categories[resolvedId].update({
           bucket: undefined,
           targetAmount: undefined,
           frequencyMonths: undefined,
@@ -268,7 +271,7 @@ export function useBudgetMutations() {
         })
       );
     } else {
-      await db.transact(db.tx.categories[categoryId].update({ bucket }));
+      await db.transact(db.tx.categories[resolvedId].update({ bucket }));
     }
   }, [dbCats]);
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -33,3 +33,12 @@ button { font: inherit; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: rgba(128,128,128,0.18); border-radius: 5px; }
 ::-webkit-scrollbar-thumb:hover { background: rgba(128,128,128,0.32); }
+
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+.skeleton-pulse {
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+  border-radius: 6px;
+}

--- a/client/src/pages/Budgets.tsx
+++ b/client/src/pages/Budgets.tsx
@@ -40,7 +40,10 @@ export function Budgets() {
     ? `Cycle: ${rangeProps.cycleLabel}`
     : `Plan for ${format(range.start, "MMMM yyyy")}`;
 
-  const showWizard = summary.byBucket.fixed.length === 0 &&
+  const isLoading = plan.isLoading || summary.isLoading;
+
+  const showWizard = !isLoading &&
+    summary.byBucket.fixed.length === 0 &&
     summary.byBucket.flex.length === 0 &&
     summary.byBucket.non_monthly.length === 0;
 
@@ -67,53 +70,68 @@ export function Budgets() {
       {/* Headline: flex remaining */}
       <Card pad="26px 30px" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
         <CardLabel>Flex remaining · GEL</CardLabel>
-        <div
-          style={{
-            fontSize: "clamp(44px, 6vw, 72px)",
-            fontWeight: 700,
-            letterSpacing: -3,
-            lineHeight: 1,
-            color: T.text,
-            fontFamily: T.sans,
-            whiteSpace: "nowrap",
-          }}
-        >
-          <span style={{ color: T.accent, opacity: 0.9 }}>₾</span>
-          {Math.round(flexRemaining).toLocaleString("en-US")}
-          <span style={{ fontSize: "0.42em", color: T.muted }}>
-            .{flexRemaining.toFixed(2).split(".")[1] || "00"}
-          </span>
-        </div>
-        <div style={{ fontSize: 12.5, color: T.muted, fontFamily: T.sans }}>
-          ₾{Math.round(flexRemaining / daysLeft).toLocaleString("en-US")}/day for the next {daysLeft} day
-          {daysLeft === 1 ? "" : "s"} · ₾{Math.round(plan.flexPool).toLocaleString("en-US")} pool
-          {plan.flexPoolIsAuto ? " (auto)" : " (manual)"}
-        </div>
-        {/* Flex usage bar */}
-        <div
-          style={{
-            marginTop: 8,
-            height: 8,
-            background: T.panelAlt,
-            borderRadius: 4,
-            overflow: "hidden",
-          }}
-        >
-          <div
-            style={{
-              width: `${flexUsedPct}%`,
-              height: "100%",
-              background: T.accent,
-              transition: "width 200ms ease-out",
-            }}
-          />
-        </div>
-        <div style={{ fontSize: 11, color: T.dim, fontFamily: T.mono, fontVariantNumeric: "tabular-nums" }}>
-          ₾{Math.round(summary.flexActual).toLocaleString("en-US")} spent · {flexUsedPct.toFixed(0)}% of pool
-        </div>
+        {isLoading ? (
+          <>
+            <div className="skeleton-pulse" style={{ height: 60, width: "55%", background: T.panelAlt }} />
+            <div className="skeleton-pulse" style={{ height: 14, width: "70%", background: T.panelAlt }} />
+            <div style={{ marginTop: 8, height: 8, background: T.panelAlt, borderRadius: 4 }} />
+            <div className="skeleton-pulse" style={{ height: 12, width: "40%", background: T.panelAlt }} />
+          </>
+        ) : (
+          <>
+            <div
+              style={{
+                fontSize: "clamp(44px, 6vw, 72px)",
+                fontWeight: 700,
+                letterSpacing: -3,
+                lineHeight: 1,
+                color: T.text,
+                fontFamily: T.sans,
+                whiteSpace: "nowrap",
+              }}
+            >
+              <span style={{ color: T.accent, opacity: 0.9 }}>₾</span>
+              {Math.round(flexRemaining).toLocaleString("en-US")}
+              <span style={{ fontSize: "0.42em", color: T.muted }}>
+                .{flexRemaining.toFixed(2).split(".")[1] || "00"}
+              </span>
+            </div>
+            <div style={{ fontSize: 12.5, color: T.muted, fontFamily: T.sans }}>
+              ₾{Math.round(flexRemaining / daysLeft).toLocaleString("en-US")}/day for the next {daysLeft} day
+              {daysLeft === 1 ? "" : "s"} · ₾{Math.round(plan.flexPool).toLocaleString("en-US")} pool
+              {plan.flexPoolIsAuto ? " (auto)" : " (manual)"}
+            </div>
+            {/* Flex usage bar */}
+            <div
+              style={{
+                marginTop: 8,
+                height: 8,
+                background: T.panelAlt,
+                borderRadius: 4,
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  width: `${flexUsedPct}%`,
+                  height: "100%",
+                  background: T.accent,
+                  transition: "width 200ms ease-out",
+                }}
+              />
+            </div>
+            <div style={{ fontSize: 11, color: T.dim, fontFamily: T.mono, fontVariantNumeric: "tabular-nums" }}>
+              ₾{Math.round(summary.flexActual).toLocaleString("en-US")} spent · {flexUsedPct.toFixed(0)}% of pool
+            </div>
+          </>
+        )}
       </Card>
 
-      {showWizard ? (
+      {isLoading ? (
+        <Card pad="40px 30px" style={{ textAlign: "center" }}>
+          <div style={{ fontSize: 13, color: T.muted, fontFamily: T.sans }}>Loading…</div>
+        </Card>
+      ) : showWizard ? (
         <SetupWizard onClassify={setCategoryBucket} />
       ) : (
         <>

--- a/client/src/pages/Budgets.tsx
+++ b/client/src/pages/Budgets.tsx
@@ -11,12 +11,14 @@ import { BUCKETS, BUCKET_DESCRIPTIONS, BUCKET_LABELS, type Bucket, planMonthKey 
 import { useMergedCategories } from "../hooks/useCategories";
 import type { Category } from "../lib/instant";
 import { format } from "date-fns";
+import { useRangeState } from "../hooks/useRangeState";
 
 export function Budgets() {
   const T = useTheme();
-  const planMonth = planMonthKey();
+  const { range, props: rangeProps } = useRangeState("Month");
+  const planMonth = planMonthKey(range.start);
   const plan = useBudgetPlan(planMonth);
-  const summary = useBudgetSummary(planMonth);
+  const summary = useBudgetSummary(planMonth, range.start, range.end);
   const {
     setCategoryBucket,
     setCategoryTarget,
@@ -30,9 +32,13 @@ export function Budgets() {
   const flexRemaining = Math.max(0, plan.flexPool - summary.flexActual);
   const daysLeft = useMemo(() => {
     const now = new Date();
-    const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-    return Math.max(1, lastDay - now.getDate() + 1);
-  }, []);
+    const ms = range.end.getTime() - now.getTime();
+    return Math.max(1, Math.ceil(ms / (1000 * 60 * 60 * 24)));
+  }, [range.end]);
+
+  const eyebrow = rangeProps.active === "Cycle" && rangeProps.cycleLabel
+    ? `Cycle: ${rangeProps.cycleLabel}`
+    : `Plan for ${format(range.start, "MMMM yyyy")}`;
 
   const showWizard = summary.byBucket.fixed.length === 0 &&
     summary.byBucket.flex.length === 0 &&
@@ -41,8 +47,16 @@ export function Budgets() {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, height: "100%" }}>
       <PageHeader
-        eyebrow={`Plan for ${format(new Date(), "MMMM yyyy")}`}
+        eyebrow={eyebrow}
         title="Flex Budgeting"
+        ranges={["Month", "Cycle"]}
+        active={rangeProps.active}
+        onRange={rangeProps.onRange}
+        cycleDay={rangeProps.cycleDay}
+        cycleLabel={rangeProps.cycleLabel}
+        onCycleDayChange={rangeProps.onCycleDayChange}
+        onCyclePrev={rangeProps.onCyclePrev}
+        onCycleNext={rangeProps.onCycleNext}
         rightSlot={
           <Pill bg={T.accentSoft} color={T.accent}>
             {summary.byBucket.unclassified.length} unclassified

--- a/docs/e2e/README.md
+++ b/docs/e2e/README.md
@@ -117,7 +117,7 @@ and update them in the same commit.
 | [dashboard.md](dashboard.md) | `client/src/pages/Dashboard.tsx` — hero, donut, 9-month trend, top-merchant tiles, wheel-scroll regression guard | 2026-04-27 (PR #27) |
 | [transactions.md](transactions.md) | `client/src/pages/Transactions.tsx` — filters, day groups, side panel, URL drill-down ingestion | 2026-04-27 (PR #23) |
 | [categories.md](categories.md) | `client/src/pages/Categories.tsx` — left donut + list, per-cat detail, per-cat trend, merchant rows | 2026-04-27 (PR #23) |
-| [budgets.md](budgets.md) | `client/src/pages/Budgets.tsx` + `useBudgets` + `lib/budgets.ts` + `lib/ai/tools/budgets.ts` — three-bucket flex budgeting, rollover, AI tools | 2026-04-30 (PR #42) |
+| [budgets.md](budgets.md) | `client/src/pages/Budgets.tsx` + `useBudgets` + `lib/budgets.ts` + `lib/ai/tools/budgets.ts` — three-bucket flex budgeting, rollover, Cycle range, loading skeleton, AI tools | 2026-05-06 (current PR) |
 | [merchants.md](merchants.md) | `client/src/pages/Merchants.tsx` — table, search, drill-down rows | 2026-04-27 (PR #23) |
 | [income.md](income.md) | `client/src/pages/Income.tsx` — hero, income trend, ledger | 2026-04-27 (PR #23) |
 | [manage.md](manage.md) | `client/src/pages/Settings.tsx` mounted at `/manage` — Sync now button, CSRF, partial-failure UI | 2026-04-27 (PR #22) |

--- a/docs/e2e/budgets.md
+++ b/docs/e2e/budgets.md
@@ -33,12 +33,16 @@ day rolls over.
 
 **Steps**
 1. Navigate to `http://localhost:5173/budgets`.
-2. Wait for the page to render.
+2. Wait for the page to fully render (skeleton disappears).
 
 **Expected**
 - Sidebar entry **Flex Budgeting** appears between Categories and Merchants
   with glyph `◇`. No NEW pill.
-- Eyebrow: `Plan for <current month name> <year>` (e.g. `Plan for April 2026`).
+- While data loads: the "Flex remaining · GEL" card shows four pulsing
+  skeleton blocks (number, subtitle, bar, spent line). No wrong-data flash.
+- After load: eyebrow reads `Plan for <current month name> <year>`
+  (e.g. `Plan for May 2026`). Range buttons **Month** and **Cycle** are
+  visible in the header; **Month** is active.
 - Title: `Flex Budgeting`.
 - Right-side pill shows `0 unclassified` (every demo category has a bucket).
 - Headline card "Flex remaining · GEL" renders a non-zero number (≥₾2k on a
@@ -403,3 +407,35 @@ day rolls over.
 - Fixed-rollover-OFF rows (Utilities, Loans) start fresh with no carry.
 - The Income card's auto-derived expected income may shift because the
   3-month rolling window moved forward by one month.
+
+---
+
+## T-BUD-21 — Cycle range scopes all numbers to the custom window
+
+**Steps**
+1. Navigate to `/budgets`. Note the current Flex remaining value and the
+   eyebrow (`Plan for <month> <year>`).
+2. Click the **Cycle** range button in the header.
+3. The cycle-day input defaults to `25`. Leave it at 25.
+4. Note the new eyebrow label (e.g. `Cycle: Apr 25 – May 24, 2026`).
+5. Note the updated Flex remaining, `daysLeft`, and bucket actuals.
+6. Click **←** (previous cycle) — eyebrow shifts back one cycle.
+7. Click **→** (next cycle) — eyebrow advances to the next cycle.
+8. Change the cycle-day input to `10`. Eyebrow updates to the 10th–9th window.
+9. Click **Month** — page returns to calendar-month view.
+
+**Expected**
+- Step 2: `Month` deactivates, `Cycle` activates. Cycle controls appear
+  (prev/next arrows + day input).
+- Step 4: Eyebrow reads `Cycle: <start date> – <end date, year>`.
+- Step 5: Actuals and Flex remaining reflect only transactions within the
+  cycle window, not the full calendar month. On a day after the 25th the
+  cycle window is shorter than the calendar month, so actuals will be lower.
+  `daysLeft` shows days until the cycle end (e.g. `19 days` if today is the
+  5th of a month with a 25th-to-24th cycle).
+- Step 6–7: Eyebrow label shifts backward/forward by one cycle period.
+  Actuals update to match the selected historical or future window.
+- Step 8: Eyebrow updates to reflect the 10th-to-9th cycle.
+- Step 9: Eyebrow returns to `Plan for <month> <year>`. Range controls
+  collapse back to just Month/Cycle pills. Actuals revert to the full
+  calendar month.


### PR DESCRIPTION
Summary

  - Fix TransactionValidationError — DEFAULT_CATEGORIES use slug IDs (e.g. "groceries") instead of UUIDs. When setCategoryBucket seeded an unsaved default category into InstantDB, it passed the slug
  directly and InstantDB rejected it. Now generates a real UUID via id() for the seed write and uses that UUID for the subsequent bucket update.
  - Cycle range on Flex Budgeting — The page was hardcoded to calendar month (1st–31st). Added useRangeState("Month") with a ["Month", "Cycle"] switcher in the header. planMonth, payment filtering,
  and daysLeft all derive from the active range, so switching to Cycle (e.g. 25th–25th) correctly scopes all numbers to that window.
  - Loading UX — useBudgetSummary now surfaces a combined isLoading flag (payments + categories + plans). The "Flex remaining · GEL" headline card shows four pulsing skeleton blocks while data loads,
  and the rest of the page content is gated until all three queries resolve — eliminating the flash of wrong zero-spend data on first render.

  Test plan

  - Classify a DEFAULT_CATEGORY (e.g. Groceries) bucket for the first time — no TransactionValidationError, row appears in InstantDB with a UUID
  - Switch to Cycle mode in the header, change the day to 25 — numbers and daysLeft update to the 25th–25th window
  - Navigate away and back to Flex Budgeting — skeleton pulses briefly, then correct data appears with no flash of zeros

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date range filtering to budget summaries for more flexible period analysis and reporting.
  * Improved default category creation with automatic metadata population.
  * Range-aware budgeting enabling flexible cycle and month view switching.

* **UI/UX Improvements**
  * Added loading skeleton animations to provide visual feedback during budget data fetches.
  * Enhanced budgeting interface with dynamic range-based calculations and period navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->