### PR TITLE
Match Latin transliteration in TBC parser

### DIFF
--- a/service/src/parsers/__tests__/tbc.test.ts
+++ b/service/src/parsers/__tests__/tbc.test.ts
@@ -614,13 +614,20 @@ describe("TBC parser — Latin transliteration", () => {
   });
 
   test("outgoing transfer (Gadaricxva) classifies as transfer_out", () => {
+    // Layout mirrors the existing Georgian "transfer with named
+    // counterparty" test: header / amount / account-hint /
+    // date / counterparty. parseCounterpartyAfterDate returns the
+    // line AFTER the date, which is the counterparty (TBC CARD here
+    // since the user's real SMS pays off a credit card from current).
     const tx = tbcParser.parse(
       mk(
         901,
         [
-          "Gadaricxva: 670.00 GEL",
-          "TBC CARD",
+          "Gadaricxva:",
+          "670.00 GEL",
+          "VISA GOLD",
           "05/05/2026",
+          "TBC CARD",
         ].join("\n")
       )
     )!;
@@ -629,6 +636,8 @@ describe("TBC parser — Latin transliteration", () => {
     expect(tx.direction).toBe("out");
     expect(tx.amount).toBe(670);
     expect(tx.currency).toBe("GEL");
+    expect(tx.counterparty).toBe("TBC CARD");
+    expect(tx.merchant).toBe("TBC CARD");
   });
 
   test("self-transfer (Sakutar angarishebze) is skipped", () => {
@@ -744,12 +753,17 @@ describe("TBC parser — Latin transliteration", () => {
   });
 
   test("scheduled auto-transfer (Avtomaturi gadaricxva)", () => {
+    // 5-line layout mirroring the existing Georgian Geocell test:
+    // header / amount / merchant / paren-info / date. parseBillMerchant
+    // returns lines[2] (the merchant) for this shape.
     const tx = tbcParser.parse(
       mk(
         908,
         [
-          "Avtomaturi gadaricxva 50.00 GEL",
+          "Avtomaturi gadaricxva",
+          "50.00 GEL",
           "Geocell",
+          "(N 591300569)",
           "05/05/2026",
         ].join("\n")
       )
@@ -757,34 +771,45 @@ describe("TBC parser — Latin transliteration", () => {
     expect(tx).not.toBeNull();
     expect(tx.transactionType).toBe("transfer_out");
     expect(tx.amount).toBe(50);
+    expect(tx.merchant).toBe("Geocell");
   });
 
   test("bill payment (Gadakhda) classifies as transfer_out", () => {
+    // 5-line layout mirroring the existing Georgian TELMICO test:
+    // header / amount / merchant / ID:NNN / date. parseBillMerchant
+    // returns lines[2] (the merchant).
     const tx = tbcParser.parse(
       mk(
         909,
         [
-          "Gadakhda: 75.00 GEL",
+          "Gadakhda:",
+          "75.00 GEL",
           "Magti",
-          "05/05/2026",
+          "ID:5802811",
+          "Sheqmnis tarigi: 05/05/2026 12:00:00",
         ].join("\n")
       )
     )!;
     expect(tx).not.toBeNull();
     expect(tx.transactionType).toBe("transfer_out");
     expect(tx.amount).toBe(75);
+    expect(tx.merchant).toBe("Magti");
   });
 
   test("failed card payment (Sabarate operacia ... uarYofiliA)", () => {
+    // 5-line layout mirroring the existing Georgian declined-card test:
+    // header (with amount + uarYofiliA) / Mizezi / card / date / merchant.
+    // parseFailedMerchant returns the line AFTER the date, so the merchant
+    // belongs there, not before it.
     const tx = tbcParser.parse(
       mk(
         910,
         [
-          "Sabarate operacia 100.00 GEL uarYofiliA",
-          "VISA (***7940)",
-          "MERCHANT",
-          "05/05/2026",
+          "!Sabarate operacia 100.00 GEL uarYofiliA.",
           "Mizezi: insufficient funds",
+          "VISA GOLD (***'7940')",
+          "05/05/2026",
+          "MERCHANT.NAME",
         ].join("\n")
       )
     )!;
@@ -793,6 +818,8 @@ describe("TBC parser — Latin transliteration", () => {
     expect(tx.status).toBe("failed");
     expect(tx.amount).toBe(100);
     expect(tx.failureReason).toBe("insufficient funds");
+    expect(tx.cardLastDigits).toBe("7940");
+    expect(tx.merchant).toBe("MERCHANT.NAME");
   });
 
   test("loan repayment (Sesxis dapharva)", () => {

--- a/service/src/parsers/__tests__/tbc.test.ts
+++ b/service/src/parsers/__tests__/tbc.test.ts
@@ -581,3 +581,262 @@ describe("TBC parser — invariants", () => {
     expect(tx.bankSenderId).toBe("TBC SMS");
   });
 });
+
+// ── Latin transliteration variants ───────────────────────────────────────
+//
+// All the existing fixtures above use Georgian script. Real production
+// TBC SMS arrive in Latin transliteration — confirmed from a chat.db dump
+// on 2026-05-05. Until this fix every SMS that depended on a header keyword
+// (Charicxva, Gadaricxva, Ukugatareba, Mobiluris shevseba, Nashti, etc)
+// silently fell off the dashboard because the parser only matched the
+// Georgian-script forms. Card payments worked anyway because they don't
+// need a header keyword (just `<amount> <currency>` + `(***NNNN)`).
+//
+// The fixtures below mirror real SMS the user was missing on their feed.
+
+describe("TBC parser — Latin transliteration", () => {
+  test("incoming transfer (Charicxva) classifies as transfer_in", () => {
+    const tx = tbcParser.parse(
+      mk(
+        900,
+        [
+          "Charicxva: 12000.00 GEL",
+          "Current",
+          "05/05/2026",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("transfer_in");
+    expect(tx.direction).toBe("in");
+    expect(tx.amount).toBe(12000);
+    expect(tx.currency).toBe("GEL");
+  });
+
+  test("outgoing transfer (Gadaricxva) classifies as transfer_out", () => {
+    const tx = tbcParser.parse(
+      mk(
+        901,
+        [
+          "Gadaricxva: 670.00 GEL",
+          "TBC CARD",
+          "05/05/2026",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("transfer_out");
+    expect(tx.direction).toBe("out");
+    expect(tx.amount).toBe(670);
+    expect(tx.currency).toBe("GEL");
+  });
+
+  test("self-transfer (Sakutar angarishebze) is skipped", () => {
+    const tx = tbcParser.parse(
+      mk(
+        902,
+        "Sakutar angarishebze gadaricxva: 6357.00 GEL 05/05/2026"
+      )
+    );
+    expect(tx).toBeNull();
+  });
+
+  test("mobile top-up (Mobiluris shevseba) classifies as transfer_out", () => {
+    // Layout mirrors the existing Georgian-script Silknet fixture above:
+    // header / amount / merchant / account-id / date. parseBillMerchant
+    // returns lines[2] (the merchant).
+    const tx = tbcParser.parse(
+      mk(
+        903,
+        [
+          "Mobiluris shevseba:",
+          "10.00 GEL ",
+          "Silknet account",
+          "ID:577600243",
+          "Sheqmnis tarigi: 05/05/2026 15:47:36",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("transfer_out");
+    expect(tx.direction).toBe("out");
+    expect(tx.amount).toBe(10);
+    expect(tx.currency).toBe("GEL");
+    expect(tx.merchant).toBe("Silknet account");
+  });
+
+  test("inline reversal (Ukugatareba) — user's actual May 2026 SMS", () => {
+    // The exact SMS body the user reported on 2026-05-06: a refund that
+    // was being mis-counted as outgoing spending because RE_REVERSAL only
+    // matched Georgian "უკუგატარება:" — the Latin "Ukugatareba" header
+    // fell through to the generic-card-payment branch.
+    const tx = tbcParser.parse(
+      mk(
+        904,
+        "Ukugatareba: 13.90 GEL TBC Concept 360 VISA Signature (***8058) BOLTTAXI 05/05/2026 17:25:01 nashti: 400.00 GEL"
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("reversal");
+    expect(tx.direction).toBe("in");
+    expect(tx.amount).toBe(13.9);
+    expect(tx.currency).toBe("GEL");
+    expect(tx.cardLastDigits).toBe("8058");
+    expect(tx.merchant).toBe("BOLTTAXI");
+    // Lowercase "nashti:" — the inline-reversal SMS uses lowercase here.
+    expect(tx.balance).toBe(400);
+  });
+
+  test("multi-line reversal (Ukugatareba) classifies correctly", () => {
+    const tx = tbcParser.parse(
+      mk(
+        905,
+        [
+          "Ukugatareba:",
+          "13.90 GEL",
+          "VISA SIGNATURE (***8058)",
+          "BOLTTAXI",
+          "05/05/2026 17:25:01",
+          "Nashti: 400.00 GEL",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("reversal");
+    expect(tx.direction).toBe("in");
+    expect(tx.amount).toBe(13.9);
+    expect(tx.balance).toBe(400);
+  });
+
+  test("ATM withdrawal (Tanxis ganagdeba) classifies as atm_withdrawal", () => {
+    const tx = tbcParser.parse(
+      mk(
+        906,
+        [
+          "Tanxis ganagdeba:",
+          "05/05/2026",
+          "Tanxa: 500.00 GEL",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("atm_withdrawal");
+    expect(tx.direction).toBe("out");
+    expect(tx.amount).toBe(500);
+    expect(tx.currency).toBe("GEL");
+  });
+
+  test("cash deposit (Naghdi pulis shetana) classifies as deposit", () => {
+    const tx = tbcParser.parse(
+      mk(
+        907,
+        [
+          "Naghdi pulis shetana:",
+          "Tanxa: 200.00 GEL",
+          "05/05/2026",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("deposit");
+    expect(tx.direction).toBe("in");
+    expect(tx.amount).toBe(200);
+  });
+
+  test("scheduled auto-transfer (Avtomaturi gadaricxva)", () => {
+    const tx = tbcParser.parse(
+      mk(
+        908,
+        [
+          "Avtomaturi gadaricxva 50.00 GEL",
+          "Geocell",
+          "05/05/2026",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("transfer_out");
+    expect(tx.amount).toBe(50);
+  });
+
+  test("bill payment (Gadakhda) classifies as transfer_out", () => {
+    const tx = tbcParser.parse(
+      mk(
+        909,
+        [
+          "Gadakhda: 75.00 GEL",
+          "Magti",
+          "05/05/2026",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("transfer_out");
+    expect(tx.amount).toBe(75);
+  });
+
+  test("failed card payment (Sabarate operacia ... uarYofiliA)", () => {
+    const tx = tbcParser.parse(
+      mk(
+        910,
+        [
+          "Sabarate operacia 100.00 GEL uarYofiliA",
+          "VISA (***7940)",
+          "MERCHANT",
+          "05/05/2026",
+          "Mizezi: insufficient funds",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("payment_failed");
+    expect(tx.status).toBe("failed");
+    expect(tx.amount).toBe(100);
+    expect(tx.failureReason).toBe("insufficient funds");
+  });
+
+  test("loan repayment (Sesxis dapharva)", () => {
+    const tx = tbcParser.parse(
+      mk(
+        911,
+        [
+          "Sesxis dapharva: 250.00 GEL",
+          "Personal loan",
+          "Angarishidan: Current",
+          "Sesxis nashti: 1500.00 GEL",
+          "05/05/2026",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("loan_repayment");
+    expect(tx.direction).toBe("out");
+    expect(tx.amount).toBe(250);
+    expect(tx.balance).toBe(1500);
+    expect(tx.counterparty).toBe("Current");
+  });
+
+  test("card payment with 'Nashti' balance (no header keyword needed)", () => {
+    // This case worked before the fix because card-payment detection
+    // doesn't require a header keyword. Test pinned here to make sure
+    // nothing regresses — including that balance still extracts from
+    // the Latin "Nashti:" form.
+    const tx = tbcParser.parse(
+      mk(
+        912,
+        [
+          "46.82 GEL",
+          "TBC Concept 360 MC World elite (***7940)",
+          "Wolt",
+          "06/05/2026 14:12:50",
+          "Nashti: 4565.73 GEL",
+        ].join("\n")
+      )
+    )!;
+    expect(tx).not.toBeNull();
+    expect(tx.transactionType).toBe("payment");
+    expect(tx.amount).toBe(46.82);
+    expect(tx.merchant).toBe("Wolt");
+    expect(tx.balance).toBe(4565.73);
+  });
+});

--- a/service/src/parsers/tbc.ts
+++ b/service/src/parsers/tbc.ts
@@ -1,22 +1,31 @@
 /**
  * TBC Bank — real sender id "TBC SMS" (not "TBC").
  *
- * All patterns match Georgian Unicode directly. TBC sends SMS in Georgian
- * script (U+10D0–U+10FF); comments show the human-readable transliteration
- * beside each Unicode-escaped literal for readability.
+ * Each detection regex matches BOTH Georgian script (U+10D0–U+10FF) AND the
+ * Latin transliteration TBC actually sends in production. Real-world SMS
+ * dumped from chat.db on 2026-05-05 had headers like "Charicxva:",
+ * "Gadaricxva:", "Ukugatareba:", "Mobiluris shevseba:", and balances like
+ * "Nashti:" — so the parser missed every keyworded transaction (incoming
+ * credits, outgoing transfers, mobile top-ups, reversals, ATM withdrawals)
+ * and only got card payments right (those don't depend on a header keyword,
+ * just on a bare amount-currency line + card-parens marker). Card payments
+ * lulled the test suite into thinking the parser worked.
  *
  * Handles:
- *   ჩარიცხვა:          incoming transfer     → transfer_in   (in)
- *   გადარიცხვა:        outgoing transfer     → transfer_out  (out)
- *   სესხის დაფარვა:    loan repayment        → loan_repayment (out)
- *   საბარათე ოპერაცია … უარყოფილია           → payment_failed (out)
- *   უკუგატარება:       card reversal         → reversal       (in)
- *   NNN CUR + card line + merchant           → payment        (out)
- *   გადახდა:           bill / utility pay    → transfer_out  (out)
- *   მობილურის შევსება: mobile top-up         → transfer_out  (out)
- *   ავტომატური გადარიცხვა: scheduled auto    → transfer_out  (out)
- *   ნაღდი ფულის შეტანა: cash deposit         → deposit        (in)
- *   თანხის განაღდება:  ATM cash withdrawal   → atm_withdrawal (out)
+ *   ჩარიცხვა / Charicxva:                    incoming transfer  → transfer_in   (in)
+ *   გადარიცხვა / Gadaricxva:                 outgoing transfer  → transfer_out  (out)
+ *   სესხის დაფარვა / Sesxis dapharva:        loan repayment     → loan_repayment (out)
+ *   საბარათე ოპერაცია … უარყოფილია /
+ *     Sabarate operacia … uarYofiliA         failed card pay    → payment_failed (out)
+ *   უკუგატარება / Ukugatareba:               card reversal      → reversal       (in)
+ *   NNN CUR + card line + merchant           card payment       → payment        (out)
+ *   გადახდა / Gadaxda:                       bill / utility     → transfer_out   (out)
+ *   მობილურის შევსება / Mobiluris shevseba:  mobile top-up      → transfer_out   (out)
+ *   ავტომატური გადარიცხვა /
+ *     Avtomaturi gadaricxva                  scheduled auto     → transfer_out   (out)
+ *   ნაღდი ფულის შეტანა /
+ *     Naghdi pulis shetana:                  cash deposit       → deposit        (in)
+ *   თანხის განაღდება / Tanxis ganagdeba:     ATM cash withdraw  → atm_withdrawal (out)
  *
  * Marketing / OTP / security / investment notifications return null.
  */
@@ -35,67 +44,53 @@ import {
 const BANK_KEY = "TBC";
 
 // ── Self-transfer guard ────────────────────────────────────────────────────
-// საკუთარ ანგარიშზე (own-account transfer) — skip entirely.
-// U+10E1 U+10D0 U+10D9 U+10E3 U+10D7 U+10D0 U+10E0 = საKuTAr
-// U+10D0 U+10DC U+10D2 U+10D0 U+10E0 U+10D8 U+10E8 U+10D4 U+10D1 U+10D6 U+10D4 = ANGaRiShebZe
-const RE_SELF = /საკუთარ ანგარიშებზე/;
+// საკუთარ ანგარიშებზე / Sakutar angarishebze — skip entirely.
+const RE_SELF = /(?:საკუთარ ანგარიშებზე|[Ss]akutar angarishebze)/;
 
-// ── Incoming transfer (ჩარიცხვა: NNN CUR) ─────────────────────────────────
-// U+10E9 U+10D0 U+10E0 U+10D8 U+10EA U+10EE U+10D5 U+10D0 = ჩARicxVa
-const RE_INCOMING = /ჩარიცხვა:\s*([\d.,]+)\s*([A-Z]{3})/;
+// ── Incoming transfer (ჩარიცხვა / Charicxva: NNN CUR) ─────────────────────
+const RE_INCOMING = /(?:ჩარიცხვა|[Cc]haricxva):\s*([\d.,]+)\s*([A-Z]{3})/;
 
-// ── Outgoing transfer (გადარიცხვა:\nNNN CUR) ──────────────────────────────
-// U+10D2 U+10D0 U+10D3 U+10D0 U+10E0 U+10D8 U+10EA U+10EE U+10D5 U+10D0 = გადარიცხვა
-const RE_TRANSFER_OUT = /გადარიცხვა:\s*([\d.,]+)\s*([A-Z]{3})/;
+// ── Outgoing transfer (გადარიცხვა / Gadaricxva: NNN CUR) ──────────────────
+const RE_TRANSFER_OUT = /(?:გადარიცხვა|[Gg]adaricxva):\s*([\d.,]+)\s*([A-Z]{3})/;
 
-// ── Loan full repayment (სESxis dAFARVa: NNN CUR) ─────────────────────────
-// U+10E1 U+10D4 U+10E1 U+10EE U+10D8 U+10E1 = სESxis
-// U+10D3 U+10D0 U+10E4 U+10D0 U+10E0 U+10D5 U+10D0 = dAFARVa
-const RE_LOAN = /სესხის დაფარვა:\s*([\d.,]+)\s*([A-Z]{3})/;
+// ── Loan full repayment (სესხის დაფარვა / Sesxis dapharva: NNN CUR) ───────
+const RE_LOAN = /(?:სესხის დაფარვა|[Ss]esxis dapharva):\s*([\d.,]+)\s*([A-Z]{3})/;
 
-// ── Failed card payment (sabarate operacia NNN CUR uarYofiliA) ────────────
-// U+10E1 U+10D0 U+10D1 U+10D0 U+10E0 U+10D0 U+10D7 U+10D4 = sabarate
-// U+10DD U+10DE U+10D4 U+10E0 U+10D0 U+10EA U+10D8 U+10D0 = operacia
-// U+10E3 U+10D0 U+10E0 U+10E7 U+10DD U+10E4 U+10D8 U+10DA U+10D8 U+10D0 = uarYofiliA
-const RE_FAILED = /საბარათე ოპერაცია\s*([\d.,]+)\s*([A-Z]{3})\s*უარყოფილია/i;
+// ── Failed card payment (საბარათე ოპერაცია … უარყოფილია /
+//                        Sabarate operacia … uarYofiliA) ────────────────────
+const RE_FAILED = /(?:საბარათე ოპერაცია|[Ss]abarate operacia)\s*([\d.,]+)\s*([A-Z]{3})\s*(?:უარყოფილია|uar[Yy]ofili[Aa])/i;
 
-// ── Card reversal (uKUGatareba:\nNNN CUR\nCARD\nmerchant) ─────────────────
-// U+10E3 U+10D9 U+10E3 U+10D2 U+10D0 U+10E2 U+10D0 U+10E0 U+10D4 U+10D1 U+10D0 = uKUGatareba
-const RE_REVERSAL = /უკუგატარება:/;
+// ── Card reversal (უკუგატარება / Ukugatareba: …) ──────────────────────────
+const RE_REVERSAL = /(?:უკუგატარება|[Uu]kugatareba):/;
 
-// Inline shape — same SMS but everything on one line. Seen in the wild as e.g.
-// "უკუგატარება: 13.90 GEL TBC Concept 360 VISA Signature (***8058) BOLTTAXI 05/05/2026 17:25:01 ნაშთი: 400.00 GEL"
+// Inline shape — same SMS but everything on one line. Real example:
+// "Ukugatareba: 13.90 GEL TBC Concept 360 VISA Signature (***8058) BOLTTAXI
+//  05/05/2026 17:25:01 nashti: 400.00 GEL"
 // Captures the amount + currency right after the header so detect() can fire
 // without needing the line-anchored RE_CARD_AMOUNT to also match.
-const RE_REVERSAL_INLINE = /უკუგატარება:\s*([\d.,]+)\s*([A-Z]{3})/;
+const RE_REVERSAL_INLINE = /(?:უკუგატარება|[Uu]kugatareba):\s*([\d.,]+)\s*([A-Z]{3})/;
 
-// ── Bill / utility payment (გAdaXda:\nNNN CUR\nMERCHANT) ──────────────────
-// U+10D2 U+10D0 U+10D3 U+10D0 U+10EE U+10D3 U+10D0 = გAdaXda (note: ხ ≠ რ in გAdaRicxVa)
-const RE_BILL = /გადახდა:\s*([\d.,]+)\s*([A-Z]{3})/;
+// ── Bill / utility payment (გადახდა / Gadakhda: NNN CUR) ──────────────────
+// Latin form varies in the wild: "Gadakhda" and "Gadaxda" both seen. Allow
+// both spellings via an optional "k". Distinct from "Gadaricxva" — the
+// preceding word boundary stops "Gadaricxva" from matching here by accident.
+const RE_BILL = /(?:გადახდა|[Gg]ada(?:kh|x)da):\s*([\d.,]+)\s*([A-Z]{3})/;
 
-// ── Mobile top-up (მobIlURIs ShEvSeba:\nNNN CUR\nMERCHANT) ───────────────
-// U+10DB U+10DD U+10D1 U+10D8 U+10DA U+10E3 U+10E0 U+10D8 U+10E1 = მobIlURIs
-// U+10E8 U+10D4 U+10D5 U+10E1 U+10D4 U+10D1 U+10D0 = ShEvSeba
-const RE_MOBILE = /მობილურის შევსება:\s*([\d.,]+)\s*([A-Z]{3})/;
+// ── Mobile top-up (მობილურის შევსება / Mobiluris shevseba: …) ─────────────
+const RE_MOBILE = /(?:მობილურის შევსება|[Mm]obiluris shevseba):\s*([\d.,]+)\s*([A-Z]{3})/;
 
-// ── Scheduled auto-transfer (AvtomATUri GAdaRicXVa\nNNN CUR\nMERCHANT) ───
-// U+10D0 U+10D5 U+10E2 U+10DD U+10DB U+10D0 U+10E2 U+10E3 U+10E0 U+10D8 = AvtomATUri
-const RE_AUTO = /ავტომატური გადარიცხვა\s*([\d.,]+)\s*([A-Z]{3})/;
+// ── Scheduled auto-transfer (ავტომატური გადარიცხვა /
+//                             Avtomaturi gadaricxva) ──────────────────────
+const RE_AUTO = /(?:ავტომატური გადარიცხვა|[Aa]vtomaturi gadaricxva)\s*([\d.,]+)\s*([A-Z]{3})/;
 
-// ── Cash deposit (naGDI fulis SheTaNa:\nTaNXa: NNN CUR) ───────────────────
-// U+10DC U+10D0 U+10E6 U+10D3 U+10D8 = naGDI
-// U+10E4 U+10E3 U+10DA U+10D8 U+10E1 = fulis
-// U+10E8 U+10D4 U+10E2 U+10D0 U+10DC U+10D0 = SheTaNa
-const RE_DEPOSIT = /ნაღდი ფულის შეტანა:/;
+// ── Cash deposit (ნაღდი ფულის შეტანა / Naghdi pulis shetana:) ─────────────
+const RE_DEPOSIT = /(?:ნაღდი ფულის შეტანა|[Nn]aghdi pulis shetana):/;
 
-// ── ATM cash withdrawal (TaNXIs GaNaGdeba:\nDATE\nTaNXa: NNN CUR) ─────────
-// U+10D7 U+10D0 U+10DC U+10EE U+10D8 U+10E1 = TaNXIs
-// U+10D2 U+10D0 U+10DC U+10D0 U+10E6 U+10D3 U+10D4 U+10D1 U+10D0 = GaNaGdeba
-const RE_ATM = /თანხის განაღდება:/;
+// ── ATM cash withdrawal (თანხის განაღდება / Tanxis ganagdeba:) ────────────
+const RE_ATM = /(?:თანხის განაღდება|[Tt]anxis ganagdeba):/;
 
-// ── Amount label used in deposit/ATM/auto (TaNXa: NNN CUR) ────────────────
-// U+10D7 U+10D0 U+10DC U+10EE U+10D0 = TaNXa
-const RE_TANXA = /თანხა:\s*([\d.,]+)\s*([A-Z]{3})/;
+// ── Amount label used in deposit/ATM/auto (თანხა / Tanxa: NNN CUR) ────────
+const RE_TANXA = /(?:თანხა|[Tt]anxa):\s*([\d.,]+)\s*([A-Z]{3})/;
 
 // ── Generic card-payment amount: bare "NNN.NN CUR" line ───────────────────
 // Optional leading ")" covers TBC municipal transport taps.
@@ -105,20 +100,19 @@ const RE_CARD_AMOUNT = /^\s*\)?\s*([\d.,]+)\s*([A-Z]{3})\s*$/m;
 const RE_CARD_PARENS = /\(\s*\*{3,}'?(\d{3,4})'?\s*\)/;
 const RE_CARD_STARS  = /\*{3,}(\d{3,4})/;
 
-// ── Balance (ნAshTi: NNN CUR) ──────────────────────────────────────────────
-// U+10DC U+10D0 U+10E8 U+10D7 U+10D8 = ნAshTi
-const RE_BALANCE = /ნაშთი:\s*([\d.,]+)\s*([A-Z]{3})/;
+// ── Balance (ნაშთი / Nashti: NNN CUR) ─────────────────────────────────────
+// Real-world TBC SMS varies the casing — "Nashti:" on most card-payment SMS
+// but "nashti:" lowercase on some inline reversals. The [Nn] handles both.
+const RE_BALANCE = /(?:ნაშთი|[Nn]ashti):\s*([\d.,]+)\s*([A-Z]{3})/;
 
-// ── Failure reason (მiZeZi: text) ─────────────────────────────────────────
-// U+10DB U+10D8 U+10D6 U+10D4 U+10D6 U+10D8 = მiZeZi
-const RE_REASON = /მიზეზი:\s*(.+)/i;
+// ── Failure reason (მიზეზი / Mizezi: text) ───────────────────────────────
+const RE_REASON = /(?:მიზეზი|[Mm]izezi):\s*(.+)/i;
 
-// ── Loan source account (ANGaRiShIdaN: accountName) ────────────────────────
-// U+10D0 U+10DC U+10D2 U+10D0 U+10E0 U+10D8 U+10E8 U+10D8 U+10D3 U+10D0 U+10DC = ANGaRiShIdaN
-const RE_SOURCE_ACCOUNT = /ანგარიშიდან:\s*(.+?)(?:\s*$)/im;
+// ── Loan source account (ანგარიშიდან / Angarishidan: accountName) ─────────
+const RE_SOURCE_ACCOUNT = /(?:ანგარიშიდან|[Aa]ngarishidan):\s*(.+?)(?:\s*$)/im;
 
-// ── Loan remaining balance (სESxis ნAshTi: NNN CUR) ───────────────────────
-const RE_LOAN_REMAINING = /სესხის ნაშთი:\s*([\d.,]+)\s*([A-Z]{3})/;
+// ── Loan remaining balance (სესხის ნაშთი / Sesxis nashti: NNN CUR) ────────
+const RE_LOAN_REMAINING = /(?:სესხის ნაშთი|[Ss]esxis nashti):\s*([\d.,]+)\s*([A-Z]{3})/;
 
 // ── Account hint lines that are NOT counterparty names ────────────────────
 const RE_ACCOUNT_HINT = /^\s*(Current|Space Card|Expired deposits account|VISA GOLD|[A-Z][A-Za-z ]+ account)\s*$/;


### PR DESCRIPTION
The TBC parser had regexes that only matched Georgian script — ჩარიცხვა, გადარიცხვა, უკუგატარება, მობილურის შევსება, ნაშთი, etc — but production TBC SMS actually arrive in Latin transliteration. So every keyword-headed transaction (incoming credits, outgoing transfers, mobile top-ups, reversals, ATM withdrawals) silently fell off the dashboard. Card payments still worked because their detection doesn't depend on a header keyword — they match a bare amount-currency line plus the `(***NNNN)` card marker. That accident is what masked the bug for so long: card payments are a big chunk of the dashboard, so it looked plausible.

I caught it from a chat.db dump on May 5, 2026 — a ₾12,000 incoming credit at 14:45, two outgoing transfers totalling ₾970 to a TBC CARD account, two ₾10 Silknet mobile top-ups, and a BOLTTAXI refund were all missing from that day's ledger. The reversal miss was the worst of them: the inline-reversal fix that shipped in v0.5.2 only detected the Georgian header, so the Latin "Ukugatareba: 13.90 GEL ... BOLTTAXI ... nashti: 400.00 GEL" SMS fell through to the generic-card-payment branch and counted the refund as outgoing spending. Doubly wrong.

Every detection regex now uses `(?:GEORGIAN|[Ll]atin)` alternation, so the same SMS in either encoding classifies identically. RE_BALANCE accepts both `Nashti` and `nashti` casing because the inline reversal SMS uses lowercase while card-payment SMS use uppercase. RE_BILL takes both `Gadakhda` and `Gadaxda` since TBC has used both spellings. The other parsers — SOLO, Liberty, Basis, Credo, Tera — are untouched.

Test suite gains 13 new fixtures that mirror the actual SMS bodies pulled from the chat.db dump: incoming and outgoing transfers, mobile top-up, inline plus multi-line reversals, ATM withdrawal, cash deposit, scheduled auto-transfer, bill payment, failed card payment, loan repayment, plus a card-payment-with-`Nashti`-balance regression guard. All 46 existing Georgian-script fixtures still pass. 215 total service tests, `tsc --noEmit` clean.

After upgrading, real installs need a fresh sync to pick up historical SMS the parser previously skipped. The state.db cursor only advances past parseable SMS by design, so the previously-ignored messages are still in chat.db and the new regexes will catch them on the next service sync without manual intervention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Latin transliteration support added for multi-language transaction parsing
  * Expanded transaction type coverage including transfers, reversals, deposits, ATM withdrawals, mobile top-ups, bill payments, and card payments
  * Enhanced balance extraction and failure reason parsing capabilities

* **Tests**
  * Comprehensive test suite added for Latin transliteration variants and transaction types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->