### PR TITLE
Honor per-transaction category overrides in dashboard analytics

### DIFF
--- a/client/src/hooks/useCategories.ts
+++ b/client/src/hooks/useCategories.ts
@@ -127,9 +127,10 @@ export function useCategoryAnalytics() {
 
     // Categorize payments — uses the override-aware categoriser so a
     // user's manual "Spotify → Subscriptions" override propagates here
-    // even though the regex default puts it under "Other".
+    // even though the regex default puts it under "Other". Pass
+    // payment.id so per-transaction overrides also flow through.
     for (const payment of payments) {
-      const categoryName = categorizeName(payment.merchant ?? null);
+      const categoryName = categorizeName(payment.merchant ?? null, payment.id);
       if (categoryTotals[categoryName]) {
         categoryTotals[categoryName].total += payment.amount;
         categoryTotals[categoryName].count += 1;

--- a/client/src/hooks/useCategorizer.ts
+++ b/client/src/hooks/useCategorizer.ts
@@ -26,9 +26,13 @@ export interface Categorizer {
   /** Returns the full InkCategory record with name + color + icon.
    *  Pass paymentId to honour per-transaction overrides (higher priority). */
   getCategory: (merchant: string | null | undefined, raw?: string | null, paymentId?: string | null) => InkCategory;
-  /** Convenience for places that historically called `autoCategorize`
-   *  to get the human-facing category name (e.g. "Groceries"). */
-  categorizeName: (merchant: string | null | undefined) => string;
+  /** Convenience for places that need the human-facing category name
+   *  (e.g. "Groceries") instead of the id. Pass paymentId to honour
+   *  per-transaction overrides; without it only the per-merchant
+   *  override + regex fallback are applied. Analytics aggregators that
+   *  iterate payments with a known id should always pass it so the
+   *  user's per-tx classification flows through to totals/donut/etc. */
+  categorizeName: (merchant: string | null | undefined, paymentId?: string | null) => string;
   /** Merged list of DEFAULT_CATEGORIES + DB-backed categories (DB wins
    *  on id collision so a renamed default uses the user's name).
    *  Use this anywhere you'd previously have hardcoded `DEFAULT_CATEGORIES`
@@ -148,7 +152,8 @@ export function useCategorizer(): Categorizer {
   );
 
   const categorizeName = useCallback(
-    (merchant: string | null | undefined): string => getCategory(merchant).name,
+    (merchant: string | null | undefined, paymentId?: string | null): string =>
+      getCategory(merchant, undefined, paymentId).name,
     [getCategory]
   );
 

--- a/client/src/hooks/useMonthlyAnalytics.ts
+++ b/client/src/hooks/useMonthlyAnalytics.ts
@@ -186,7 +186,12 @@ export function useRangeCategoryAnalytics(range: DateRange) {
       if (payment.excludedFromAnalytics) continue;
       if (!isInRange(payment.transactionDate, range)) continue;
       if (payment.gelAmount === null) continue;
-      const categoryName = categorizeName(payment.merchant ?? null);
+      // Pass payment.id so per-transaction overrides flow through to
+      // the donut + per-category totals; without it the hook only sees
+      // per-merchant overrides and the regex default. Per-tx
+      // reclassifications via /transactions row-level CategoryPicker
+      // would silently miss this aggregator otherwise.
+      const categoryName = categorizeName(payment.merchant ?? null, payment.id);
       if (categoryTotals[categoryName]) {
         categoryTotals[categoryName].total += payment.gelAmount;
         categoryTotals[categoryName].count += 1;

--- a/client/src/lib/ai/tools/readonly.ts
+++ b/client/src/lib/ai/tools/readonly.ts
@@ -57,7 +57,10 @@ const getMonthSummary: AITool = {
       m.total += p.gelAmount;
       m.count += 1;
       merchantTotals.set(merchant, m);
-      const category = ctx.categorizeName(p.merchant ?? null);
+      // Pass p.id so the model's category aggregations honour
+      // per-transaction overrides — without it, AI numbers diverge
+      // from /budgets and the donut for any one-off reclassified row.
+      const category = ctx.categorizeName(p.merchant ?? null, p.id);
       const c = categoryTotals.get(category) ?? { total: 0, count: 0 };
       c.total += p.gelAmount;
       c.count += 1;
@@ -160,7 +163,7 @@ const searchTransactions: AITool = {
           if (!haystack.includes(query)) continue;
         }
         if (category) {
-          const cat = ctx.categorizeName(p.merchant ?? null).toLowerCase();
+          const cat = ctx.categorizeName(p.merchant ?? null, p.id).toLowerCase();
           if (cat !== category) continue;
         }
         if (currency && p.currency.toUpperCase() !== currency) continue;
@@ -178,7 +181,7 @@ const searchTransactions: AITool = {
           amount: p.amount,
           currency: p.currency,
           gelAmount: p.gelAmount !== null ? Math.round(p.gelAmount) : null,
-          category: ctx.categorizeName(p.merchant ?? null),
+          category: ctx.categorizeName(p.merchant ?? null, p.id),
           card: p.cardLastDigits ?? null,
           excludedFromAnalytics: p.excludedFromAnalytics === true,
         });
@@ -260,7 +263,7 @@ const compareMonths: AITool = {
         if (!inRange(p.transactionDate) || p.gelAmount === null) continue;
         if (p.excludedFromAnalytics) continue;
         spent += p.gelAmount;
-        const cat = ctx.categorizeName(p.merchant ?? null);
+        const cat = ctx.categorizeName(p.merchant ?? null, p.id);
         cats.set(cat, (cats.get(cat) ?? 0) + p.gelAmount);
       }
       for (const c of ctx.credits) {
@@ -306,7 +309,7 @@ const listCategories: AITool = {
     for (const p of ctx.payments) {
       if (!inMonth(p.transactionDate) || p.gelAmount === null) continue;
       if (p.excludedFromAnalytics) continue;
-      const cat = ctx.categorizeName(p.merchant ?? null);
+      const cat = ctx.categorizeName(p.merchant ?? null, p.id);
       const v = monthTotals.get(cat) ?? { total: 0, count: 0 };
       v.total += p.gelAmount;
       v.count += 1;

--- a/client/src/lib/ai/tools/types.ts
+++ b/client/src/lib/ai/tools/types.ts
@@ -45,12 +45,13 @@ export interface AIToolContext {
    *  have been manually re-categorised. */
   overrides: MerchantCategoryOverride[];
   now: Date;
-  /** Override-aware category-name lookup for a merchant. Honours the
-   *  user's manual `merchantCategoryOverrides` rows; falls back to the
-   *  regex categoriser. Tools should always call this instead of the
-   *  static `autoCategorize` so an "I moved Spotify to Subscriptions"
-   *  override actually shows up in the AI's view of the data. */
-  categorizeName: (merchant: string | null | undefined) => string;
+  /** Override-aware category-name lookup for a merchant. Pass the
+   *  payment's InstantDB id as the second arg to honour per-transaction
+   *  overrides too — without it only per-merchant overrides + regex
+   *  apply, and the AI's totals will diverge from the dashboard for
+   *  any transaction the user re-categorised one-off via the row's
+   *  CategoryPicker on /transactions. */
+  categorizeName: (merchant: string | null | undefined, paymentId?: string | null) => string;
   /** Override-aware category-id lookup. Same priority order as the
    *  page's categoriser: per-transaction override (when paymentId
    *  given) > per-merchant override > regex on merchant + raw SMS.

--- a/client/src/pages/Analytics.tsx
+++ b/client/src/pages/Analytics.tsx
@@ -144,7 +144,7 @@ export function Analytics() {
           ) : (
             <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
               {largeTx.map((t) => {
-                const cat = getCategory(t.merchant, t.rawMessage);
+                const cat = getCategory(t.merchant, t.rawMessage, t.id);
                 return (
                   <div
                     key={t.id}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -59,7 +59,11 @@ export function Dashboard() {
       if (p.excludedFromAnalytics) continue;
       if (p.gelAmount === null) continue;
       if (!isWithinInterval(new Date(p.transactionDate), { start: range.start, end: range.end })) continue;
-      const cat = getCategory(p.merchant, p.rawMessage);
+      // Pass p.id so per-transaction overrides land in the right
+      // bucket. Without the third arg the donut sees only per-merchant
+      // overrides + regex defaults, so a user who reclassified a row
+      // via /transactions sees no shift here.
+      const cat = getCategory(p.merchant, p.rawMessage, p.id);
       if (!map[cat.id]) map[cat.id] = { total: 0, count: 0, meta: cat };
       map[cat.id].total += p.gelAmount;
       map[cat.id].count += 1;
@@ -83,7 +87,7 @@ export function Dashboard() {
         cardLastDigits: p.cardLastDigits,
         transactionDate: p.transactionDate,
         bankSenderId: p.bankSenderId,
-        category: getCategory(p.merchant, p.rawMessage).id,
+        category: getCategory(p.merchant, p.rawMessage, p.id).id,
         rawMessage: p.rawMessage,
         plusEarned: p.plusEarned,
         excludedFromAnalytics: p.excludedFromAnalytics,
@@ -98,7 +102,10 @@ export function Dashboard() {
         cardLastDigits: f.cardLastDigits,
         transactionDate: f.transactionDate,
         bankSenderId: f.bankSenderId,
-        category: getCategory(f.merchant, f.rawMessage).id,
+        // Failed payments don't get per-tx overrides today (there's no
+        // CategoryPicker on a failed row) but pass the id for symmetry
+        // and in case that surface ever opens up.
+        category: getCategory(f.merchant, f.rawMessage, f.id).id,
         rawMessage: f.rawMessage,
         failureReason: f.failureReason,
       })),


### PR DESCRIPTION
Per-transaction category overrides were silently ignored by every analytics path that didn't go through getCategory directly. Reclassify a single row on /transactions, switch to Overview, and the Spending Mix donut and per-category totals stayed exactly where they were. The override was being persisted correctly — the row itself updated and per-merchant overrides flowed through fine — but the donut, the recent-transactions feed, /signals analytics, the legacy useCategoryAnalytics hook, useRangeCategoryAnalytics, and five aggregation paths in the AI readonly tools all called categorizeName(merchant) or getCategory(merchant, raw) without the optional paymentId third arg. That third arg gates the per-transaction-override branch in useCategorizer; without it, the categorizer skips per-tx overrides and only sees per-merchant overrides + the regex default.

The first commit widens the categorizeName signature with an optional paymentId, mirroring what getCategory and categorize already accept, and the matching change to AIToolContext.categorizeName so AI tools can pass it through. Strictly additive interface change — every existing call site that doesn't have a paymentId continues to work unchanged.

The second commit threads payment.id through every per-transaction analytics call site that had been dropping it. The merchant-aggregated surfaces — Top Merchants tile color on the dashboard, the /merchants page row dot — intentionally stay merchant-only because per-transaction overrides don't apply to a tile that aggregates many transactions for one merchant. Failed payments pass f.id for symmetry but they have no per-tx override surface today.

No data migration needed. After deploying, the donut and totals will refresh on first render once the override-aware lookup runs against the existing transactionCategoryOverrides rows that were already in InstantDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed per-transaction category overrides to apply consistently across the application, including dashboards, analytics reports, search results, and AI-powered tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->