### PR TITLE
Add Must Pay planning page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "bun test src"
   },
   "dependencies": {
     "@instantdb/react": "^0.22.106",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Layout } from "./components/Layout";
-import { Dashboard, Transactions, Categories, Budgets, Merchants, Income, Signals, Settings, Assistant } from "./pages";
+import { Dashboard, Transactions, Categories, Budgets, Merchants, Income, Signals, Settings, Assistant, Plan } from "./pages";
 
 function App() {
   return (
@@ -13,6 +13,7 @@ function App() {
           <Route path="categories" element={<Categories />} />
           <Route path="budgets" element={<Budgets />} />
           <Route path="merchants" element={<Merchants />} />
+          <Route path="plan" element={<Plan />} />
           <Route path="assistant" element={<Assistant />} />
           <Route path="signals" element={<Signals />} />
           <Route path="manage" element={<Settings />} />

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -15,6 +15,7 @@ import {
 import { usePayments } from "../hooks/useTransactions";
 import { useSignals } from "../hooks/useSignals";
 import { useCredits } from "../hooks/useCredits";
+import { usePendingMustPayCount } from "../hooks/useMustPay";
 import { useHealth } from "../hooks/useHealth";
 import {
   Onboarding,
@@ -98,6 +99,7 @@ function ConfiguredShell() {
   const { payments } = usePayments();
   const signals = useSignals();
   const { credits } = useCredits();
+  const mustPayCount = usePendingMustPayCount();
   return (
     <>
       <div
@@ -110,6 +112,7 @@ function ConfiguredShell() {
           txCount={payments.length}
           incomeCount={credits.length}
           signalsCount={signals.activeCount || undefined}
+          mustPayCount={mustPayCount || undefined}
         />
         <main
           style={{

--- a/client/src/dev/demoData.ts
+++ b/client/src/dev/demoData.ts
@@ -7,7 +7,7 @@
 // from `./demoDb`, which itself is only reached behind a static
 // `import.meta.env.DEV && isDemoMode()` gate in `lib/instant.ts`.
 
-import type { Payment, FailedPayment, Credit, Category, BankSender, BudgetPlan } from "../lib/instant";
+import type { Payment, FailedPayment, Credit, Category, BankSender, BudgetPlan, MustPayItem, MustPayState } from "../lib/instant";
 import { DEFAULT_CATEGORIES } from "../lib/utils";
 
 function mulberry32(seed: number) {
@@ -434,6 +434,72 @@ export interface DemoDataset {
   categories: Category[];
   bankSenders: BankSender[];
   budgetPlans: BudgetPlan[];
+  mustPayItems: MustPayItem[];
+  mustPayState: MustPayState[];
+}
+
+// Seeded must-pay list. Mix of recurring monthly bills + a one-off,
+// plus one row marked paid this cycle so the strike-through state is
+// visible in demo mode without the demo viewer having to click first.
+function buildMustPayItems(now: Date): MustPayItem[] {
+  const ts = now.getTime();
+  return [
+    {
+      id: "mp-rent",
+      title: "Rent",
+      amountGEL: 800,
+      lastPaidAt: undefined,
+      isRecurring: true,
+      createdAt: ts - 30 * 24 * 3600 * 1000,
+      updatedAt: ts - 30 * 24 * 3600 * 1000,
+    },
+    {
+      id: "mp-loan",
+      title: "Car loan",
+      amountGEL: 450,
+      lastPaidAt: undefined,
+      isRecurring: true,
+      notes: "Auto-deducts on the 5th",
+      createdAt: ts - 60 * 24 * 3600 * 1000,
+      updatedAt: ts - 60 * 24 * 3600 * 1000,
+    },
+    {
+      id: "mp-friend",
+      title: "Pay back Luka",
+      amountGEL: 200,
+      lastPaidAt: undefined,
+      isRecurring: false,
+      notes: "Borrowed for concert tickets",
+      createdAt: ts - 5 * 24 * 3600 * 1000,
+      updatedAt: ts - 5 * 24 * 3600 * 1000,
+    },
+    {
+      id: "mp-subs",
+      title: "Spotify + Netflix",
+      amountGEL: 60,
+      // Already paid this cycle — shows the strike-through state on
+      // demo load so reviewers see the visual without interacting.
+      lastPaidAt: ts - 3 * 24 * 3600 * 1000,
+      isRecurring: true,
+      createdAt: ts - 90 * 24 * 3600 * 1000,
+      updatedAt: ts - 3 * 24 * 3600 * 1000,
+    },
+  ];
+}
+
+function buildMustPayState(): MustPayState[] {
+  // Pot seeded at ₾2000 — well above the ₾1450 of unpaid obligations
+  // in buildMustPayItems so the headline "Free" figure renders green.
+  // Drop this lower (e.g. 1200) if you want demo viewers to land
+  // straight on the overdrawn warning state.
+  return [
+    {
+      id: "mps-singleton",
+      key: "singleton",
+      currentPotGEL: 2000,
+      updatedAt: Date.now(),
+    },
+  ];
 }
 
 // Two months of budgetPlans seeded for the demo: the current month
@@ -481,6 +547,8 @@ export function buildDemoDataset(seed: "default" | "empty"): DemoDataset {
       categories: [],
       bankSenders: [],
       budgetPlans: [],
+      mustPayItems: [],
+      mustPayState: [],
     };
   }
   const rng = mulberry32(20260424);
@@ -492,5 +560,7 @@ export function buildDemoDataset(seed: "default" | "empty"): DemoDataset {
     categories: CATEGORIES,
     bankSenders: SENDERS,
     budgetPlans: buildBudgetPlans(now),
+    mustPayItems: buildMustPayItems(now),
+    mustPayState: buildMustPayState(),
   };
 }

--- a/client/src/dev/demoDb.ts
+++ b/client/src/dev/demoDb.ts
@@ -36,6 +36,8 @@ function seed(dataset: DemoDataset) {
   store.set("categories", dataset.categories as unknown as AnyRecord[]);
   store.set("bankSenders", dataset.bankSenders as unknown as AnyRecord[]);
   store.set("budgetPlans", dataset.budgetPlans as unknown as AnyRecord[]);
+  store.set("mustPayItems", dataset.mustPayItems as unknown as AnyRecord[]);
+  store.set("mustPayState", dataset.mustPayState as unknown as AnyRecord[]);
 }
 
 function getSnapshot(collection: Collection): readonly AnyRecord[] {

--- a/client/src/hooks/__tests__/useMustPay.test.ts
+++ b/client/src/hooks/__tests__/useMustPay.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
-  isItemPaidThisCycle,
+  isItemPaid,
   summarizeMustPay,
   computePotMath,
 } from "../useMustPay";
@@ -13,6 +13,9 @@ function item(over: Partial<MustPayItem> = {}): MustPayItem {
     title: over.title ?? "Test item",
     amountGEL: over.amountGEL ?? 100,
     lastPaidAt: over.lastPaidAt,
+    // The design dropped the recurring toggle but the schema field
+    // stays — every new item is one-off. Default to false here so
+    // fixtures don't have to specify it.
     isRecurring: over.isRecurring ?? false,
     notes: over.notes,
     dueDate: over.dueDate,
@@ -21,56 +24,33 @@ function item(over: Partial<MustPayItem> = {}): MustPayItem {
   };
 }
 
-const MAY_15 = new Date("2026-05-15T12:00:00Z");
-const MAY_1 = new Date("2026-05-01T08:00:00Z");
-const APR_28 = new Date("2026-04-28T10:00:00Z");
-const APR_30 = new Date("2026-04-30T23:59:00Z");
-const MAY_2025 = new Date("2025-05-15T12:00:00Z");
-
-describe("isItemPaidThisCycle", () => {
+describe("isItemPaid", () => {
   test("never-paid item is unpaid", () => {
-    expect(isItemPaidThisCycle(item({ lastPaidAt: undefined }), MAY_15)).toBe(false);
+    expect(isItemPaid(item({ lastPaidAt: undefined }))).toBe(false);
   });
 
-  test("non-recurring with lastPaidAt is permanently paid", () => {
-    // Paid a year ago, still counts as done because it was a one-off.
-    expect(
-      isItemPaidThisCycle(item({ isRecurring: false, lastPaidAt: MAY_2025.getTime() }), MAY_15)
-    ).toBe(true);
+  test("item with any lastPaidAt is paid", () => {
+    expect(isItemPaid(item({ lastPaidAt: Date.now() }))).toBe(true);
   });
 
-  test("recurring item paid this month is paid", () => {
-    expect(
-      isItemPaidThisCycle(item({ isRecurring: true, lastPaidAt: MAY_1.getTime() }), MAY_15)
-    ).toBe(true);
+  test("paid is paid forever — last year's lastPaidAt still counts", () => {
+    // The design removed the auto-month-rollover feature. Once paid,
+    // an item stays paid until the user explicitly unchecks it.
+    const yearAgo = new Date("2025-05-15").getTime();
+    expect(isItemPaid(item({ lastPaidAt: yearAgo }))).toBe(true);
   });
 
-  test("recurring item paid last month is unpaid (rollover)", () => {
-    expect(
-      isItemPaidThisCycle(item({ isRecurring: true, lastPaidAt: APR_28.getTime() }), MAY_15)
-    ).toBe(false);
-  });
-
-  test("recurring item paid on the last second of last month rolls over", () => {
-    // Boundary check — Apr 30 23:59 is still April, so on May 1+ it
-    // should be unpaid again. Catches off-by-one bugs in month math.
-    expect(
-      isItemPaidThisCycle(item({ isRecurring: true, lastPaidAt: APR_30.getTime() }), MAY_1)
-    ).toBe(false);
-  });
-
-  test("recurring item paid same month last year is unpaid (not just same-month)", () => {
-    // "May 2025" is not the same cycle as "May 2026" — isSameMonth from
-    // date-fns considers year, so this should NOT count as paid.
-    expect(
-      isItemPaidThisCycle(item({ isRecurring: true, lastPaidAt: MAY_2025.getTime() }), MAY_15)
-    ).toBe(false);
+  test("lastPaidAt of 0 still counts as paid", () => {
+    // Edge case: epoch zero is a valid timestamp; only null/undefined
+    // mean "never paid". A regression here would silently hide rows
+    // that got toggled at a weird system clock.
+    expect(isItemPaid(item({ lastPaidAt: 0 }))).toBe(true);
   });
 });
 
 describe("summarizeMustPay", () => {
   test("empty list returns zeros", () => {
-    expect(summarizeMustPay([], MAY_15)).toEqual({
+    expect(summarizeMustPay([])).toEqual({
       pendingCount: 0,
       pendingTotal: 0,
       paidCount: 0,
@@ -80,12 +60,12 @@ describe("summarizeMustPay", () => {
 
   test("mixed paid/unpaid sums correctly", () => {
     const items = [
-      item({ amountGEL: 100, isRecurring: false, lastPaidAt: undefined }), // pending
-      item({ amountGEL: 200, isRecurring: false, lastPaidAt: MAY_1.getTime() }), // paid (one-off)
-      item({ amountGEL: 50, isRecurring: true, lastPaidAt: MAY_1.getTime() }), // paid (recurring this month)
-      item({ amountGEL: 75, isRecurring: true, lastPaidAt: APR_28.getTime() }), // pending (rolled over)
+      item({ amountGEL: 100, lastPaidAt: undefined }), // pending
+      item({ amountGEL: 200, lastPaidAt: Date.now() }), // paid
+      item({ amountGEL: 50, lastPaidAt: Date.now() }), // paid
+      item({ amountGEL: 75, lastPaidAt: undefined }), // pending
     ];
-    expect(summarizeMustPay(items, MAY_15)).toEqual({
+    expect(summarizeMustPay(items)).toEqual({
       pendingCount: 2,
       pendingTotal: 175,
       paidCount: 2,
@@ -93,54 +73,63 @@ describe("summarizeMustPay", () => {
     });
   });
 
-  test("all recurring items paid this month → pending sum is 0", () => {
+  test("all items paid → pending sum is 0", () => {
     const items = [
-      item({ amountGEL: 800, isRecurring: true, lastPaidAt: MAY_1.getTime() }),
-      item({ amountGEL: 1200, isRecurring: true, lastPaidAt: MAY_1.getTime() }),
+      item({ amountGEL: 800, lastPaidAt: Date.now() }),
+      item({ amountGEL: 1200, lastPaidAt: Date.now() }),
     ];
-    expect(summarizeMustPay(items, MAY_15).pendingTotal).toBe(0);
+    expect(summarizeMustPay(items).pendingTotal).toBe(0);
   });
 
-  test("recurring items paid last month roll into pending", () => {
-    // Mirrors the real-world "I marked rent paid in April, now it's
-    // May and rent is due again" flow that's the whole point of the
-    // recurring flag.
+  test("all items unpaid → paid sum is 0", () => {
     const items = [
-      item({ amountGEL: 800, isRecurring: true, lastPaidAt: APR_28.getTime() }),
-      item({ amountGEL: 1200, isRecurring: true, lastPaidAt: APR_28.getTime() }),
+      item({ amountGEL: 800, lastPaidAt: undefined }),
+      item({ amountGEL: 1200, lastPaidAt: undefined }),
     ];
-    expect(summarizeMustPay(items, MAY_15)).toEqual({
-      pendingCount: 2,
-      pendingTotal: 2000,
-      paidCount: 0,
-      paidTotal: 0,
-    });
+    expect(summarizeMustPay(items).paidTotal).toBe(0);
   });
 });
 
 describe("computePotMath", () => {
-  test("pot 100, pending 60 → free 40, not overdrawn", () => {
-    expect(computePotMath(100, 60)).toEqual({ free: 40, isOverdrawn: false });
+  test("pot 100, pending 60, paid 0 → free 40, not overdrawn", () => {
+    expect(computePotMath(100, 60, 0)).toEqual({ free: 40, isOverdrawn: false });
   });
 
-  test("pot 50, pending 60 → free -10, overdrawn", () => {
-    expect(computePotMath(50, 60)).toEqual({ free: -10, isOverdrawn: true });
+  test("marking an item paid does NOT change free", () => {
+    // Core invariant: Free = Pot − (Pending + Paid). The split between
+    // pending and paid is workflow state, not flow. Moving money from
+    // the pending bucket to the paid bucket keeps the same total
+    // obligations and the same free figure. This is the bug fix the
+    // user explicitly called out — checking an item used to inflate
+    // Free, which they read as "checking means I got richer."
+    const beforeCheck = computePotMath(100, 60, 0); // 60 pending, 0 paid
+    const afterCheck = computePotMath(100, 0, 60); // 60 moved into paid
+    expect(beforeCheck.free).toBe(afterCheck.free);
+    expect(beforeCheck.free).toBe(40);
   });
 
-  test("pot 0, pending 0 → free 0, not overdrawn", () => {
-    expect(computePotMath(0, 0)).toEqual({ free: 0, isOverdrawn: false });
+  test("pot 50, pending 60, paid 0 → free -10, overdrawn", () => {
+    expect(computePotMath(50, 60, 0)).toEqual({ free: -10, isOverdrawn: true });
   });
 
-  test("pot 100, pending 100 → free 0, not overdrawn (exact match)", () => {
+  test("paid obligations alone can overdraw the pot", () => {
+    // Pot 100, no pending, 200 already paid — total obligations
+    // exceed pot, free should be -100 overdrawn.
+    expect(computePotMath(100, 0, 200)).toEqual({ free: -100, isOverdrawn: true });
+  });
+
+  test("mixed pending + paid sum correctly", () => {
+    expect(computePotMath(1000, 600, 300)).toEqual({ free: 100, isOverdrawn: false });
+  });
+
+  test("pot 0, pending 0, paid 0 → free 0, not overdrawn", () => {
+    expect(computePotMath(0, 0, 0)).toEqual({ free: 0, isOverdrawn: false });
+  });
+
+  test("pot 100, total obligations 100 → free 0, not overdrawn (exact match)", () => {
     // Edge: zero free isn't overdrawn. The accent-color warning only
-    // fires on strict-less-than-zero.
-    expect(computePotMath(100, 100)).toEqual({ free: 0, isOverdrawn: false });
-  });
-
-  test("pot 0, pending 50 → free -50, overdrawn", () => {
-    // Common real-world case: user hasn't entered their pot yet but
-    // already has obligations. The page should show "Over by ₾50"
-    // so they know to set the pot.
-    expect(computePotMath(0, 50)).toEqual({ free: -50, isOverdrawn: true });
+    // fires on strict-less-than-zero. Whether the obligations are
+    // pending, paid, or mixed shouldn't matter.
+    expect(computePotMath(100, 70, 30)).toEqual({ free: 0, isOverdrawn: false });
   });
 });

--- a/client/src/hooks/__tests__/useMustPay.test.ts
+++ b/client/src/hooks/__tests__/useMustPay.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isItemPaidThisCycle,
+  summarizeMustPay,
+  computePotMath,
+} from "../useMustPay";
+import type { MustPayItem } from "../../lib/instant";
+
+// Compact factory so each fixture row reads as one line.
+function item(over: Partial<MustPayItem> = {}): MustPayItem {
+  return {
+    id: over.id ?? "row-" + Math.random().toString(36).slice(2, 8),
+    title: over.title ?? "Test item",
+    amountGEL: over.amountGEL ?? 100,
+    lastPaidAt: over.lastPaidAt,
+    isRecurring: over.isRecurring ?? false,
+    notes: over.notes,
+    dueDate: over.dueDate,
+    createdAt: over.createdAt ?? Date.now(),
+    updatedAt: over.updatedAt ?? Date.now(),
+  };
+}
+
+const MAY_15 = new Date("2026-05-15T12:00:00Z");
+const MAY_1 = new Date("2026-05-01T08:00:00Z");
+const APR_28 = new Date("2026-04-28T10:00:00Z");
+const APR_30 = new Date("2026-04-30T23:59:00Z");
+const MAY_2025 = new Date("2025-05-15T12:00:00Z");
+
+describe("isItemPaidThisCycle", () => {
+  test("never-paid item is unpaid", () => {
+    expect(isItemPaidThisCycle(item({ lastPaidAt: undefined }), MAY_15)).toBe(false);
+  });
+
+  test("non-recurring with lastPaidAt is permanently paid", () => {
+    // Paid a year ago, still counts as done because it was a one-off.
+    expect(
+      isItemPaidThisCycle(item({ isRecurring: false, lastPaidAt: MAY_2025.getTime() }), MAY_15)
+    ).toBe(true);
+  });
+
+  test("recurring item paid this month is paid", () => {
+    expect(
+      isItemPaidThisCycle(item({ isRecurring: true, lastPaidAt: MAY_1.getTime() }), MAY_15)
+    ).toBe(true);
+  });
+
+  test("recurring item paid last month is unpaid (rollover)", () => {
+    expect(
+      isItemPaidThisCycle(item({ isRecurring: true, lastPaidAt: APR_28.getTime() }), MAY_15)
+    ).toBe(false);
+  });
+
+  test("recurring item paid on the last second of last month rolls over", () => {
+    // Boundary check — Apr 30 23:59 is still April, so on May 1+ it
+    // should be unpaid again. Catches off-by-one bugs in month math.
+    expect(
+      isItemPaidThisCycle(item({ isRecurring: true, lastPaidAt: APR_30.getTime() }), MAY_1)
+    ).toBe(false);
+  });
+
+  test("recurring item paid same month last year is unpaid (not just same-month)", () => {
+    // "May 2025" is not the same cycle as "May 2026" — isSameMonth from
+    // date-fns considers year, so this should NOT count as paid.
+    expect(
+      isItemPaidThisCycle(item({ isRecurring: true, lastPaidAt: MAY_2025.getTime() }), MAY_15)
+    ).toBe(false);
+  });
+});
+
+describe("summarizeMustPay", () => {
+  test("empty list returns zeros", () => {
+    expect(summarizeMustPay([], MAY_15)).toEqual({
+      pendingCount: 0,
+      pendingTotal: 0,
+      paidCount: 0,
+      paidTotal: 0,
+    });
+  });
+
+  test("mixed paid/unpaid sums correctly", () => {
+    const items = [
+      item({ amountGEL: 100, isRecurring: false, lastPaidAt: undefined }), // pending
+      item({ amountGEL: 200, isRecurring: false, lastPaidAt: MAY_1.getTime() }), // paid (one-off)
+      item({ amountGEL: 50, isRecurring: true, lastPaidAt: MAY_1.getTime() }), // paid (recurring this month)
+      item({ amountGEL: 75, isRecurring: true, lastPaidAt: APR_28.getTime() }), // pending (rolled over)
+    ];
+    expect(summarizeMustPay(items, MAY_15)).toEqual({
+      pendingCount: 2,
+      pendingTotal: 175,
+      paidCount: 2,
+      paidTotal: 250,
+    });
+  });
+
+  test("all recurring items paid this month → pending sum is 0", () => {
+    const items = [
+      item({ amountGEL: 800, isRecurring: true, lastPaidAt: MAY_1.getTime() }),
+      item({ amountGEL: 1200, isRecurring: true, lastPaidAt: MAY_1.getTime() }),
+    ];
+    expect(summarizeMustPay(items, MAY_15).pendingTotal).toBe(0);
+  });
+
+  test("recurring items paid last month roll into pending", () => {
+    // Mirrors the real-world "I marked rent paid in April, now it's
+    // May and rent is due again" flow that's the whole point of the
+    // recurring flag.
+    const items = [
+      item({ amountGEL: 800, isRecurring: true, lastPaidAt: APR_28.getTime() }),
+      item({ amountGEL: 1200, isRecurring: true, lastPaidAt: APR_28.getTime() }),
+    ];
+    expect(summarizeMustPay(items, MAY_15)).toEqual({
+      pendingCount: 2,
+      pendingTotal: 2000,
+      paidCount: 0,
+      paidTotal: 0,
+    });
+  });
+});
+
+describe("computePotMath", () => {
+  test("pot 100, pending 60 → free 40, not overdrawn", () => {
+    expect(computePotMath(100, 60)).toEqual({ free: 40, isOverdrawn: false });
+  });
+
+  test("pot 50, pending 60 → free -10, overdrawn", () => {
+    expect(computePotMath(50, 60)).toEqual({ free: -10, isOverdrawn: true });
+  });
+
+  test("pot 0, pending 0 → free 0, not overdrawn", () => {
+    expect(computePotMath(0, 0)).toEqual({ free: 0, isOverdrawn: false });
+  });
+
+  test("pot 100, pending 100 → free 0, not overdrawn (exact match)", () => {
+    // Edge: zero free isn't overdrawn. The accent-color warning only
+    // fires on strict-less-than-zero.
+    expect(computePotMath(100, 100)).toEqual({ free: 0, isOverdrawn: false });
+  });
+
+  test("pot 0, pending 50 → free -50, overdrawn", () => {
+    // Common real-world case: user hasn't entered their pot yet but
+    // already has obligations. The page should show "Over by ₾50"
+    // so they know to set the pot.
+    expect(computePotMath(0, 50)).toEqual({ free: -50, isOverdrawn: true });
+  });
+});

--- a/client/src/hooks/useMustPay.ts
+++ b/client/src/hooks/useMustPay.ts
@@ -1,0 +1,160 @@
+import { useMemo } from "react";
+import { isSameMonth } from "date-fns";
+import { id } from "@instantdb/react";
+import { db, type MustPayItem, type MustPayState } from "../lib/instant";
+
+const SINGLETON_KEY = "singleton";
+
+export function useMustPayItems() {
+  const { data, isLoading, error } = db.useQuery({ mustPayItems: {} });
+  const items = useMemo(() => (data?.mustPayItems ?? []) as MustPayItem[], [data?.mustPayItems]);
+  return { items, isLoading, error };
+}
+
+/**
+ * The pot is a singleton — one row keyed "singleton" with the user's
+ * current wallet amount. We query everything in `mustPayState` and
+ * pick the first match instead of a where-filter so the hook works
+ * identically against the live db and the demo-db (which doesn't
+ * implement InstantDB's `$.where` syntax). The row count is bounded at
+ * 1 by the unique-key constraint so an unindexed scan is fine.
+ */
+export function useMustPayState() {
+  const { data, isLoading, error } = db.useQuery({ mustPayState: {} });
+  const state = useMemo(() => {
+    const rows = (data?.mustPayState ?? []) as MustPayState[];
+    return rows.find((r) => r.key === SINGLETON_KEY) ?? null;
+  }, [data?.mustPayState]);
+  return {
+    currentPotGEL: state?.currentPotGEL ?? 0,
+    updatedAt: state?.updatedAt ?? 0,
+    hasValue: state != null,
+    isLoading,
+    error,
+  };
+}
+
+export function useMustPayActions() {
+  const { data } = db.useQuery({ mustPayState: {} });
+
+  const create = async (input: {
+    title: string;
+    amountGEL: number;
+    isRecurring: boolean;
+    notes?: string;
+    dueDate?: number;
+  }) => {
+    const now = Date.now();
+    const itemId = id();
+    await db.transact(
+      db.tx.mustPayItems[itemId].update({
+        ...input,
+        createdAt: now,
+        updatedAt: now,
+      })
+    );
+    return itemId;
+  };
+
+  const update = async (itemId: string, patch: Partial<Omit<MustPayItem, "id" | "createdAt">>) => {
+    await db.transact(
+      db.tx.mustPayItems[itemId].update({ ...patch, updatedAt: Date.now() })
+    );
+  };
+
+  /**
+   * Toggling "paid" doesn't store a boolean — it sets or clears
+   * `lastPaidAt` and lets the consumer derive paid-ness from the
+   * timestamp via `isItemPaidThisCycle`. That's what gives recurring
+   * items their automatic month-rollover without any background job.
+   */
+  const togglePaid = async (item: MustPayItem) => {
+    const now = new Date();
+    const currentlyPaid = isItemPaidThisCycle(item, now);
+    await db.transact(
+      db.tx.mustPayItems[item.id].update({
+        lastPaidAt: currentlyPaid ? null : now.getTime(),
+        updatedAt: now.getTime(),
+      })
+    );
+  };
+
+  const remove = async (itemId: string) => {
+    await db.transact(db.tx.mustPayItems[itemId].delete());
+  };
+
+  /**
+   * Upsert the singleton pot. Find an existing row first so we hit
+   * `.update()` on the same id and InstantDB recognises it as an
+   * update rather than creating a second row that would conflict
+   * with the unique-key constraint. First-time callers get a fresh
+   * row id.
+   */
+  const setCurrentPot = async (amount: number) => {
+    const rows = (data?.mustPayState ?? []) as MustPayState[];
+    const existing = rows.find((r) => r.key === SINGLETON_KEY);
+    const rowId = existing?.id ?? id();
+    await db.transact(
+      db.tx.mustPayState[rowId].update({
+        key: SINGLETON_KEY,
+        currentPotGEL: amount,
+        updatedAt: Date.now(),
+      })
+    );
+  };
+
+  return { create, update, togglePaid, remove, setCurrentPot };
+}
+
+/**
+ * Counter for the sidebar pillBadge. Reads via useMustPayItems so
+ * Sidebar doesn't have to plumb a separate query — InstantDB
+ * deduplicates the underlying subscription anyway.
+ */
+export function usePendingMustPayCount(): number {
+  const { items } = useMustPayItems();
+  const now = new Date();
+  return items.filter((it) => !isItemPaidThisCycle(it, now)).length;
+}
+
+// ── Pure helpers (no React, no DB — unit-testable) ────────────────────────
+
+export function isItemPaidThisCycle(item: MustPayItem, now: Date = new Date()): boolean {
+  if (item.lastPaidAt == null) return false;
+  if (!item.isRecurring) return true;
+  return isSameMonth(new Date(item.lastPaidAt), now);
+}
+
+export interface MustPaySummary {
+  pendingCount: number;
+  pendingTotal: number;
+  paidCount: number;
+  paidTotal: number;
+}
+
+export function summarizeMustPay(items: MustPayItem[], now: Date = new Date()): MustPaySummary {
+  let pendingCount = 0;
+  let pendingTotal = 0;
+  let paidCount = 0;
+  let paidTotal = 0;
+  for (const it of items) {
+    if (isItemPaidThisCycle(it, now)) {
+      paidCount++;
+      paidTotal += it.amountGEL;
+    } else {
+      pendingCount++;
+      pendingTotal += it.amountGEL;
+    }
+  }
+  return { pendingCount, pendingTotal, paidCount, paidTotal };
+}
+
+export interface PotMath {
+  free: number;
+  isOverdrawn: boolean;
+}
+
+export function computePotMath(pot: number, pendingTotal: number): PotMath {
+  const free = pot - pendingTotal;
+  return { free, isOverdrawn: free < 0 };
+}

--- a/client/src/hooks/useMustPay.ts
+++ b/client/src/hooks/useMustPay.ts
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { isSameMonth } from "date-fns";
 import { id } from "@instantdb/react";
 import { db, type MustPayItem, type MustPayState } from "../lib/instant";
 
@@ -37,18 +36,16 @@ export function useMustPayState() {
 export function useMustPayActions() {
   const { data } = db.useQuery({ mustPayState: {} });
 
-  const create = async (input: {
-    title: string;
-    amountGEL: number;
-    isRecurring: boolean;
-    notes?: string;
-    dueDate?: number;
-  }) => {
+  const create = async (input: { title: string; amountGEL: number }) => {
     const now = Date.now();
     const itemId = id();
+    // isRecurring stays in the schema for backward compat but the
+    // design dropped the toggle — every new item is one-off, "paid"
+    // means paid forever until manually unchecked.
     await db.transact(
       db.tx.mustPayItems[itemId].update({
         ...input,
+        isRecurring: false,
         createdAt: now,
         updatedAt: now,
       })
@@ -63,18 +60,15 @@ export function useMustPayActions() {
   };
 
   /**
-   * Toggling "paid" doesn't store a boolean — it sets or clears
-   * `lastPaidAt` and lets the consumer derive paid-ness from the
-   * timestamp via `isItemPaidThisCycle`. That's what gives recurring
-   * items their automatic month-rollover without any background job.
+   * Toggling "paid" sets or clears `lastPaidAt`. The page treats any
+   * non-null lastPaidAt as paid (paid stays paid until unchecked).
    */
   const togglePaid = async (item: MustPayItem) => {
-    const now = new Date();
-    const currentlyPaid = isItemPaidThisCycle(item, now);
+    const now = Date.now();
     await db.transact(
       db.tx.mustPayItems[item.id].update({
-        lastPaidAt: currentlyPaid ? null : now.getTime(),
-        updatedAt: now.getTime(),
+        lastPaidAt: isItemPaid(item) ? null : now,
+        updatedAt: now,
       })
     );
   };
@@ -113,16 +107,13 @@ export function useMustPayActions() {
  */
 export function usePendingMustPayCount(): number {
   const { items } = useMustPayItems();
-  const now = new Date();
-  return items.filter((it) => !isItemPaidThisCycle(it, now)).length;
+  return items.filter((it) => !isItemPaid(it)).length;
 }
 
 // ── Pure helpers (no React, no DB — unit-testable) ────────────────────────
 
-export function isItemPaidThisCycle(item: MustPayItem, now: Date = new Date()): boolean {
-  if (item.lastPaidAt == null) return false;
-  if (!item.isRecurring) return true;
-  return isSameMonth(new Date(item.lastPaidAt), now);
+export function isItemPaid(item: MustPayItem): boolean {
+  return item.lastPaidAt != null;
 }
 
 export interface MustPaySummary {
@@ -132,13 +123,13 @@ export interface MustPaySummary {
   paidTotal: number;
 }
 
-export function summarizeMustPay(items: MustPayItem[], now: Date = new Date()): MustPaySummary {
+export function summarizeMustPay(items: MustPayItem[]): MustPaySummary {
   let pendingCount = 0;
   let pendingTotal = 0;
   let paidCount = 0;
   let paidTotal = 0;
   for (const it of items) {
-    if (isItemPaidThisCycle(it, now)) {
+    if (isItemPaid(it)) {
       paidCount++;
       paidTotal += it.amountGEL;
     } else {
@@ -154,7 +145,14 @@ export interface PotMath {
   isOverdrawn: boolean;
 }
 
-export function computePotMath(pot: number, pendingTotal: number): PotMath {
-  const free = pot - pendingTotal;
+/**
+ * Free = Pot − (Pending + Paid). The pot represents the user's
+ * starting wallet; paid obligations have already left it conceptually
+ * but we still subtract them so checking an item paid doesn't make
+ * Free rise (the money was always going to leave). The split between
+ * pending and paid is a workflow indicator, not a flow.
+ */
+export function computePotMath(pot: number, pendingTotal: number, paidTotal: number): PotMath {
+  const free = pot - pendingTotal - paidTotal;
   return { free, isOverdrawn: free < 0 };
 }

--- a/client/src/ink/Sidebar.tsx
+++ b/client/src/ink/Sidebar.tsx
@@ -28,14 +28,15 @@ export function Sidebar({
     { to: "/", name: "Overview", glyph: "◉" },
     { to: "/transactions", name: "Transactions", glyph: "≡", badge: txCount ? txCount.toLocaleString("en-US") : undefined },
     { to: "/income", name: "Income", glyph: "↓", badge: incomeCount ? incomeCount.toLocaleString("en-US") : undefined },
-    // pillBadge for Must Pay (vs the muted `badge` used by Transactions
-    // and Income) because the count here represents work the user
-    // hasn't done yet — the brighter accent pill matches "items needing
-    // attention" the same way Signals uses it for triggered rules.
-    { to: "/plan", name: "Must Pay", glyph: "⊕", pillBadge: mustPayCount ? String(mustPayCount) : undefined },
     { to: "/categories", name: "Categories", glyph: "◐" },
     { to: "/budgets", name: "Flex Budgeting", glyph: "◇" },
     { to: "/merchants", name: "Merchants", glyph: "◆" },
+    // pillBadge for Must Pay (vs the muted `badge` used by Transactions
+    // and Income) because the count represents work the user hasn't
+    // done yet — the brighter accent pill matches "items needing
+    // attention" the same way Signals uses it for triggered rules.
+    // Position between Merchants and Assistant per the design.
+    { to: "/plan", name: "Must pay", glyph: "◫", pillBadge: mustPayCount ? String(mustPayCount) : undefined },
     { to: "/assistant", name: "Assistant", glyph: "✧" },
     { to: "/signals", name: "Signals", glyph: "✦", badge: signalsCount ? String(signalsCount) : undefined },
     { to: "/manage", name: "Manage", glyph: "⚙" },

--- a/client/src/ink/Sidebar.tsx
+++ b/client/src/ink/Sidebar.tsx
@@ -15,10 +15,12 @@ export function Sidebar({
   txCount,
   signalsCount,
   incomeCount,
+  mustPayCount,
 }: {
   txCount?: number;
   signalsCount?: number;
   incomeCount?: number;
+  mustPayCount?: number;
 }) {
   const T = useTheme();
   const pwa = usePwaInstall();
@@ -26,6 +28,11 @@ export function Sidebar({
     { to: "/", name: "Overview", glyph: "◉" },
     { to: "/transactions", name: "Transactions", glyph: "≡", badge: txCount ? txCount.toLocaleString("en-US") : undefined },
     { to: "/income", name: "Income", glyph: "↓", badge: incomeCount ? incomeCount.toLocaleString("en-US") : undefined },
+    // pillBadge for Must Pay (vs the muted `badge` used by Transactions
+    // and Income) because the count here represents work the user
+    // hasn't done yet — the brighter accent pill matches "items needing
+    // attention" the same way Signals uses it for triggered rules.
+    { to: "/plan", name: "Must Pay", glyph: "⊕", pillBadge: mustPayCount ? String(mustPayCount) : undefined },
     { to: "/categories", name: "Categories", glyph: "◐" },
     { to: "/budgets", name: "Flex Budgeting", glyph: "◇" },
     { to: "/merchants", name: "Merchants", glyph: "◆" },

--- a/client/src/lib/instant.ts
+++ b/client/src/lib/instant.ts
@@ -87,6 +87,33 @@ const schema = i.schema({
       categoryId: i.string(),
       createdAt: i.number(),
     }),
+    // Free-form "things I owe" list. Not derived from SMS — the user
+    // types these in directly. Used by the Must Pay page to give them
+    // a glance at obligations vs the wallet pot before they spend.
+    mustPayItems: i.entity({
+      title: i.string(),
+      amountGEL: i.number(),
+      // null = never paid (still pending). Number = epoch ms of the
+      // most recent mark-paid click. Derived paid state is computed in
+      // useMustPay.isItemPaidThisCycle so recurring items auto-reset on
+      // month rollover without a cron.
+      lastPaidAt: i.number().optional(),
+      isRecurring: i.boolean(),
+      notes: i.string().optional(),
+      dueDate: i.number().optional(),
+      createdAt: i.number(),
+      updatedAt: i.number(),
+    }),
+    // Singleton row holding the user's current "pot" — how much money
+    // they have right now. Subtracted from the pending obligations
+    // total to surface the headline "free" figure on the Must Pay
+    // page. Keyed "singleton" with a unique constraint so concurrent
+    // upserts can't duplicate it.
+    mustPayState: i.entity({
+      key: i.string().unique(),
+      currentPotGEL: i.number(),
+      updatedAt: i.number(),
+    }),
     credits: i.entity({
       transactionId: i.string().unique(),
       transactionType: i.string(),
@@ -247,6 +274,25 @@ export type TransactionCategoryOverride = {
   paymentId: string;
   categoryId: string;
   createdAt: number;
+};
+
+export type MustPayItem = {
+  id: string;
+  title: string;
+  amountGEL: number;
+  lastPaidAt?: number;
+  isRecurring: boolean;
+  notes?: string;
+  dueDate?: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type MustPayState = {
+  id: string;
+  key: string;
+  currentPotGEL: number;
+  updatedAt: number;
 };
 
 export type Credit = {

--- a/client/src/pages/Plan.tsx
+++ b/client/src/pages/Plan.tsx
@@ -1,0 +1,654 @@
+import { useMemo, useState, useEffect, useRef } from "react";
+import { format } from "date-fns";
+import { useTheme, type InkTheme } from "../ink/theme";
+import { Card, CardLabel, PageHeader, Pill } from "../ink/primitives";
+import {
+  useMustPayItems,
+  useMustPayState,
+  useMustPayActions,
+  isItemPaidThisCycle,
+  summarizeMustPay,
+  computePotMath,
+} from "../hooks/useMustPay";
+import { useBudgetPlan } from "../hooks/useBudgets";
+import type { MustPayItem } from "../lib/instant";
+
+export function Plan() {
+  const T = useTheme();
+  const now = new Date();
+  const { items, isLoading } = useMustPayItems();
+  const { currentPotGEL } = useMustPayState();
+  const { create, update, togglePaid, remove, setCurrentPot } = useMustPayActions();
+  // useBudgetPlan already resolves the auto-derive fallback when no
+  // stored row exists for the current month, so we get a single
+  // canonical expectedIncome number to compare obligations against.
+  const { expectedIncome: rawExpectedIncome } = useBudgetPlan();
+
+  const [creating, setCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const summary = useMemo(() => summarizeMustPay(items, now), [items, now]);
+  const { free, isOverdrawn } = computePotMath(currentPotGEL, summary.pendingTotal);
+
+  // Sort: unpaid first (by dueDate asc if present, else createdAt desc),
+  // paid below in createdAt desc order. Single sort with a composite key.
+  const sorted = useMemo(() => {
+    const copy = [...items];
+    copy.sort((a, b) => {
+      const aPaid = isItemPaidThisCycle(a, now);
+      const bPaid = isItemPaidThisCycle(b, now);
+      if (aPaid !== bPaid) return aPaid ? 1 : -1;
+      if (!aPaid) {
+        // Both pending — due date asc wins, otherwise newest first.
+        if (a.dueDate != null && b.dueDate != null) return a.dueDate - b.dueDate;
+        if (a.dueDate != null) return -1;
+        if (b.dueDate != null) return 1;
+      }
+      return b.createdAt - a.createdAt;
+    });
+    return copy;
+  }, [items, now]);
+
+  // Hide the comparison line entirely when no number is available
+  // (fresh install with no prior income history) so we don't render
+  // "vs ₾0".
+  const expectedIncome = rawExpectedIncome > 0 ? rawExpectedIncome : null;
+
+  const eyebrow = `Plan what you owe · ${format(now, "MMMM")}`;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap }}>
+      <PageHeader
+        eyebrow={eyebrow}
+        title="Must Pay"
+        ranges={null}
+        rightSlot={
+          summary.pendingCount > 0 ? (
+            <Pill bg={T.accentSoft} color={T.accent}>
+              {summary.pendingCount} pending
+            </Pill>
+          ) : (
+            <Pill bg={T.panelAlt} color={T.dim}>
+              All clear
+            </Pill>
+          )
+        }
+      />
+
+      <HeadlineCard
+        T={T}
+        currentPotGEL={currentPotGEL}
+        pendingTotal={summary.pendingTotal}
+        free={free}
+        isOverdrawn={isOverdrawn}
+        expectedIncome={expectedIncome}
+        onPotChange={setCurrentPot}
+      />
+
+      <Card pad="20px 22px" style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {isLoading ? (
+          <div style={{ color: T.muted, fontSize: 13, padding: "20px 0", fontFamily: T.sans }}>Loading…</div>
+        ) : items.length === 0 && !creating ? (
+          <div style={{ color: T.muted, fontSize: 13, padding: "20px 0", fontFamily: T.sans }}>
+            Nothing to pay yet. Click below to add your first obligation.
+          </div>
+        ) : (
+          sorted.map((it) => {
+            const isEditing = editingId === it.id;
+            if (isEditing) {
+              return (
+                <ItemForm
+                  key={it.id}
+                  T={T}
+                  initial={it}
+                  onCancel={() => setEditingId(null)}
+                  onSubmit={async (input) => {
+                    await update(it.id, input);
+                    setEditingId(null);
+                  }}
+                  submitLabel="Save"
+                />
+              );
+            }
+            return (
+              <ItemRow
+                key={it.id}
+                T={T}
+                item={it}
+                now={now}
+                onToggle={() => togglePaid(it)}
+                onEdit={() => {
+                  setEditingId(it.id);
+                  setCreating(false);
+                }}
+                onDelete={() => {
+                  if (window.confirm(`Delete "${it.title}"? This cannot be undone.`)) {
+                    void remove(it.id);
+                  }
+                }}
+              />
+            );
+          })
+        )}
+
+        {creating ? (
+          <ItemForm
+            T={T}
+            onCancel={() => setCreating(false)}
+            onSubmit={async (input) => {
+              await create(input);
+              setCreating(false);
+            }}
+            submitLabel="Add"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => {
+              setCreating(true);
+              setEditingId(null);
+            }}
+            style={{
+              marginTop: 8,
+              padding: "10px 12px",
+              background: "transparent",
+              border: `1px dashed ${T.line}`,
+              borderRadius: 10,
+              color: T.muted,
+              fontSize: 12.5,
+              fontWeight: 600,
+              fontFamily: T.sans,
+              cursor: "pointer",
+              textAlign: "left",
+            }}
+          >
+            + Add obligation…
+          </button>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+// ── Headline card: Pot / Pending / Free with optional income compare ──────
+
+function HeadlineCard({
+  T,
+  currentPotGEL,
+  pendingTotal,
+  free,
+  isOverdrawn,
+  expectedIncome,
+  onPotChange,
+}: {
+  T: InkTheme;
+  currentPotGEL: number;
+  pendingTotal: number;
+  free: number;
+  isOverdrawn: boolean;
+  expectedIncome: number | null;
+  onPotChange: (amount: number) => Promise<void>;
+}) {
+  const [draft, setDraft] = useState<string>(String(currentPotGEL));
+  const [focused, setFocused] = useState(false);
+
+  // Keep the input in sync when an external write updates the pot
+  // (e.g. demo seed loads, or another tab updates the singleton). The
+  // user's in-flight edit takes priority — we only re-sync when they're
+  // not focused so we don't yank the value out from under them.
+  useEffect(() => {
+    if (!focused) setDraft(String(currentPotGEL));
+  }, [currentPotGEL, focused]);
+
+  const commit = () => {
+    const parsed = Number(draft);
+    if (Number.isFinite(parsed) && parsed >= 0 && parsed !== currentPotGEL) {
+      void onPotChange(parsed);
+    } else {
+      // Invalid / unchanged — revert the input to the persisted value.
+      setDraft(String(currentPotGEL));
+    }
+  };
+
+  const leftoverAfterObligations =
+    expectedIncome != null ? expectedIncome - pendingTotal : null;
+
+  return (
+    <Card pad="24px 28px" style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: 24,
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <CardLabel>Current pot</CardLabel>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+            <span style={{ fontSize: 32, fontWeight: 800, color: T.text, fontFamily: T.sans }}>₾</span>
+            <input
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="any"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onFocus={() => setFocused(true)}
+              onBlur={() => {
+                setFocused(false);
+                commit();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  (e.currentTarget as HTMLInputElement).blur();
+                } else if (e.key === "Escape") {
+                  setDraft(String(currentPotGEL));
+                  (e.currentTarget as HTMLInputElement).blur();
+                }
+              }}
+              style={{
+                fontSize: 32,
+                fontWeight: 800,
+                letterSpacing: -1.2,
+                color: T.text,
+                fontFamily: T.sans,
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                padding: 0,
+                width: "100%",
+                minWidth: 0,
+                fontVariantNumeric: "tabular-nums",
+              }}
+            />
+          </div>
+          <div style={{ fontSize: 11, color: T.dim, fontFamily: T.sans }}>
+            What's in your wallet right now
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <CardLabel>Pending</CardLabel>
+          <div
+            style={{
+              fontSize: 32,
+              fontWeight: 800,
+              letterSpacing: -1.2,
+              color: T.text,
+              fontFamily: T.sans,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            ₾{Math.round(pendingTotal).toLocaleString("en-US")}
+          </div>
+          <div style={{ fontSize: 11, color: T.dim, fontFamily: T.sans }}>
+            Things still to pay
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <CardLabel>Free</CardLabel>
+          <div
+            style={{
+              fontSize: 32,
+              fontWeight: 800,
+              letterSpacing: -1.2,
+              color: isOverdrawn ? T.accent : T.green,
+              fontFamily: T.sans,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {isOverdrawn ? "−" : ""}₾{Math.abs(Math.round(free)).toLocaleString("en-US")}
+          </div>
+          <div style={{ fontSize: 11, color: isOverdrawn ? T.accent : T.dim, fontFamily: T.sans }}>
+            {isOverdrawn
+              ? `Over by ₾${Math.abs(Math.round(free)).toLocaleString("en-US")}`
+              : "Pot minus obligations"}
+          </div>
+        </div>
+      </div>
+
+      {expectedIncome != null && leftoverAfterObligations != null && (
+        <div
+          style={{
+            fontSize: 12,
+            color: T.muted,
+            fontFamily: T.sans,
+            paddingTop: 10,
+            borderTop: `1px solid ${T.line}`,
+          }}
+        >
+          vs ₾{Math.round(expectedIncome).toLocaleString("en-US")} typical income ·{" "}
+          <span style={{ color: leftoverAfterObligations < 0 ? T.accent : T.text, fontWeight: 700 }}>
+            ₾{Math.abs(Math.round(leftoverAfterObligations)).toLocaleString("en-US")}
+            {leftoverAfterObligations < 0 ? " short" : " leftover"}
+          </span>{" "}
+          after obligations
+        </div>
+      )}
+    </Card>
+  );
+}
+
+// ── Single row ─────────────────────────────────────────────────────────────
+
+function ItemRow({
+  T,
+  item,
+  now,
+  onToggle,
+  onEdit,
+  onDelete,
+}: {
+  T: InkTheme;
+  item: MustPayItem;
+  now: Date;
+  onToggle: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const paid = isItemPaidThisCycle(item, now);
+  const overdue = !paid && item.dueDate != null && item.dueDate < now.getTime();
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "12px 12px",
+        borderRadius: 10,
+        opacity: paid ? 0.45 : 1,
+        transition: "opacity 120ms ease-out",
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        title={paid ? "Mark unpaid" : "Mark paid"}
+        style={{
+          width: 22,
+          height: 22,
+          borderRadius: 6,
+          border: `1.5px solid ${paid ? T.green : T.line}`,
+          background: paid ? T.green : "transparent",
+          color: "#fff",
+          fontSize: 13,
+          lineHeight: 1,
+          cursor: "pointer",
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {paid ? "✓" : ""}
+      </button>
+
+      <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 2 }}>
+        <div
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            color: T.text,
+            fontFamily: T.sans,
+            textDecoration: paid ? "line-through" : "none",
+          }}
+        >
+          {item.title}
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          {item.isRecurring && (
+            <span style={{ fontSize: 10, color: T.dim, fontFamily: T.mono }}>↻ monthly</span>
+          )}
+          {item.dueDate != null && (
+            <span style={{ fontSize: 10, color: overdue ? T.accent : T.dim, fontFamily: T.mono, fontWeight: overdue ? 700 : 400 }}>
+              {overdue ? "OVERDUE · " : "due "}
+              {format(new Date(item.dueDate), "MMM d")}
+            </span>
+          )}
+          {item.notes && (
+            <span style={{ fontSize: 11, color: T.muted, fontFamily: T.sans }}>{item.notes}</span>
+          )}
+        </div>
+      </div>
+
+      <span
+        style={{
+          fontSize: 14,
+          fontWeight: 700,
+          color: T.text,
+          fontFamily: T.sans,
+          minWidth: 70,
+          textAlign: "right",
+          fontVariantNumeric: "tabular-nums",
+          textDecoration: paid ? "line-through" : "none",
+        }}
+      >
+        ₾{Math.round(item.amountGEL).toLocaleString("en-US")}
+      </span>
+
+      <button
+        type="button"
+        title="Edit"
+        onClick={onEdit}
+        style={{
+          width: 22,
+          height: 22,
+          borderRadius: 11,
+          border: `1px solid ${T.line}`,
+          background: "transparent",
+          color: T.dim,
+          fontSize: 11,
+          lineHeight: 1,
+          cursor: "pointer",
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        ✎
+      </button>
+      <button
+        type="button"
+        title="Delete"
+        onClick={onDelete}
+        style={{
+          width: 22,
+          height: 22,
+          borderRadius: 11,
+          border: `1px solid ${T.line}`,
+          background: "transparent",
+          color: T.dim,
+          fontSize: 12,
+          lineHeight: 1,
+          cursor: "pointer",
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+// ── Inline create/edit form ───────────────────────────────────────────────
+
+function ItemForm({
+  T,
+  initial,
+  onSubmit,
+  onCancel,
+  submitLabel,
+}: {
+  T: InkTheme;
+  initial?: Partial<MustPayItem>;
+  onSubmit: (input: {
+    title: string;
+    amountGEL: number;
+    isRecurring: boolean;
+    notes?: string;
+    dueDate?: number;
+  }) => Promise<void>;
+  onCancel: () => void;
+  submitLabel: string;
+}) {
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [amount, setAmount] = useState(initial?.amountGEL != null ? String(initial.amountGEL) : "");
+  const [isRecurring, setIsRecurring] = useState(initial?.isRecurring ?? false);
+  const [notes, setNotes] = useState(initial?.notes ?? "");
+  const [dueDate, setDueDate] = useState(
+    initial?.dueDate != null ? format(new Date(initial.dueDate), "yyyy-MM-dd") : ""
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const submit = async () => {
+    const trimmed = title.trim();
+    const parsedAmount = Number(amount);
+    if (!trimmed || !Number.isFinite(parsedAmount) || parsedAmount <= 0) return;
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        title: trimmed,
+        amountGEL: parsedAmount,
+        isRecurring,
+        notes: notes.trim() || undefined,
+        dueDate: dueDate ? new Date(dueDate).getTime() : undefined,
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inputStyle: React.CSSProperties = {
+    padding: "8px 10px",
+    background: T.panelAlt,
+    border: `1px solid ${T.line}`,
+    borderRadius: 8,
+    color: T.text,
+    fontSize: 13,
+    fontFamily: T.sans,
+    outline: "none",
+  };
+
+  return (
+    <div
+      style={{
+        padding: "12px",
+        background: T.panelAlt,
+        border: `1px solid ${T.line}`,
+        borderRadius: 10,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        marginTop: 4,
+      }}
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 120px", gap: 10 }}>
+        <input
+          ref={titleRef}
+          type="text"
+          placeholder="What needs paying? (e.g. Rent)"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          style={inputStyle}
+        />
+        <input
+          type="number"
+          inputMode="decimal"
+          min={0}
+          step="any"
+          placeholder="Amount ₾"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          style={{ ...inputStyle, fontVariantNumeric: "tabular-nums" }}
+        />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 160px", gap: 10 }}>
+        <input
+          type="text"
+          placeholder="Notes (optional)"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          style={inputStyle}
+        />
+        <input
+          type="date"
+          placeholder="Due date"
+          value={dueDate}
+          onChange={(e) => setDueDate(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          color: T.muted,
+          fontSize: 12.5,
+          fontFamily: T.sans,
+          cursor: "pointer",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={isRecurring}
+          onChange={(e) => setIsRecurring(e.target.checked)}
+          style={{ cursor: "pointer" }}
+        />
+        Repeats monthly — auto-resets on the 1st
+      </label>
+
+      <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{
+            padding: "7px 14px",
+            background: "transparent",
+            border: `1px solid ${T.line}`,
+            borderRadius: 8,
+            color: T.muted,
+            fontSize: 12,
+            fontWeight: 600,
+            fontFamily: T.sans,
+            cursor: "pointer",
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={submitting || !title.trim() || !amount}
+          style={{
+            padding: "7px 14px",
+            background: T.accent,
+            border: `1px solid ${T.accent}`,
+            borderRadius: 8,
+            color: "#fff",
+            fontSize: 12,
+            fontWeight: 700,
+            fontFamily: T.sans,
+            cursor: submitting || !title.trim() || !amount ? "not-allowed" : "pointer",
+            opacity: submitting || !title.trim() || !amount ? 0.5 : 1,
+          }}
+        >
+          {submitting ? "…" : submitLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Plan.tsx
+++ b/client/src/pages/Plan.tsx
@@ -202,12 +202,18 @@ function HeadlineCard({
   paidCount: number;
   onPotChange: (amount: number) => Promise<void>;
 }) {
+  // The draft string only matters while editing. Initialising it from
+  // `pot` at click-time (rather than mirroring pot via useEffect+setState)
+  // avoids the react-hooks/set-state-in-effect lint rule and removes a
+  // class of stale-closure bugs where an external pot update mid-edit
+  // would yank the value out from under the user.
   const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(String(pot));
+  const [draft, setDraft] = useState("");
 
-  useEffect(() => {
-    if (!editing) setDraft(String(pot));
-  }, [pot, editing]);
+  const startEdit = () => {
+    setDraft(String(pot));
+    setEditing(true);
+  };
 
   const commit = () => {
     const v = parseFloat(draft.replace(/[^\d.-]/g, ""));
@@ -274,10 +280,7 @@ function HeadlineCard({
             ) : (
               <button
                 type="button"
-                onClick={() => {
-                  setDraft(String(pot));
-                  setEditing(true);
-                }}
+                onClick={startEdit}
                 style={{
                   background: "transparent",
                   border: "none",

--- a/client/src/pages/Plan.tsx
+++ b/client/src/pages/Plan.tsx
@@ -1,508 +1,710 @@
 import { useMemo, useState, useEffect, useRef } from "react";
-import { format } from "date-fns";
 import { useTheme, type InkTheme } from "../ink/theme";
-import { Card, CardLabel, PageHeader, Pill } from "../ink/primitives";
+import { Card, CardTitle, PageHeader, Pill } from "../ink/primitives";
 import {
   useMustPayItems,
   useMustPayState,
   useMustPayActions,
-  isItemPaidThisCycle,
+  isItemPaid,
   summarizeMustPay,
   computePotMath,
 } from "../hooks/useMustPay";
-import { useBudgetPlan } from "../hooks/useBudgets";
 import type { MustPayItem } from "../lib/instant";
+
+const POT_PRESETS = [1500, 2000, 3000, 5000];
 
 export function Plan() {
   const T = useTheme();
-  const now = new Date();
   const { items, isLoading } = useMustPayItems();
   const { currentPotGEL } = useMustPayState();
   const { create, update, togglePaid, remove, setCurrentPot } = useMustPayActions();
-  // useBudgetPlan already resolves the auto-derive fallback when no
-  // stored row exists for the current month, so we get a single
-  // canonical expectedIncome number to compare obligations against.
-  const { expectedIncome: rawExpectedIncome } = useBudgetPlan();
 
-  const [creating, setCreating] = useState(false);
+  const [adding, setAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
 
-  const summary = useMemo(() => summarizeMustPay(items, now), [items, now]);
-  const { free, isOverdrawn } = computePotMath(currentPotGEL, summary.pendingTotal);
+  const summary = useMemo(() => summarizeMustPay(items), [items]);
+  const { free, isOverdrawn } = computePotMath(currentPotGEL, summary.pendingTotal, summary.paidTotal);
+  // Three percentages for the stacked progress bar. Paid (green) and
+  // pending (accent) consume the obligation portion of the pot; the
+  // remainder is free.
+  const paidPct = currentPotGEL > 0 ? Math.min(100, (summary.paidTotal / currentPotGEL) * 100) : 0;
+  const pendingPct = currentPotGEL > 0 ? Math.min(100 - paidPct, (summary.pendingTotal / currentPotGEL) * 100) : 0;
+  const freePct = currentPotGEL > 0 ? Math.max(0, (free / currentPotGEL) * 100) : 0;
 
-  // Sort: unpaid first (by dueDate asc if present, else createdAt desc),
-  // paid below in createdAt desc order. Single sort with a composite key.
+  // Sort: unpaid first (newest first), paid below (in createdAt desc order).
   const sorted = useMemo(() => {
     const copy = [...items];
     copy.sort((a, b) => {
-      const aPaid = isItemPaidThisCycle(a, now);
-      const bPaid = isItemPaidThisCycle(b, now);
+      const aPaid = isItemPaid(a);
+      const bPaid = isItemPaid(b);
       if (aPaid !== bPaid) return aPaid ? 1 : -1;
-      if (!aPaid) {
-        // Both pending — due date asc wins, otherwise newest first.
-        if (a.dueDate != null && b.dueDate != null) return a.dueDate - b.dueDate;
-        if (a.dueDate != null) return -1;
-        if (b.dueDate != null) return 1;
-      }
       return b.createdAt - a.createdAt;
     });
     return copy;
-  }, [items, now]);
-
-  // Hide the comparison line entirely when no number is available
-  // (fresh install with no prior income history) so we don't render
-  // "vs ₾0".
-  const expectedIncome = rawExpectedIncome > 0 ? rawExpectedIncome : null;
-
-  const eyebrow = `Plan what you owe · ${format(now, "MMMM")}`;
+  }, [items]);
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap }}>
+    <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap, minHeight: 0 }}>
       <PageHeader
-        eyebrow={eyebrow}
-        title="Must Pay"
+        eyebrow="What's already promised · before you spend"
+        title="Must pay"
         ranges={null}
         rightSlot={
-          summary.pendingCount > 0 ? (
-            <Pill bg={T.accentSoft} color={T.accent}>
-              {summary.pendingCount} pending
-            </Pill>
-          ) : (
-            <Pill bg={T.panelAlt} color={T.dim}>
-              All clear
-            </Pill>
-          )
+          <Pill bg={T.accentSoft} color={T.accent}>
+            {summary.pendingCount} unpaid
+          </Pill>
         }
       />
 
+      {/* Headline — Free dominates. Three columns split by vertical
+          dividers, Free in the middle takes 1.4fr so it visually
+          claims the page. */}
       <HeadlineCard
         T={T}
-        currentPotGEL={currentPotGEL}
-        pendingTotal={summary.pendingTotal}
+        pot={currentPotGEL}
+        pending={summary.pendingTotal}
+        paid={summary.paidTotal}
         free={free}
         isOverdrawn={isOverdrawn}
-        expectedIncome={expectedIncome}
+        paidPct={paidPct}
+        pendingPct={pendingPct}
+        freePct={freePct}
+        itemCount={items.length}
+        pendingCount={summary.pendingCount}
+        paidCount={summary.paidCount}
         onPotChange={setCurrentPot}
       />
 
-      <Card pad="20px 22px" style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      {/* Obligations list */}
+      <Card pad="0">
+        <div
+          style={{
+            padding: "14px 20px",
+            borderBottom: `1px solid ${T.line}`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 12,
+          }}
+        >
+          <CardTitle>Obligations</CardTitle>
+          <button
+            type="button"
+            onClick={() => {
+              setAdding(true);
+              setEditingId(null);
+            }}
+            style={{
+              padding: "7px 13px",
+              borderRadius: 9,
+              border: "none",
+              background: T.accent,
+              color: "#fff",
+              fontSize: 12,
+              fontWeight: 700,
+              fontFamily: T.sans,
+              cursor: "pointer",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <span style={{ fontSize: 14, lineHeight: 1 }}>+</span> Add item
+          </button>
+        </div>
+
+        {adding && (
+          <RowEditor
+            T={T}
+            initial={{ title: "", amountGEL: NaN }}
+            onCancel={() => setAdding(false)}
+            onSave={async (v) => {
+              await create({ title: v.title, amountGEL: v.amountGEL });
+              setAdding(false);
+            }}
+          />
+        )}
+
         {isLoading ? (
-          <div style={{ color: T.muted, fontSize: 13, padding: "20px 0", fontFamily: T.sans }}>Loading…</div>
-        ) : items.length === 0 && !creating ? (
-          <div style={{ color: T.muted, fontSize: 13, padding: "20px 0", fontFamily: T.sans }}>
-            Nothing to pay yet. Click below to add your first obligation.
+          <div style={{ padding: "40px 20px", textAlign: "center", color: T.muted, fontSize: 13, fontFamily: T.sans }}>
+            Loading…
           </div>
+        ) : items.length === 0 && !adding ? (
+          <EmptyState T={T} onAdd={() => setAdding(true)} />
         ) : (
-          sorted.map((it) => {
-            const isEditing = editingId === it.id;
-            if (isEditing) {
-              return (
-                <ItemForm
+          <div>
+            {sorted.map((it, i) =>
+              editingId === it.id ? (
+                <RowEditor
                   key={it.id}
                   T={T}
                   initial={it}
                   onCancel={() => setEditingId(null)}
-                  onSubmit={async (input) => {
-                    await update(it.id, input);
+                  onSave={async (v) => {
+                    await update(it.id, { title: v.title, amountGEL: v.amountGEL });
                     setEditingId(null);
                   }}
-                  submitLabel="Save"
                 />
-              );
-            }
-            return (
-              <ItemRow
-                key={it.id}
-                T={T}
-                item={it}
-                now={now}
-                onToggle={() => togglePaid(it)}
-                onEdit={() => {
-                  setEditingId(it.id);
-                  setCreating(false);
-                }}
-                onDelete={() => {
-                  if (window.confirm(`Delete "${it.title}"? This cannot be undone.`)) {
-                    void remove(it.id);
-                  }
-                }}
-              />
-            );
-          })
-        )}
-
-        {creating ? (
-          <ItemForm
-            T={T}
-            onCancel={() => setCreating(false)}
-            onSubmit={async (input) => {
-              await create(input);
-              setCreating(false);
-            }}
-            submitLabel="Add"
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={() => {
-              setCreating(true);
-              setEditingId(null);
-            }}
-            style={{
-              marginTop: 8,
-              padding: "10px 12px",
-              background: "transparent",
-              border: `1px dashed ${T.line}`,
-              borderRadius: 10,
-              color: T.muted,
-              fontSize: 12.5,
-              fontWeight: 600,
-              fontFamily: T.sans,
-              cursor: "pointer",
-              textAlign: "left",
-            }}
-          >
-            + Add obligation…
-          </button>
+              ) : (
+                <Row
+                  key={it.id}
+                  T={T}
+                  item={it}
+                  isLast={i === sorted.length - 1}
+                  onToggle={() => togglePaid(it)}
+                  onEdit={() => {
+                    setEditingId(it.id);
+                    setAdding(false);
+                  }}
+                  onDelete={() => {
+                    if (window.confirm(`Delete "${it.title}"? This cannot be undone.`)) {
+                      void remove(it.id);
+                    }
+                  }}
+                />
+              )
+            )}
+          </div>
         )}
       </Card>
     </div>
   );
 }
 
-// ── Headline card: Pot / Pending / Free with optional income compare ──────
+// ── Headline card: Pot / Free / Pending in 3 columns ───────────────────────
 
 function HeadlineCard({
   T,
-  currentPotGEL,
-  pendingTotal,
+  pot,
+  pending,
+  paid,
   free,
   isOverdrawn,
-  expectedIncome,
+  paidPct,
+  pendingPct,
+  freePct,
+  itemCount,
+  pendingCount,
+  paidCount,
   onPotChange,
 }: {
   T: InkTheme;
-  currentPotGEL: number;
-  pendingTotal: number;
+  pot: number;
+  pending: number;
+  paid: number;
   free: number;
   isOverdrawn: boolean;
-  expectedIncome: number | null;
+  paidPct: number;
+  pendingPct: number;
+  freePct: number;
+  itemCount: number;
+  pendingCount: number;
+  paidCount: number;
   onPotChange: (amount: number) => Promise<void>;
 }) {
-  const [draft, setDraft] = useState<string>(String(currentPotGEL));
-  const [focused, setFocused] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(pot));
 
-  // Keep the input in sync when an external write updates the pot
-  // (e.g. demo seed loads, or another tab updates the singleton). The
-  // user's in-flight edit takes priority — we only re-sync when they're
-  // not focused so we don't yank the value out from under them.
   useEffect(() => {
-    if (!focused) setDraft(String(currentPotGEL));
-  }, [currentPotGEL, focused]);
+    if (!editing) setDraft(String(pot));
+  }, [pot, editing]);
 
   const commit = () => {
-    const parsed = Number(draft);
-    if (Number.isFinite(parsed) && parsed >= 0 && parsed !== currentPotGEL) {
-      void onPotChange(parsed);
-    } else {
-      // Invalid / unchanged — revert the input to the persisted value.
-      setDraft(String(currentPotGEL));
+    const v = parseFloat(draft.replace(/[^\d.-]/g, ""));
+    if (Number.isFinite(v) && v >= 0 && v !== pot) {
+      void onPotChange(v);
     }
+    setEditing(false);
   };
 
-  const leftoverAfterObligations =
-    expectedIncome != null ? expectedIncome - pendingTotal : null;
+  // Stack on narrow viewports — three columns become a 3-row stack so
+  // the headline stays readable on phones and split-pane Macs.
+  const isNarrow = typeof window !== "undefined" && window.innerWidth < 760;
 
   return (
-    <Card pad="24px 28px" style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+    <Card pad="0" style={{ overflow: "hidden" }}>
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: "1fr 1fr 1fr",
-          gap: 24,
+          // Four columns on desktop with Free still 1.4fr so it stays
+          // dominant. Narrow viewports stack everything vertically.
+          gridTemplateColumns: isNarrow ? "1fr" : "0.95fr 1.4fr 0.85fr 0.85fr",
+          alignItems: "stretch",
         }}
       >
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <CardLabel>Current pot</CardLabel>
-          <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
-            <span style={{ fontSize: 32, fontWeight: 800, color: T.text, fontFamily: T.sans }}>₾</span>
-            <input
-              type="number"
-              inputMode="decimal"
-              min={0}
-              step="any"
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              onFocus={() => setFocused(true)}
-              onBlur={() => {
-                setFocused(false);
-                commit();
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  (e.currentTarget as HTMLInputElement).blur();
-                } else if (e.key === "Escape") {
-                  setDraft(String(currentPotGEL));
-                  (e.currentTarget as HTMLInputElement).blur();
-                }
-              }}
-              style={{
-                fontSize: 32,
-                fontWeight: 800,
-                letterSpacing: -1.2,
-                color: T.text,
-                fontFamily: T.sans,
-                background: "transparent",
-                border: "none",
-                outline: "none",
-                padding: 0,
-                width: "100%",
-                minWidth: 0,
-                fontVariantNumeric: "tabular-nums",
-              }}
-            />
+        {/* POT — left, editable */}
+        <div
+          style={{
+            padding: "32px 32px",
+            borderRight: isNarrow ? "none" : `1px solid ${T.line}`,
+            borderBottom: isNarrow ? `1px solid ${T.line}` : "none",
+          }}
+        >
+          <SectionEyebrow T={T}>Pot</SectionEyebrow>
+          <SectionSubtitle T={T}>What you have right now</SectionSubtitle>
+          <div style={{ marginTop: 20 }}>
+            {editing ? (
+              <input
+                autoFocus
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onBlur={commit}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") commit();
+                  if (e.key === "Escape") {
+                    setDraft(String(pot));
+                    setEditing(false);
+                  }
+                }}
+                inputMode="decimal"
+                style={{
+                  width: "100%",
+                  background: "transparent",
+                  border: "none",
+                  outline: "none",
+                  color: T.text,
+                  fontFamily: T.sans,
+                  fontSize: 44,
+                  fontWeight: 700,
+                  letterSpacing: -1.6,
+                  padding: 0,
+                  lineHeight: 1.1,
+                }}
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setDraft(String(pot));
+                  setEditing(true);
+                }}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  padding: 0,
+                  cursor: "text",
+                  fontFamily: T.sans,
+                  color: T.text,
+                  fontSize: 44,
+                  fontWeight: 700,
+                  letterSpacing: -1.6,
+                  lineHeight: 1.1,
+                  textAlign: "left",
+                }}
+              >
+                ₾{pot.toLocaleString("en-US", { maximumFractionDigits: 2 })}
+                <span
+                  style={{
+                    marginLeft: 10,
+                    fontSize: 11,
+                    color: T.dim,
+                    fontFamily: T.mono,
+                    fontWeight: 500,
+                    letterSpacing: 0.5,
+                    textTransform: "uppercase",
+                    verticalAlign: "middle",
+                  }}
+                >
+                  edit ✎
+                </span>
+              </button>
+            )}
           </div>
-          <div style={{ fontSize: 11, color: T.dim, fontFamily: T.sans }}>
-            What's in your wallet right now
+          <div style={{ display: "flex", gap: 6, marginTop: 16, flexWrap: "wrap" }}>
+            {POT_PRESETS.map((v) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => void onPotChange(v)}
+                style={{
+                  padding: "5px 10px",
+                  borderRadius: 6,
+                  border: `1px solid ${T.line}`,
+                  background: T.panelAlt,
+                  color: T.muted,
+                  fontSize: 10.5,
+                  fontFamily: T.mono,
+                  cursor: "pointer",
+                }}
+              >
+                ₾{v.toLocaleString("en-US")}
+              </button>
+            ))}
           </div>
         </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <CardLabel>Pending</CardLabel>
+        {/* FREE — middle, dominant. Tinted background plus a blurred
+            orb in the corner that picks up the success/warning color
+            and gives the cell its visual weight. */}
+        <div
+          style={{
+            padding: "32px 36px",
+            background: free >= 0 ? "rgba(75,217,162,0.06)" : T.accentSoft,
+            borderRight: isNarrow ? "none" : `1px solid ${T.line}`,
+            borderBottom: isNarrow ? `1px solid ${T.line}` : "none",
+            position: "relative",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: -80,
+              right: -50,
+              width: 220,
+              height: 220,
+              borderRadius: "50%",
+              background: free >= 0 ? T.green : T.accent,
+              opacity: 0.18,
+              filter: "blur(70px)",
+            }}
+          />
+          <div style={{ position: "relative" }}>
+            <div
+              style={{
+                fontSize: 11,
+                color: free >= 0 ? T.green : T.accent,
+                fontFamily: T.mono,
+                letterSpacing: 1.4,
+                textTransform: "uppercase",
+                fontWeight: 700,
+              }}
+            >
+              {free >= 0 ? "Free to spend" : "Over by"}
+            </div>
+            <div style={{ fontSize: 11.5, color: T.muted, marginTop: 4, fontFamily: T.sans }}>
+              {free >= 0
+                ? "Yours after everything promised"
+                : `Pending exceeds your pot by ₾${Math.abs(free).toLocaleString("en-US")}`}
+            </div>
+            <div
+              style={{
+                marginTop: 16,
+                fontFamily: T.sans,
+                fontWeight: 700,
+                fontSize: "clamp(56px, 7.5vw, 84px)",
+                letterSpacing: -3.6,
+                lineHeight: 1,
+                color: free >= 0 ? T.green : T.accent,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {isOverdrawn ? "−" : ""}₾
+              {Math.abs(free).toLocaleString("en-US", { maximumFractionDigits: 2 })}
+            </div>
+            <div style={{ marginTop: 22 }}>
+              {/* Stacked bar: green (paid) + accent (pending) + empty
+                  (free). Reads left-to-right as a quick breakdown of
+                  where the pot is committed. */}
+              <div
+                style={{
+                  height: 8,
+                  borderRadius: 4,
+                  background: T.panelAlt,
+                  overflow: "hidden",
+                  display: "flex",
+                }}
+              >
+                <div
+                  style={{
+                    height: "100%",
+                    width: `${paidPct}%`,
+                    background: T.green,
+                    transition: "width .3s ease",
+                  }}
+                />
+                <div
+                  style={{
+                    height: "100%",
+                    width: `${pendingPct}%`,
+                    background: T.accent,
+                    transition: "width .3s ease",
+                  }}
+                />
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  marginTop: 7,
+                  fontSize: 10.5,
+                  color: T.dim,
+                  fontFamily: T.mono,
+                  letterSpacing: 0.3,
+                }}
+              >
+                <span>{Math.round(paidPct)}% paid · {Math.round(pendingPct)}% pending</span>
+                <span>{Math.round(freePct)}% free</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* PENDING */}
+        <div
+          style={{
+            padding: "32px 28px",
+            borderRight: isNarrow ? "none" : `1px solid ${T.line}`,
+            borderBottom: isNarrow ? `1px solid ${T.line}` : "none",
+          }}
+        >
+          <SectionEyebrow T={T}>Pending</SectionEyebrow>
+          <SectionSubtitle T={T}>Sum of unpaid</SectionSubtitle>
           <div
             style={{
-              fontSize: 32,
-              fontWeight: 800,
-              letterSpacing: -1.2,
+              marginTop: 20,
+              fontSize: 38,
+              fontWeight: 700,
               color: T.text,
               fontFamily: T.sans,
-              fontVariantNumeric: "tabular-nums",
+              letterSpacing: -1.4,
+              lineHeight: 1.1,
             }}
           >
-            ₾{Math.round(pendingTotal).toLocaleString("en-US")}
+            ₾{pending.toLocaleString("en-US", { maximumFractionDigits: 2 })}
           </div>
-          <div style={{ fontSize: 11, color: T.dim, fontFamily: T.sans }}>
-            Things still to pay
+          <div
+            style={{
+              marginTop: 16,
+              fontSize: 11.5,
+              color: T.muted,
+              fontFamily: T.sans,
+              lineHeight: 1.5,
+            }}
+          >
+            {pendingCount} of {itemCount} item{itemCount === 1 ? "" : "s"} still to pay
           </div>
         </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <CardLabel>Free</CardLabel>
+        {/* PAID — far right. Tinted faint-green background so the
+            green-vs-accent paid/pending split reads at a glance and
+            mirrors the green segment in the progress bar above. */}
+        <div
+          style={{
+            padding: "32px 28px",
+            background: "rgba(75,217,162,0.04)",
+          }}
+        >
           <div
             style={{
-              fontSize: 32,
-              fontWeight: 800,
-              letterSpacing: -1.2,
-              color: isOverdrawn ? T.accent : T.green,
-              fontFamily: T.sans,
-              fontVariantNumeric: "tabular-nums",
+              fontSize: 11,
+              color: T.green,
+              fontFamily: T.mono,
+              letterSpacing: 1.2,
+              textTransform: "uppercase",
+              fontWeight: 700,
             }}
           >
-            {isOverdrawn ? "−" : ""}₾{Math.abs(Math.round(free)).toLocaleString("en-US")}
+            Paid
           </div>
-          <div style={{ fontSize: 11, color: isOverdrawn ? T.accent : T.dim, fontFamily: T.sans }}>
-            {isOverdrawn
-              ? `Over by ₾${Math.abs(Math.round(free)).toLocaleString("en-US")}`
-              : "Pot minus obligations"}
+          <SectionSubtitle T={T}>Already settled</SectionSubtitle>
+          <div
+            style={{
+              marginTop: 20,
+              fontSize: 38,
+              fontWeight: 700,
+              color: T.green,
+              fontFamily: T.sans,
+              letterSpacing: -1.4,
+              lineHeight: 1.1,
+            }}
+          >
+            ₾{paid.toLocaleString("en-US", { maximumFractionDigits: 2 })}
+          </div>
+          <div
+            style={{
+              marginTop: 16,
+              fontSize: 11.5,
+              color: T.muted,
+              fontFamily: T.sans,
+              lineHeight: 1.5,
+            }}
+          >
+            {paidCount} of {itemCount} item{itemCount === 1 ? "" : "s"} settled
           </div>
         </div>
       </div>
-
-      {expectedIncome != null && leftoverAfterObligations != null && (
-        <div
-          style={{
-            fontSize: 12,
-            color: T.muted,
-            fontFamily: T.sans,
-            paddingTop: 10,
-            borderTop: `1px solid ${T.line}`,
-          }}
-        >
-          vs ₾{Math.round(expectedIncome).toLocaleString("en-US")} typical income ·{" "}
-          <span style={{ color: leftoverAfterObligations < 0 ? T.accent : T.text, fontWeight: 700 }}>
-            ₾{Math.abs(Math.round(leftoverAfterObligations)).toLocaleString("en-US")}
-            {leftoverAfterObligations < 0 ? " short" : " leftover"}
-          </span>{" "}
-          after obligations
-        </div>
-      )}
     </Card>
   );
 }
 
-// ── Single row ─────────────────────────────────────────────────────────────
+function SectionEyebrow({ T, children }: { T: InkTheme; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        fontSize: 11,
+        color: T.dim,
+        fontFamily: T.mono,
+        letterSpacing: 1.2,
+        textTransform: "uppercase",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
 
-function ItemRow({
+function SectionSubtitle({ T, children }: { T: InkTheme; children: React.ReactNode }) {
+  return (
+    <div style={{ fontSize: 11.5, color: T.muted, marginTop: 4, fontFamily: T.sans }}>
+      {children}
+    </div>
+  );
+}
+
+// ── Row ────────────────────────────────────────────────────────────────────
+
+function Row({
   T,
   item,
-  now,
+  isLast,
   onToggle,
   onEdit,
   onDelete,
 }: {
   T: InkTheme;
   item: MustPayItem;
-  now: Date;
+  isLast: boolean;
   onToggle: () => void;
   onEdit: () => void;
   onDelete: () => void;
 }) {
-  const paid = isItemPaidThisCycle(item, now);
-  const overdue = !paid && item.dueDate != null && item.dueDate < now.getTime();
-
+  const paid = isItemPaid(item);
   return (
     <div
       style={{
-        display: "flex",
+        display: "grid",
+        gridTemplateColumns: "32px 1fr auto auto",
+        gap: 14,
         alignItems: "center",
-        gap: 12,
-        padding: "12px 12px",
-        borderRadius: 10,
-        opacity: paid ? 0.45 : 1,
-        transition: "opacity 120ms ease-out",
+        padding: "16px 20px",
+        borderBottom: isLast ? "none" : `1px solid ${T.line}`,
       }}
     >
       <button
         type="button"
         onClick={onToggle}
-        title={paid ? "Mark unpaid" : "Mark paid"}
+        aria-label={paid ? "Mark unpaid" : "Mark paid"}
         style={{
-          width: 22,
-          height: 22,
-          borderRadius: 6,
-          border: `1.5px solid ${paid ? T.green : T.line}`,
-          background: paid ? T.green : "transparent",
-          color: "#fff",
-          fontSize: 13,
-          lineHeight: 1,
+          width: 24,
+          height: 24,
+          borderRadius: 7,
+          background: paid ? T.accent : "transparent",
+          border: paid ? `1.5px solid ${T.accent}` : `1.5px solid ${T.lineStrong || T.line}`,
           cursor: "pointer",
-          flexShrink: 0,
+          padding: 0,
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
+          transition: "background .12s, border-color .12s",
         }}
       >
-        {paid ? "✓" : ""}
+        {paid && <span style={{ color: "#fff", fontSize: 14, fontWeight: 800, lineHeight: 1 }}>✓</span>}
       </button>
 
-      <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 2 }}>
+      <div style={{ minWidth: 0 }}>
         <div
           style={{
-            fontSize: 13,
+            fontSize: 15,
             fontWeight: 600,
-            color: T.text,
+            color: paid ? T.muted : T.text,
             fontFamily: T.sans,
             textDecoration: paid ? "line-through" : "none",
+            textDecorationColor: T.muted,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
           }}
         >
           {item.title}
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-          {item.isRecurring && (
-            <span style={{ fontSize: 10, color: T.dim, fontFamily: T.mono }}>↻ monthly</span>
-          )}
-          {item.dueDate != null && (
-            <span style={{ fontSize: 10, color: overdue ? T.accent : T.dim, fontFamily: T.mono, fontWeight: overdue ? 700 : 400 }}>
-              {overdue ? "OVERDUE · " : "due "}
-              {format(new Date(item.dueDate), "MMM d")}
-            </span>
-          )}
-          {item.notes && (
-            <span style={{ fontSize: 11, color: T.muted, fontFamily: T.sans }}>{item.notes}</span>
-          )}
-        </div>
       </div>
 
-      <span
+      <div
         style={{
-          fontSize: 14,
-          fontWeight: 700,
-          color: T.text,
+          fontSize: 17,
           fontFamily: T.sans,
-          minWidth: 70,
-          textAlign: "right",
+          fontWeight: 700,
+          color: paid ? T.muted : T.text,
           fontVariantNumeric: "tabular-nums",
+          letterSpacing: -0.4,
           textDecoration: paid ? "line-through" : "none",
+          textDecorationColor: T.muted,
+          minWidth: 92,
+          textAlign: "right",
         }}
       >
-        ₾{Math.round(item.amountGEL).toLocaleString("en-US")}
-      </span>
+        ₾{item.amountGEL.toLocaleString("en-US", { maximumFractionDigits: 2 })}
+      </div>
 
-      <button
-        type="button"
-        title="Edit"
-        onClick={onEdit}
-        style={{
-          width: 22,
-          height: 22,
-          borderRadius: 11,
-          border: `1px solid ${T.line}`,
-          background: "transparent",
-          color: T.dim,
-          fontSize: 11,
-          lineHeight: 1,
-          cursor: "pointer",
-          flexShrink: 0,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        ✎
-      </button>
-      <button
-        type="button"
-        title="Delete"
-        onClick={onDelete}
-        style={{
-          width: 22,
-          height: 22,
-          borderRadius: 11,
-          border: `1px solid ${T.line}`,
-          background: "transparent",
-          color: T.dim,
-          fontSize: 12,
-          lineHeight: 1,
-          cursor: "pointer",
-          flexShrink: 0,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        ×
-      </button>
+      <div style={{ display: "flex", gap: 4 }}>
+        <button
+          type="button"
+          onClick={onEdit}
+          title="Edit"
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 7,
+            background: "transparent",
+            border: `1px solid ${T.line}`,
+            color: T.muted,
+            cursor: "pointer",
+            fontSize: 12,
+            fontFamily: T.sans,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 0,
+          }}
+        >
+          ✎
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          title="Delete"
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 7,
+            background: "transparent",
+            border: `1px solid ${T.line}`,
+            color: T.muted,
+            cursor: "pointer",
+            fontSize: 14,
+            fontFamily: T.sans,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 0,
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      </div>
     </div>
   );
 }
 
-// ── Inline create/edit form ───────────────────────────────────────────────
+// ── Inline editor: name + amount only ─────────────────────────────────────
 
-function ItemForm({
+function RowEditor({
   T,
   initial,
-  onSubmit,
+  onSave,
   onCancel,
-  submitLabel,
 }: {
   T: InkTheme;
-  initial?: Partial<MustPayItem>;
-  onSubmit: (input: {
-    title: string;
-    amountGEL: number;
-    isRecurring: boolean;
-    notes?: string;
-    dueDate?: number;
-  }) => Promise<void>;
+  initial: { title: string; amountGEL: number };
+  onSave: (v: { title: string; amountGEL: number }) => Promise<void>;
   onCancel: () => void;
-  submitLabel: string;
 }) {
-  const [title, setTitle] = useState(initial?.title ?? "");
-  const [amount, setAmount] = useState(initial?.amountGEL != null ? String(initial.amountGEL) : "");
-  const [isRecurring, setIsRecurring] = useState(initial?.isRecurring ?? false);
-  const [notes, setNotes] = useState(initial?.notes ?? "");
-  const [dueDate, setDueDate] = useState(
-    initial?.dueDate != null ? format(new Date(initial.dueDate), "yyyy-MM-dd") : ""
+  const [title, setTitle] = useState(initial.title);
+  const [amount, setAmount] = useState(
+    Number.isFinite(initial.amountGEL) ? String(initial.amountGEL) : ""
   );
   const [submitting, setSubmitting] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
@@ -511,144 +713,183 @@ function ItemForm({
     titleRef.current?.focus();
   }, []);
 
-  const submit = async () => {
-    const trimmed = title.trim();
-    const parsedAmount = Number(amount);
-    if (!trimmed || !Number.isFinite(parsedAmount) || parsedAmount <= 0) return;
+  const parsedAmount = parseFloat(amount);
+  const valid = title.trim().length > 0 && Number.isFinite(parsedAmount) && parsedAmount > 0;
+
+  const submit = async (e?: React.FormEvent) => {
+    if (e) e.preventDefault();
+    if (!valid || submitting) return;
     setSubmitting(true);
     try {
-      await onSubmit({
-        title: trimmed,
-        amountGEL: parsedAmount,
-        isRecurring,
-        notes: notes.trim() || undefined,
-        dueDate: dueDate ? new Date(dueDate).getTime() : undefined,
-      });
+      await onSave({ title: title.trim(), amountGEL: parsedAmount });
     } finally {
       setSubmitting(false);
     }
   };
 
-  const inputStyle: React.CSSProperties = {
-    padding: "8px 10px",
-    background: T.panelAlt,
-    border: `1px solid ${T.line}`,
-    borderRadius: 8,
-    color: T.text,
-    fontSize: 13,
-    fontFamily: T.sans,
-    outline: "none",
-  };
-
   return (
-    <div
+    <form
+      onSubmit={submit}
       style={{
-        padding: "12px",
+        display: "grid",
+        gridTemplateColumns: "32px 1fr 150px auto",
+        gap: 12,
+        alignItems: "center",
+        padding: "14px 20px",
         background: T.panelAlt,
-        border: `1px solid ${T.line}`,
-        borderRadius: 10,
-        display: "flex",
-        flexDirection: "column",
-        gap: 10,
-        marginTop: 4,
+        borderBottom: `1px solid ${T.line}`,
       }}
     >
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 120px", gap: 10 }}>
-        <input
-          ref={titleRef}
-          type="text"
-          placeholder="What needs paying? (e.g. Rent)"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          style={inputStyle}
-        />
-        <input
-          type="number"
-          inputMode="decimal"
-          min={0}
-          step="any"
-          placeholder="Amount ₾"
-          value={amount}
-          onChange={(e) => setAmount(e.target.value)}
-          style={{ ...inputStyle, fontVariantNumeric: "tabular-nums" }}
-        />
-      </div>
+      <div style={{ width: 24, height: 24, borderRadius: 7, border: `1.5px dashed ${T.line}` }} />
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 160px", gap: 10 }}>
-        <input
-          type="text"
-          placeholder="Notes (optional)"
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-          style={inputStyle}
-        />
-        <input
-          type="date"
-          placeholder="Due date"
-          value={dueDate}
-          onChange={(e) => setDueDate(e.target.value)}
-          style={inputStyle}
-        />
-      </div>
-
-      <label
+      <input
+        ref={titleRef}
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="What's owed? — Rent, Loan, Pay back Luka…"
         style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          color: T.muted,
-          fontSize: 12.5,
+          background: T.bg,
+          border: `1px solid ${T.line}`,
+          color: T.text,
+          padding: "10px 12px",
+          borderRadius: 8,
+          fontSize: 14,
           fontFamily: T.sans,
-          cursor: "pointer",
+          outline: "none",
         }}
-      >
-        <input
-          type="checkbox"
-          checked={isRecurring}
-          onChange={(e) => setIsRecurring(e.target.checked)}
-          style={{ cursor: "pointer" }}
-        />
-        Repeats monthly — auto-resets on the 1st
-      </label>
+      />
 
-      <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+      <div style={{ position: "relative" }}>
+        <span
+          style={{
+            position: "absolute",
+            left: 12,
+            top: "50%",
+            transform: "translateY(-50%)",
+            color: T.muted,
+            fontSize: 13,
+            fontFamily: T.sans,
+            pointerEvents: "none",
+          }}
+        >
+          ₾
+        </span>
+        <input
+          value={amount}
+          onChange={(e) => setAmount(e.target.value.replace(/[^\d.]/g, ""))}
+          inputMode="decimal"
+          placeholder="0"
+          style={{
+            width: "100%",
+            background: T.bg,
+            border: `1px solid ${T.line}`,
+            color: T.text,
+            padding: "10px 12px 10px 24px",
+            borderRadius: 8,
+            fontSize: 14,
+            fontFamily: T.sans,
+            outline: "none",
+            textAlign: "right",
+            fontVariantNumeric: "tabular-nums",
+          }}
+        />
+      </div>
+
+      <div style={{ display: "flex", gap: 6 }}>
         <button
           type="button"
           onClick={onCancel}
           style={{
-            padding: "7px 14px",
+            padding: "9px 12px",
+            borderRadius: 8,
             background: "transparent",
             border: `1px solid ${T.line}`,
-            borderRadius: 8,
             color: T.muted,
             fontSize: 12,
-            fontWeight: 600,
             fontFamily: T.sans,
+            fontWeight: 600,
             cursor: "pointer",
           }}
         >
           Cancel
         </button>
         <button
-          type="button"
-          onClick={submit}
-          disabled={submitting || !title.trim() || !amount}
+          type="submit"
+          disabled={!valid || submitting}
           style={{
-            padding: "7px 14px",
-            background: T.accent,
-            border: `1px solid ${T.accent}`,
+            padding: "9px 14px",
             borderRadius: 8,
-            color: "#fff",
+            border: "none",
+            background: valid && !submitting ? T.accent : T.panelAlt,
+            color: valid && !submitting ? "#fff" : T.dim,
             fontSize: 12,
-            fontWeight: 700,
             fontFamily: T.sans,
-            cursor: submitting || !title.trim() || !amount ? "not-allowed" : "pointer",
-            opacity: submitting || !title.trim() || !amount ? 0.5 : 1,
+            fontWeight: 700,
+            cursor: valid && !submitting ? "pointer" : "not-allowed",
           }}
         >
-          {submitting ? "…" : submitLabel}
+          Save ↵
         </button>
       </div>
+    </form>
+  );
+}
+
+// ── Empty state ────────────────────────────────────────────────────────────
+
+function EmptyState({ T, onAdd }: { T: InkTheme; onAdd: () => void }) {
+  return (
+    <div style={{ padding: "60px 32px", textAlign: "center" }}>
+      <div
+        style={{
+          width: 56,
+          height: 56,
+          borderRadius: 16,
+          background: T.panelAlt,
+          color: T.accent,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 24,
+          margin: "0 auto 16px",
+          fontFamily: T.sans,
+        }}
+      >
+        ✓
+      </div>
+      <div style={{ fontSize: 18, fontFamily: T.serif, color: T.text, letterSpacing: -0.5, marginBottom: 8 }}>
+        Nothing promised yet.
+      </div>
+      <div
+        style={{
+          fontSize: 13,
+          color: T.muted,
+          fontFamily: T.sans,
+          lineHeight: 1.55,
+          maxWidth: 320,
+          margin: "0 auto",
+        }}
+      >
+        Add what you owe — rent, loans, money to friends — and you'll know at a glance what's really yours to spend.
+      </div>
+      <button
+        type="button"
+        onClick={onAdd}
+        style={{
+          marginTop: 18,
+          padding: "10px 18px",
+          borderRadius: 10,
+          border: "none",
+          background: T.accent,
+          color: "#fff",
+          fontSize: 12.5,
+          fontWeight: 700,
+          fontFamily: T.sans,
+          cursor: "pointer",
+        }}
+      >
+        Add your first item
+      </button>
     </div>
   );
 }

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -5,5 +5,6 @@ export { Budgets } from "./Budgets";
 export { Merchants } from "./Merchants";
 export { Income } from "./Income";
 export { Analytics as Signals } from "./Analytics";
+export { Plan } from "./Plan";
 export { Settings } from "./Settings";
 export { Assistant } from "./Assistant";

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/service/src/__tests__/instant-schema.test.ts
+++ b/service/src/__tests__/instant-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import schema from "../instant-schema";
+import { bootstrapSeed } from "../setup/apply";
 
 // The schema object's internal shape is defined by @instantdb/admin —
 // we access `entities.<name>.attrs.<field>` and each attr has `valueType`,
@@ -115,6 +116,32 @@ describe("credits entity", () => {
   test("has amount (unlike failedPayments)", () => {
     expect(c.attrs.amount).toBeDefined();
     expect(c.attrs.amount.config.indexed).toBe(true);
+  });
+});
+
+describe("bootstrap seed coverage", () => {
+  // The applySetup bootstrap pass writes a stub row + then deletes it
+  // for each entity in bootstrapSeed, which forces InstantDB to create
+  // the attrs. Any schema entity that is queried before the user has
+  // written real data to it (e.g. mustPayItems from Layout's sidebar
+  // badge, or budgetPlans from /budgets) needs to be in this seed.
+  // Forgetting to add a new entity here is what triggered the Codex
+  // P1 finding on PR #51 — this test guards future schema additions.
+  test("every schema entity has a corresponding seed row", () => {
+    const entityNames = Object.keys(entities).sort();
+    const seededTables = bootstrapSeed().map((s) => s.table).sort();
+    for (const name of entityNames) {
+      expect(seededTables).toContain(name);
+    }
+  });
+
+  test("seed rows are unique per table — no double-write that would skip an entity", () => {
+    const seededTables = bootstrapSeed().map((s) => s.table);
+    const counts = new Map<string, number>();
+    for (const t of seededTables) counts.set(t, (counts.get(t) ?? 0) + 1);
+    for (const [name, n] of counts) {
+      expect(n).toBe(1);
+    }
   });
 });
 

--- a/service/src/instant-schema.ts
+++ b/service/src/instant-schema.ts
@@ -153,6 +153,36 @@ const schema = i.schema({
       categoryId: i.string(),
       createdAt: i.number(),
     }),
+
+    // Free-form "things I owe" list. Not derived from SMS — the user
+    // types these in directly on the Must Pay page. We keep the
+    // service-side mirror so future tooling (cron exports, AI
+    // read-only summaries, etc.) has a typed schema to query against.
+    mustPayItems: i.entity({
+      title: i.string(),
+      amountGEL: i.number(),
+      // null = never paid (still pending). Number = epoch ms of the
+      // most recent mark-paid click. Recurring items auto-reset on
+      // month rollover purely as a render-time computation in
+      // useMustPay.isItemPaidThisCycle — no cron, no migration.
+      lastPaidAt: i.number().optional(),
+      isRecurring: i.boolean(),
+      notes: i.string().optional(),
+      dueDate: i.number().optional(),
+      createdAt: i.number(),
+      updatedAt: i.number(),
+    }),
+
+    // Singleton row holding the user's current "pot" — how much money
+    // they have right now. The Must Pay page subtracts pending
+    // obligations from this to give them "free" — the headline number
+    // they actually came to the page for. Keyed "singleton" with a
+    // unique constraint so concurrent upserts can't duplicate it.
+    mustPayState: i.entity({
+      key: i.string().unique(),
+      currentPotGEL: i.number(),
+      updatedAt: i.number(),
+    }),
   },
   links: {},
 });

--- a/service/src/setup/apply.ts
+++ b/service/src/setup/apply.ts
@@ -155,6 +155,12 @@ export function bootstrapSeed(): Array<{ table: string; data: Record<string, unk
         title: "__setup__",
         amountGEL: 0,
         isRecurring: false,
+        // lastPaidAt is the field the togglePaid action writes on
+        // every mark-paid click. Include a dummy value here so the
+        // attribute exists in InstantDB before the first user toggle —
+        // otherwise the schema-backed client would hit a
+        // missing-attribute error on the very first interaction.
+        lastPaidAt: 0,
         createdAt: now,
         updatedAt: now,
       },

--- a/service/src/setup/apply.ts
+++ b/service/src/setup/apply.ts
@@ -70,8 +70,9 @@ function extract(values: FieldMap): ExtractedValues {
   };
 }
 
-/** Seed rows written during the bootstrap pass to force attribute creation. */
-function bootstrapSeed(): Array<{ table: string; data: Record<string, unknown> }> {
+/** Seed rows written during the bootstrap pass to force attribute creation.
+ *  Exported so tests can assert every schema entity has a seed row. */
+export function bootstrapSeed(): Array<{ table: string; data: Record<string, unknown> }> {
   const now = Date.now();
   return [
     {
@@ -141,6 +142,63 @@ function bootstrapSeed(): Array<{ table: string; data: Record<string, unknown> }
         syncedAt: now,
         bankSenderId: "TEST",
         rawMessage: "Setup schema push (credit)",
+      },
+    },
+    // Must Pay entities. mustPayItems is queried by Layout on every
+    // page mount (the sidebar pillBadge counter), so the attrs must
+    // exist before the first dashboard render or InstantDB will throw
+    // a missing-attribute error. mustPayState rides along on the same
+    // bootstrap pass.
+    {
+      table: "mustPayItems",
+      data: {
+        title: "__setup__",
+        amountGEL: 0,
+        isRecurring: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+    },
+    {
+      table: "mustPayState",
+      data: {
+        key: "__setup__",
+        currentPotGEL: 0,
+        updatedAt: now,
+      },
+    },
+    // Three pre-existing entities that were never in the bootstrap
+    // seed but should have been from day one. Their attrs only got
+    // created lazily on first user write, which meant fresh installs
+    // could hit "missing attribute" errors on first visit to /budgets,
+    // /categories, or any page that reads merchant/transaction
+    // overrides. Adding them here makes the bootstrap exhaustive.
+    {
+      table: "budgetPlans",
+      data: {
+        planMonth: "0000-00",
+        expectedIncome: 0,
+        expectedIncomeAuto: true,
+        flexPool: 0,
+        flexPoolAuto: true,
+        createdAt: now,
+        updatedAt: now,
+      },
+    },
+    {
+      table: "merchantCategoryOverrides",
+      data: {
+        merchant: "__setup__",
+        categoryId: "__setup__",
+        createdAt: now,
+      },
+    },
+    {
+      table: "transactionCategoryOverrides",
+      data: {
+        paymentId: "__setup__",
+        categoryId: "__setup__",
+        createdAt: now,
       },
     },
   ];


### PR DESCRIPTION
Adds a new page in the sidebar called Must Pay where the user lists upcoming obligations like rent, loan repayments, and friend-pay-backs, each with a title and an amount. The headline at the top of the page shows three numbers side by side: Current pot (an editable input — what's in your wallet right now), Pending (sum of unpaid obligations), and Free (pot minus pending). The Free figure renders in green most of the time and flips to the accent color with an "Over by ₾X" subtitle when obligations exceed the pot. Sidebar gets a bright accent pillBadge next to the new nav item showing how many items are still unpaid.

Items have a per-item recurring toggle. Recurring items auto-reset on the 1st of each month — the trick is that lastPaidAt is stored as a timestamp rather than a boolean isPaid, so the derived paid-state check (isItemPaidThisCycle) just compares the timestamp's calendar month against today. Month rollover happens at read time, no cron, no background job, no migration. One-off items stay paid forever once you've clicked the checkbox. Marking paid renders the row with opacity 0.45 and a line-through; one click un-does it.

When the budgetPlans data has an expectedIncome for the current month (either a stored override or the flex-budgeting auto-derived trimmed mean), a secondary muted line below the headline shows "vs ₾X typical income, ₾Y leftover after obligations" so the obligations get anchored against what a typical month brings in. The line hides entirely when no expectedIncome value is available — no "vs ₾0" placeholder on fresh installs.

Schema gains two entities. mustPayItems holds the list of obligations with title, amountGEL, optional lastPaidAt, isRecurring, optional notes, optional dueDate, and creation/update timestamps. mustPayState is a singleton row keyed "singleton" with currentPotGEL — the user's wallet pot. Both are defined in service/src/instant-schema.ts and mirrored in client/src/lib/instant.ts. No manual schema push is needed for an existing install — InstantDB is schemaless-friendly enough that the first write auto-creates attrs, and the next applySetup run picks up the schema-backed registration via the existing two-pass bootstrap.

The page mirrors Categories.tsx's inline-edit row pattern, reuses Card / CardLabel / PageHeader / Pill primitives, and ranges={null} hides the time-range buttons since this page isn't range-scoped. Sidebar.tsx's existing pillBadge rendering gives us the bright accent (coral by default, but tracks the user's accent theme choice) pill with white text for free — no theme changes required.

Pure helpers — isItemPaidThisCycle, summarizeMustPay, computePotMath — live alongside the hook in useMustPay.ts and get fifteen bun-test cases covering the month-rollover boundary, the same-month-last-year edge case, mixed paid/unpaid summation, and the pot == pending case where free should land at zero without flipping isOverdrawn. client/package.json gains a "test": "bun test src" script; tsconfig.app.json excludes __tests__ from the tsc -b pass so vite build doesn't trip on the bun:test import.

Demo mode (?demo=1) seeds four sample obligations — recurring rent ₾800, recurring car loan ₾450, one-off pay-back-Luka ₾200, recurring Spotify+Netflix ₾60 marked as paid three days ago — plus a ₾2000 pot. That combination lands the demo on the green Free state with the strike-through state already visible on the subscriptions row, so a reviewer sees the full visual range on first load. The demoDb.ts seed() function gains entries for both new collections.

No migration steps for existing installs. On first launch after pulling this branch, the schema's two new entities are recognised by InstantDB's bootstrap; the page renders an empty list and a ₾0 pot until the user adds their first row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Plan page to manage "Must pay" obligations with editable pot, pending/paid totals, progress bar, add/edit/delete rows, toggle paid, and visual de-emphasis for paid items.
  * Sidebar shows a “Must pay” nav item with an unpaid count badge.
* **Tests**
  * Added tests covering must-pay utilities and calculations.
* **Chores**
  * Added a project test script for running the test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tornikegomareli/Xarji/pull/51)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->