### PR TITLE
Fix over-budget indicators and spending mix accuracy in Cycle mode

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Layout } from "./components/Layout";
-import { Dashboard, Transactions, Categories, Budgets, Merchants, Income, Signals, Settings, Assistant, Plan } from "./pages";
+import { Dashboard, Transactions, Categories, Budgets, Merchants, Income, Signals, Settings, Assistant, Plan, ByCategoryPage } from "./pages";
 
 function App() {
   return (
@@ -17,6 +17,7 @@ function App() {
           <Route path="assistant" element={<Assistant />} />
           <Route path="signals" element={<Signals />} />
           <Route path="manage" element={<Settings />} />
+          <Route path="category-transactions" element={<ByCategoryPage />} />
           {/* Compatibility redirects for the routes that existed in the
               previous version of the app, so old bookmarks and shared
               links still resolve. */}

--- a/client/src/ink/Sidebar.tsx
+++ b/client/src/ink/Sidebar.tsx
@@ -29,6 +29,7 @@ export function Sidebar({
     { to: "/transactions", name: "Transactions", glyph: "≡", badge: txCount ? txCount.toLocaleString("en-US") : undefined },
     { to: "/income", name: "Income", glyph: "↓", badge: incomeCount ? incomeCount.toLocaleString("en-US") : undefined },
     { to: "/categories", name: "Categories", glyph: "◐" },
+    { to: "/category-transactions", name: "By Category", glyph: "◧" },
     { to: "/budgets", name: "Flex Budgeting", glyph: "◇" },
     { to: "/merchants", name: "Merchants", glyph: "◆" },
     // pillBadge for Must Pay (vs the muted `badge` used by Transactions

--- a/client/src/pages/Budgets.tsx
+++ b/client/src/pages/Budgets.tsx
@@ -258,7 +258,10 @@ function BucketStrip({
       }}
     >
       {items.map((it) => {
-        const pct = it.target > 0 ? Math.min(100, (it.actual / it.target) * 100) : 0;
+        const rawPct = it.target > 0 ? (it.actual / it.target) * 100 : 0;
+        const barPct = Math.min(100, rawPct);
+        const isOver = rawPct > 100;
+        const overBy = it.actual - it.target;
         return (
           <Card key={it.label} pad="16px 18px" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
@@ -266,9 +269,10 @@ function BucketStrip({
               <span
                 style={{
                   fontSize: 11,
-                  color: T.dim,
+                  color: isOver ? T.accent : T.dim,
                   fontFamily: T.mono,
                   fontVariantNumeric: "tabular-nums",
+                  fontWeight: isOver ? 600 : undefined,
                 }}
               >
                 ₾{Math.round(it.actual)} / ₾{Math.round(it.target)}
@@ -277,15 +281,23 @@ function BucketStrip({
             <div style={{ height: 6, background: T.panelAlt, borderRadius: 3, overflow: "hidden" }}>
               <div
                 style={{
-                  width: `${pct}%`,
+                  width: `${barPct}%`,
                   height: "100%",
-                  background: it.color,
+                  background: isOver ? T.accent : it.color,
                   transition: "width 200ms ease-out",
                 }}
               />
             </div>
-            <div style={{ fontSize: 10, color: T.muted, fontFamily: T.mono }}>
-              {pct.toFixed(0)}% used
+            <div style={{ fontSize: 10, fontFamily: T.mono, display: "flex", gap: 6, alignItems: "center" }}>
+              {isOver ? (
+                <>
+                  <span style={{ color: T.accent, fontWeight: 600 }}>{rawPct.toFixed(0)}% used</span>
+                  <span style={{ color: T.muted }}>·</span>
+                  <span style={{ color: T.accent }}>₾{Math.round(overBy)} over budget</span>
+                </>
+              ) : (
+                <span style={{ color: T.muted }}>{rawPct.toFixed(0)}% used</span>
+              )}
             </div>
           </Card>
         );

--- a/client/src/pages/ByCategoryPage.tsx
+++ b/client/src/pages/ByCategoryPage.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { useTheme } from "../ink/theme";
+import { Card, PageHeader } from "../ink/primitives";
+import { TxRow, type InkTx } from "../ink/TxRow";
+import { useConvertedPayments } from "../hooks/useTransactions";
+import { useCategorizer } from "../hooks/useCategorizer";
+import { useRangeState } from "../hooks/useRangeState";
+import { isInRange } from "../lib/dateRange";
+import { formatGEL } from "../ink/format";
+import type { InkCategory } from "../lib/utils";
+
+interface CatAgg {
+  cat: string;
+  total: number;
+  count: number;
+  meta: InkCategory;
+}
+
+export function ByCategoryPage() {
+  const T = useTheme();
+  const { payments } = useConvertedPayments();
+  const { range, props: rangeProps } = useRangeState("Month");
+  const { categorize, getCategory } = useCategorizer();
+  const [openIds, setOpenIds] = useState<Set<string>>(new Set());
+
+  const monthPayments = useMemo(
+    () =>
+      payments.filter(
+        (p) => !p.excludedFromAnalytics && p.gelAmount !== null && isInRange(p.transactionDate, range)
+      ),
+    [payments, range]
+  );
+
+  useEffect(() => {
+    setOpenIds(new Set());
+  }, [range]);
+
+  const cats: CatAgg[] = useMemo(() => {
+    const map: Record<string, CatAgg> = {};
+    for (const p of monthPayments) {
+      if (p.gelAmount === null) continue;
+      const cat = getCategory(p.merchant, p.rawMessage, p.id);
+      if (!map[cat.id]) map[cat.id] = { cat: cat.id, total: 0, count: 0, meta: cat };
+      map[cat.id].total += p.gelAmount;
+      map[cat.id].count += 1;
+    }
+    return Object.values(map).sort((a, b) => b.total - a.total);
+  }, [monthPayments, getCategory]);
+
+  const txsByCat = useMemo(() => {
+    const map: Record<string, InkTx[]> = {};
+    for (const p of monthPayments) {
+      const catId = categorize(p.merchant, p.rawMessage, p.id);
+      if (!map[catId]) map[catId] = [];
+      map[catId].push({
+        id: p.id,
+        kind: "payment" as const,
+        merchant: p.merchant || "",
+        rawMerchant: p.rawMessage,
+        amount: p.amount,
+        currency: p.currency,
+        cardLastDigits: p.cardLastDigits,
+        transactionDate: p.transactionDate,
+        bankSenderId: p.bankSenderId,
+        category: catId,
+        rawMessage: p.rawMessage,
+        excludedFromAnalytics: p.excludedFromAnalytics,
+      });
+    }
+    for (const key of Object.keys(map)) {
+      map[key].sort((a, b) => b.transactionDate - a.transactionDate);
+    }
+    return map;
+  }, [monthPayments, categorize]);
+
+  const toggle = (id: string) =>
+    setOpenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: T.density.gap }}>
+      <PageHeader eyebrow="Transactions · by category" title="By Category" {...rangeProps} />
+      {cats.length === 0 ? (
+        <Card>
+          <div
+            style={{
+              color: T.muted,
+              fontSize: 13,
+              padding: "48px 0",
+              textAlign: "center",
+              fontFamily: T.sans,
+            }}
+          >
+            No transactions in this range.
+          </div>
+        </Card>
+      ) : (
+        <Card pad="0">
+          <div style={{ overflowY: "auto" }}>
+            {cats.map((c, idx) => {
+              const isOpen = openIds.has(c.cat);
+              const isLastCat = idx === cats.length - 1;
+              const txs = txsByCat[c.cat] ?? [];
+              return (
+                <div key={c.cat}>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => toggle(c.cat)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") toggle(c.cat);
+                    }}
+                    onMouseEnter={(e) => {
+                      (e.currentTarget as HTMLDivElement).style.background = T.panelAlt;
+                    }}
+                    onMouseLeave={(e) => {
+                      (e.currentTarget as HTMLDivElement).style.background = "transparent";
+                    }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      padding: "14px 24px",
+                      cursor: "pointer",
+                      borderBottom: !isLastCat || isOpen ? `1px solid ${T.line}` : "none",
+                      userSelect: "none",
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: 4,
+                        background: c.meta.color,
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span
+                      style={{
+                        fontFamily: T.mono,
+                        fontSize: 14,
+                        color: T.muted,
+                        flexShrink: 0,
+                      }}
+                    >
+                      {c.meta.icon}
+                    </span>
+                    <span
+                      style={{
+                        flex: 1,
+                        fontSize: 13.5,
+                        fontWeight: 700,
+                        color: T.text,
+                        fontFamily: T.sans,
+                      }}
+                    >
+                      {c.meta.name}
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 11,
+                        color: T.dim,
+                        fontFamily: T.mono,
+                        marginRight: 12,
+                      }}
+                    >
+                      {c.count} tx
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 13.5,
+                        fontWeight: 700,
+                        fontFamily: T.sans,
+                        fontVariantNumeric: "tabular-nums",
+                        color: T.text,
+                        marginRight: 8,
+                      }}
+                    >
+                      {formatGEL(c.total, { decimals: 0 })}
+                    </span>
+                    <motion.span
+                      animate={{ rotate: isOpen ? 0 : -90 }}
+                      transition={{ duration: 0.15 }}
+                      style={{ fontSize: 11, color: T.dim, fontFamily: T.mono, display: "inline-block" }}
+                    >
+                      ▾
+                    </motion.span>
+                  </div>
+                  <AnimatePresence initial={false}>
+                    {isOpen && (
+                      <motion.div
+                        key={c.cat}
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+                        style={{ overflow: "hidden" }}
+                      >
+                        <div style={{ paddingBottom: 8 }}>
+                          {txs.map((t, i) => (
+                            <TxRow key={t.id} t={t} isLast={i === txs.length - 1} compact />
+                          ))}
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -45,7 +45,9 @@ export function Dashboard() {
   const prevMonthName = prevPeriod.label;
   const prevMonthShort = prevPeriod.label.split(" ")[0]; // "Mar 2026" → "Mar", "Mar 1 – 31" → "Mar"
   const monthYearLabel = range.label;
-  const monthShortName = range.label.split(" ")[0].toUpperCase();
+  const monthShortName = range.key === "Cycle"
+    ? "CYCLE"
+    : range.label.split(" ")[0].toUpperCase();
   const income = monthCredits.total;
   const net = income - stats.total;
   const savingsRate = income > 0 ? (net / income) * 100 : 0;
@@ -81,7 +83,9 @@ export function Dashboard() {
   }, [payments, getCategory, range]);
 
   const topCats = byCategory.slice(0, 5);
-  const totalCatSum = topCats.reduce((s, c) => s + c.total, 0) || 1;
+  // Denominator is all-categories total so percentages reflect actual
+  // share of total spend, not just share-of-top-5.
+  const totalCatSum = byCategory.reduce((s, c) => s + c.total, 0) || 1;
 
   // Recent transactions (payments + failed + credits mixed, newest first)
   const recent: InkTx[] = useMemo(() => {

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -8,3 +8,4 @@ export { Analytics as Signals } from "./Analytics";
 export { Plan } from "./Plan";
 export { Settings } from "./Settings";
 export { Assistant } from "./Assistant";
+export { ByCategoryPage } from "./ByCategoryPage";


### PR DESCRIPTION
## Summary
  - **Budgets page**: bucket cards now show the real percentage when spend exceeds the target (e.g. "138% used · ₾1085 over budget") instead of capping at   
  100% with no visual signal                                                                                                                                 
  - **Dashboard – Spending mix**: center label for Cycle range was showing the start-month abbreviation ("APR") — now shows "CYCLE"                          
  - **Dashboard – Spending mix**: legend percentages now represent share of *total* spend, not share of top-5 spend, so they reconcile correctly with the    
  center value                                                                                                                                               
                                                                                                                                                             
  ## Test plan                                                                                                                                               
  - [ ] Set a budget bucket below current month's spend — confirm it shows `>100%`, accent color, and correct "over budget" amount                           
  - [ ] Switch dashboard range to Cycle — confirm donut center shows "CYCLE" and legend %s add up to ≤100% of the center value  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Transactions · by category" page and a matching route; new sidebar item for quick access.
  * Enhanced budget tracking: over-budget items show distinct styling and an explicit overage amount.

* **Bug Fixes**
  * Spending mix percentages now correctly calculate against the full-category total.
  * Month label derivation updated for more accurate short month display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tornikegomareli/Xarji/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->